### PR TITLE
Add variable declaration attributes for filtering

### DIFF
--- a/sourcecode-parser/source_sink.go
+++ b/sourcecode-parser/source_sink.go
@@ -118,6 +118,12 @@ func (gnc *GraphNodeContext) GetValue(key, val string) string {
 			}
 		}
 		return ""
+	case "scope":
+		return gnc.Node.Scope
+	case "variablevalue":
+		return gnc.Node.VariableValue
+	case "variabledatatype":
+		return gnc.Node.DataType
 	default:
 		fmt.Printf("Unsupported attribute key: %s\n", key)
 		return ""


### PR DESCRIPTION
Related: #18 

Supported attributes,

- scope
- variabledatatype
- variablevalue
- name
- modifier

Example:

```bash
>FIND variable_declaration WHERE variabledatatype = 'int'
Executing query: FIND variable_declaration WHERE variabledatatype = 'int'
------Query Results------
int id = item.getItemId();
int number;
int width = displaymetrics.widthPixels;
```