### PR TITLE
Added throws type attribute and fixed != operator check

### DIFF
--- a/sourcecode-parser/queryparser/lexer.go
+++ b/sourcecode-parser/queryparser/lexer.go
@@ -28,6 +28,10 @@ func (l *Lexer) NextToken() Token {
 	switch l.ch {
 	case '=':
 		tok = Token{Type: OPERATOR, Literal: string(l.ch)}
+	case '!':
+		ch := l.ch
+		l.readChar()
+		tok = Token{Type: OPERATOR, Literal: string(ch) + string(l.ch)}
 	case '\'':
 		tok.Type = STRING
 		tok.Literal = l.readString()

--- a/sourcecode-parser/source_sink.go
+++ b/sourcecode-parser/source_sink.go
@@ -110,6 +110,13 @@ func (gnc *GraphNodeContext) GetValue(key, val string) string {
 		return gnc.Node.VariableValue
 	case "variabledatatype":
 		return gnc.Node.DataType
+	case "throwstype":
+		for i, arg := range gnc.Node.ThrowsExceptions {
+			if arg == val {
+				return gnc.Node.ThrowsExceptions[i]
+			}
+		}
+		return ""
 	case "has_access":
 		if gnc.Node.hasAccess {
 			return "true"


### PR DESCRIPTION
Now that throwstype attr is added to method_declaration

this enables to query

```sql
FIND method_declaration WHERE throwstype = "IOException"
```

Additionally fixes `!=` operator crash