### PR TITLE
Added support for output format as json

### DIFF
--- a/sourcecode-parser/main.go
+++ b/sourcecode-parser/main.go
@@ -2,51 +2,74 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"queryparser"
 	"strings"
 )
 
-func main() {
-	// accept command line param optional path to source code
-	var sourceDirectory string
-	graph := NewCodeGraph()
-	if len(os.Args) > 1 {
-		sourceDirectory = os.Args[1]
-		graph = Initialize(sourceDirectory)
-	}
-	// loop to accept queries
-	for {
-		var input string
-		fmt.Print("Path-Finder Query Console: \n>")
-		in := bufio.NewReader(os.Stdin)
-
-		input, err := in.ReadString('\n')
-		if err != nil {
-			fmt.Println("Error reading input")
-			return
+func processQuery(input string, graph *CodeGraph, output string) {
+	lex := queryparser.NewLexer(input)
+	pars := queryparser.NewParser(lex)
+	query := pars.ParseQuery()
+	if query == nil {
+		fmt.Println("Failed to parse query:")
+		for _, err := range pars.Errors() {
+			fmt.Println(err)
 		}
-		// if input starts with :quit string
-		if strings.HasPrefix(input, ":quit") {
-			return
-		}
-		fmt.Print("Executing query: " + input)
-		lex := queryparser.NewLexer(input)
-		pars := queryparser.NewParser(lex)
-		query := pars.ParseQuery()
-		if query == nil {
-			fmt.Println("Failed to parse query:")
-			for _, err := range pars.Errors() {
-				fmt.Println(err)
+	} else {
+		entities := QueryEntities(graph, query)
+		if output == "json" {
+			// convert struct to query_results
+			queryResults, err := json.Marshal(entities)
+			if err != nil {
+				fmt.Println("Error processing query results")
+			} else {
+				fmt.Println(string(queryResults))
 			}
 		} else {
-			entities := QueryEntities(graph, query)
 			fmt.Println("------Query Results------")
 			for _, entity := range entities {
 				fmt.Println(entity.CodeSnippet)
 			}
 			fmt.Println("-------------------")
+		}
+	}
+}
+
+func main() {
+	// accept command line param optional path to source code
+	graph := NewCodeGraph()
+	output := flag.String("output", "", "Supported output format: json")
+	query := flag.String("query", "", "Query to execute")
+	project := flag.String("project", "", "Project to analyze")
+	flag.Parse()
+	// loop to accept queries
+	if project != nil {
+		graph = Initialize(*project)
+	}
+	// check if output and query are provided
+	if output != nil && query != nil && *output != "" && *query != "" {
+		processQuery(*query, graph, *output)
+	} else {
+		for {
+			var input string
+			fmt.Print("Path-Finder Query Console: \n>")
+			in := bufio.NewReader(os.Stdin)
+
+			input, err := in.ReadString('\n')
+			if err != nil {
+				fmt.Println("Error reading input")
+				return
+			}
+			// if input starts with :quit string
+			if strings.HasPrefix(input, ":quit") {
+				return
+			}
+			fmt.Print("Executing query: " + input)
+			processQuery(input, graph, "text")
 		}
 	}
 }


### PR DESCRIPTION
Add support for output format as json and query to execute directly.

Example:

```bash
➜  sourcecode-parser git:(shiva/output-flag) ✗ go run . --help                                                                                                       
Usage of /var/folders/0f/8t9fxdr92nj6vcxgv1bqxz540000gp/T/go-build263825568/b001/exe/sourcecode-parser:
  -output string
        Output format: json
  -project string
        Project to analyze
  -query string
        Query to execute
```