### PR TITLE
Feature: Support isJavaSource

### DIFF
--- a/sourcecode-parser/source_sink.go
+++ b/sourcecode-parser/source_sink.go
@@ -115,6 +115,11 @@ func (gnc *GraphNodeContext) GetValue(key, val string) string {
 			return "true"
 		}
 		return "false"
+	case "is_java_source":
+		if gnc.Node.isJavaSourceFile {
+			return "true"
+		}
+		return "false"
 	default:
 		fmt.Printf("Unsupported attribute key: %s\n", key)
 		return ""


### PR DESCRIPTION
`is_java_source` attribute helps to filter java source code.

### Query

```bash
FIND variable_declaration WHERE is_java_source = 'true'
```

Closes #31 