### PR TITLE
Support for Output file format flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ example-java-project/
 main
 sourcecode-parser/sourcecode-parser
 .idea/
+*.json

--- a/sourcecode-parser/main.go
+++ b/sourcecode-parser/main.go
@@ -71,6 +71,7 @@ func executeProject(project, query, output string, stdin bool) (string, error) {
 func main() {
 	// accept command line param optional path to source code
 	output := flag.String("output", "", "Supported output format: json")
+	outputFile := flag.String("output-file", "", "Output file path")
 	query := flag.String("query", "", "Query to execute")
 	project := flag.String("project", "", "Project to analyze")
 	stdin := flag.Bool("stdin", false, "Read query from stdin")
@@ -81,5 +82,25 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	fmt.Println(result)
+	if *outputFile != "" {
+		file, err := os.Create(*outputFile)
+		if err != nil {
+			fmt.Println("Error creating output file: ", err)
+			return
+		}
+		defer func(file *os.File) {
+			err := file.Close()
+			if err != nil {
+				fmt.Println("Error closing output file: ", err)
+				return
+			}
+		}(file)
+		_, err = file.WriteString(result)
+		if err != nil {
+			fmt.Println("Error writing output file: ", err)
+			return
+		}
+	} else {
+		fmt.Println(result)
+	}
 }


### PR DESCRIPTION
closes: #22 

### Description 

I have introduced `--output-file` format flag so that the results are stored in output file as json array.

### Example

```bash
pathfinder --project /Users/shiva/src/android --output json 
--query "FIND class_declaration WHERE visibility = 'public'" --output-file result.json
```