### PR TITLE
Fixed method invocation param

### DIFF
--- a/sourcecode-parser/construct.go
+++ b/sourcecode-parser/construct.go
@@ -253,6 +253,17 @@ func buildGraphFromAST(node *sitter.Node, sourceCode []byte, graph *CodeGraph, c
 					argument := argumentsNode.Child(j)
 					if argument.Type() == "identifier" {
 						arguments = append(arguments, argument.Content(sourceCode))
+					} else if argument.Type() == "string_literal" {
+						stringliteral := argument.Content(sourceCode)
+						if strings.HasPrefix(stringliteral, "\"") {
+							stringliteral = stringliteral[1:]
+						}
+						if strings.HasSuffix(stringliteral, "\"") {
+							stringliteral = stringliteral[:len(stringliteral)-1]
+						}
+						arguments = append(arguments, stringliteral)
+					} else {
+						arguments = append(arguments, argument.Content(sourceCode))
 					}
 				}
 			}

--- a/sourcecode-parser/construct.go
+++ b/sourcecode-parser/construct.go
@@ -251,18 +251,15 @@ func buildGraphFromAST(node *sitter.Node, sourceCode []byte, graph *CodeGraph, c
 				argumentsNode := node.Child(i)
 				for j := 0; j < int(argumentsNode.ChildCount()); j++ {
 					argument := argumentsNode.Child(j)
-					if argument.Type() == "identifier" {
+					switch argument.Type() {
+					case "identifier":
 						arguments = append(arguments, argument.Content(sourceCode))
-					} else if argument.Type() == "string_literal" {
+					case "string_literal":
 						stringliteral := argument.Content(sourceCode)
-						if strings.HasPrefix(stringliteral, "\"") {
-							stringliteral = stringliteral[1:]
-						}
-						if strings.HasSuffix(stringliteral, "\"") {
-							stringliteral = stringliteral[:len(stringliteral)-1]
-						}
+						stringliteral = strings.TrimPrefix(stringliteral, "\"")
+						stringliteral = strings.TrimSuffix(stringliteral, "\"")
 						arguments = append(arguments, stringliteral)
-					} else {
+					default:
 						arguments = append(arguments, argument.Content(sourceCode))
 					}
 				}


### PR DESCRIPTION
Previously method invocation call param wasn't handled properly. Now it parses that with string literal check too