### PR TITLE
Support Method Chaining for Attributes and Entities

### DIFF
--- a/sourcecode-parser/model/javadoc.go
+++ b/sourcecode-parser/model/javadoc.go
@@ -23,3 +23,67 @@ func NewJavadocTag(tagName, text, docType string) *JavadocTag {
 		DocType: docType,
 	}
 }
+
+func (j *Javadoc) GetCommentAuthor() string {
+	for _, tag := range j.Tags {
+		if tag.TagName == "author" {
+			return tag.Text
+		}
+	}
+	return ""
+}
+
+func (j *Javadoc) GetCommentSee() string {
+	for _, tag := range j.Tags {
+		if tag.TagName == "see" {
+			return tag.Text
+		}
+	}
+	return ""
+}
+
+func (j *Javadoc) GetCommentVersion() string {
+	for _, tag := range j.Tags {
+		if tag.TagName == "version" {
+			return tag.Text
+		}
+	}
+	return ""
+}
+
+func (j *Javadoc) GetCommentSince() string {
+	for _, tag := range j.Tags {
+		if tag.TagName == "since" {
+			return tag.Text
+		}
+	}
+	return ""
+}
+
+func (j *Javadoc) GetCommentParam() []string {
+	result := []string{}
+	for _, tag := range j.Tags {
+		if tag.TagName == "param" {
+			result = append(result, tag.Text)
+		}
+	}
+	return result
+}
+
+func (j *Javadoc) GetCommentThrows() string {
+	for _, tag := range j.Tags {
+		if tag.TagName == "throws" {
+			return tag.Text
+		}
+	}
+	return ""
+}
+
+func (j *Javadoc) GetCommentReturn() string {
+	for _, tag := range j.Tags {
+		if tag.TagName == "return" {
+			return tag.Text
+		}
+	}
+	return ""
+}

--- a/sourcecode-parser/model/javadoc_test.go
+++ b/sourcecode-parser/model/javadoc_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -91,5 +92,501 @@ func TestJavadocWithNumberOfCommentLines(t *testing.T) {
 
 	if jdoc.NumberOfCommentLines != 5 {
 		t.Errorf("Expected NumberOfCommentLines to be 5, got %d", jdoc.NumberOfCommentLines)
+	}
+}
+
+func TestGetCommentAuthor(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected string
+	}{
+		{
+			name: "Single author tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "Jane Doe", DocType: "author"},
+				},
+			},
+			expected: "Jane Doe",
+		},
+		{
+			name: "Multiple author tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "John Smith", DocType: "author"},
+					{TagName: "author", Text: "Jane Doe", DocType: "author"},
+				},
+			},
+			expected: "John Smith",
+		},
+		{
+			name: "No author tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "version", Text: "1.0", DocType: "version"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: "",
+		},
+		{
+			name: "Author tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "", DocType: "author"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Author tag not first in list",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "version", Text: "1.0", DocType: "version"},
+					{TagName: "author", Text: "Alice Cooper", DocType: "author"},
+				},
+			},
+			expected: "Alice Cooper",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentAuthor()
+			if result != tt.expected {
+				t.Errorf("GetCommentAuthor() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCommentSee(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected string
+	}{
+		{
+			name: "Single see tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "see", Text: "com.example.OtherClass", DocType: "see"},
+				},
+			},
+			expected: "com.example.OtherClass",
+		},
+		{
+			name: "Multiple see tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "see", Text: "com.example.FirstClass", DocType: "see"},
+					{TagName: "see", Text: "com.example.SecondClass", DocType: "see"},
+				},
+			},
+			expected: "com.example.FirstClass",
+		},
+		{
+			name: "No see tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input", DocType: "param"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: "",
+		},
+		{
+			name: "See tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "see", Text: "", DocType: "see"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "See tag not first in list",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input", DocType: "param"},
+					{TagName: "see", Text: "com.example.ReferencedClass", DocType: "see"},
+				},
+			},
+			expected: "com.example.ReferencedClass",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentSee()
+			if result != tt.expected {
+				t.Errorf("GetCommentSee() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCommentVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected string
+	}{
+		{
+			name: "Single version tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "version", Text: "1.0.0", DocType: "version"},
+				},
+			},
+			expected: "1.0.0",
+		},
+		{
+			name: "Multiple version tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "version", Text: "1.0.0", DocType: "version"},
+					{TagName: "version", Text: "2.0.0", DocType: "version"},
+				},
+			},
+			expected: "1.0.0",
+		},
+		{
+			name: "No version tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "John Doe", DocType: "author"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: "",
+		},
+		{
+			name: "Version tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "version", Text: "", DocType: "version"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Version tag not first in list",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "Jane Smith", DocType: "author"},
+					{TagName: "version", Text: "3.1.4", DocType: "version"},
+				},
+			},
+			expected: "3.1.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentVersion()
+			if result != tt.expected {
+				t.Errorf("GetCommentVersion() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCommentSince(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected string
+	}{
+		{
+			name: "Single since tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "since", Text: "1.5", DocType: "since"},
+				},
+			},
+			expected: "1.5",
+		},
+		{
+			name: "Multiple since tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "since", Text: "1.0", DocType: "since"},
+					{TagName: "since", Text: "2.0", DocType: "since"},
+				},
+			},
+			expected: "1.0",
+		},
+		{
+			name: "No since tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input", DocType: "param"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: "",
+		},
+		{
+			name: "Since tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "since", Text: "", DocType: "since"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Since tag not first in list",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input", DocType: "param"},
+					{TagName: "since", Text: "3.0", DocType: "since"},
+				},
+			},
+			expected: "3.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentSince()
+			if result != tt.expected {
+				t.Errorf("GetCommentSince() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCommentParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected []string
+	}{
+		{
+			name: "Single param tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input The input string", DocType: "param"},
+				},
+			},
+			expected: []string{"input The input string"},
+		},
+		{
+			name: "Multiple param tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "a First parameter", DocType: "param"},
+					{TagName: "param", Text: "b Second parameter", DocType: "param"},
+					{TagName: "param", Text: "c Third parameter", DocType: "param"},
+				},
+			},
+			expected: []string{"a First parameter", "b Second parameter", "c Third parameter"},
+		},
+		{
+			name: "Mixed tags with param",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "John Doe", DocType: "author"},
+					{TagName: "param", Text: "x Parameter x", DocType: "param"},
+					{TagName: "return", Text: "The result", DocType: "return"},
+					{TagName: "param", Text: "y Parameter y", DocType: "param"},
+				},
+			},
+			expected: []string{"x Parameter x", "y Parameter y"},
+		},
+		{
+			name: "No param tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "author", Text: "Jane Smith", DocType: "author"},
+					{TagName: "version", Text: "1.0", DocType: "version"},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: []string{},
+		},
+		{
+			name: "Param tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "", DocType: "param"},
+				},
+			},
+			expected: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentParam()
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("GetCommentParam() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCommentThrows(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected string
+	}{
+		{
+			name: "Single throws tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "throws", Text: "IOException If an I/O error occurs", DocType: "throws"},
+				},
+			},
+			expected: "IOException If an I/O error occurs",
+		},
+		{
+			name: "Multiple throws tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "throws", Text: "IllegalArgumentException If the argument is invalid", DocType: "throws"},
+					{TagName: "throws", Text: "NullPointerException If the input is null", DocType: "throws"},
+				},
+			},
+			expected: "IllegalArgumentException If the argument is invalid",
+		},
+		{
+			name: "No throws tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input The input string", DocType: "param"},
+					{TagName: "return", Text: "The processed result", DocType: "return"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: "",
+		},
+		{
+			name: "Throws tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "throws", Text: "", DocType: "throws"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Throws tag not first in list",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "x The x coordinate", DocType: "param"},
+					{TagName: "throws", Text: "ArithmeticException If division by zero occurs", DocType: "throws"},
+				},
+			},
+			expected: "ArithmeticException If division by zero occurs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentThrows()
+			if result != tt.expected {
+				t.Errorf("GetCommentThrows() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetCommentReturn(t *testing.T) {
+	tests := []struct {
+		name     string
+		javadoc  *Javadoc
+		expected string
+	}{
+		{
+			name: "Single return tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "return", Text: "The processed result", DocType: "return"},
+				},
+			},
+			expected: "The processed result",
+		},
+		{
+			name: "Multiple return tags",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "return", Text: "First return description", DocType: "return"},
+					{TagName: "return", Text: "Second return description", DocType: "return"},
+				},
+			},
+			expected: "First return description",
+		},
+		{
+			name: "No return tag",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "input The input string", DocType: "param"},
+					{TagName: "throws", Text: "IOException If an I/O error occurs", DocType: "throws"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Javadoc",
+			javadoc:  &Javadoc{},
+			expected: "",
+		},
+		{
+			name: "Return tag with empty text",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "return", Text: "", DocType: "return"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Return tag not first in list",
+			javadoc: &Javadoc{
+				Tags: []*JavadocTag{
+					{TagName: "param", Text: "x The x coordinate", DocType: "param"},
+					{TagName: "return", Text: "The calculated result", DocType: "return"},
+				},
+			},
+			expected: "The calculated result",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.javadoc.GetCommentReturn()
+			if result != tt.expected {
+				t.Errorf("GetCommentReturn() = %v, want %v", result, tt.expected)
+			}
+		})
 	}
 }

--- a/sourcecode-parser/query.go
+++ b/sourcecode-parser/query.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/shivasurya/code-pathfinder/sourcecode-parser/model"
+
 	"github.com/expr-lang/expr"
 	parser "github.com/shivasurya/code-pathfinder/sourcecode-parser/antlr"
 )
@@ -67,80 +69,11 @@ func (env *Env) IsJavaSourceFile() bool {
 	return env.Node.isJavaSourceFile
 }
 
-func (env *Env) GetCommentAuthor() string {
-	if env.Node.JavaDoc != nil {
-		if env.Node.JavaDoc.Author != "" {
-			return env.Node.JavaDoc.Author
-		}
+func (env *Env) GetDoc() *model.Javadoc {
+	if env.Node.JavaDoc == nil {
+		env.Node.JavaDoc = &model.Javadoc{}
 	}
-	return ""
-}
-
-func (env *Env) GetCommentSee() string {
-	if env.Node.JavaDoc != nil {
-		for _, docTag := range env.Node.JavaDoc.Tags {
-			if docTag.TagName == "see" && docTag.Text != "" {
-				return docTag.Text
-			}
-		}
-	}
-	return ""
-}
-
-func (env *Env) GetCommentVersion() string {
-	if env.Node.JavaDoc != nil {
-		for _, docTag := range env.Node.JavaDoc.Tags {
-			if docTag.TagName == "version" && docTag.Text != "" {
-				return docTag.Text
-			}
-		}
-	}
-	return ""
-}
-
-func (env *Env) GetCommentSince() string {
-	if env.Node.JavaDoc != nil {
-		for _, docTag := range env.Node.JavaDoc.Tags {
-			if docTag.TagName == "since" && docTag.Text != "" {
-				return docTag.Text
-			}
-		}
-	}
-	return ""
-}
-
-func (env *Env) GetCommentParam() []string {
-	result := []string{}
-	if env.Node.JavaDoc != nil {
-		for _, docTag := range env.Node.JavaDoc.Tags {
-			if docTag.TagName == "param" && docTag.Text != "" {
-				result = append(result, docTag.Text)
-			}
-		}
-	}
-	return result
-}
-
-func (env *Env) GetCommentThrows() string {
-	if env.Node.JavaDoc != nil {
-		for _, docTag := range env.Node.JavaDoc.Tags {
-			if docTag.TagName == "throws" && docTag.Text != "" {
-				return docTag.Text
-			}
-		}
-	}
-	return ""
-}
-
-func (env *Env) GetCommentReturn() string {
-	if env.Node.JavaDoc != nil {
-		for _, docTag := range env.Node.JavaDoc.Tags {
-			if docTag.TagName == "return" && docTag.Text != "" {
-				return docTag.Text
-			}
-		}
-	}
-	return ""
+	return env.Node.JavaDoc
 }
 
 func QueryEntities(graph *CodeGraph, query parser.Query) []*GraphNode {
@@ -178,45 +111,27 @@ func generateProxyEnv(node *GraphNode, query parser.Query) map[string]interface{
 	env := map[string]interface{}{
 		"isJavaSourceFile": proxyenv.IsJavaSourceFile(),
 		methodDeclaration: map[string]interface{}{
-			"getVisibility":     proxyenv.GetVisibility,
-			"getAnnotation":     proxyenv.GetAnnotations,
-			"getReturnType":     proxyenv.GetReturnType,
-			"getName":           proxyenv.GetName,
-			"getArgumentType":   proxyenv.GetArgumentTypes,
-			"getArgumentName":   proxyenv.GetArgumentNames,
-			"getThrowsType":     proxyenv.GetThrowsTypes,
-			"getCommentAuthor":  proxyenv.GetCommentAuthor,
-			"getCommentSee":     proxyenv.GetCommentSee,
-			"getCommentVersion": proxyenv.GetCommentVersion,
-			"getCommentSince":   proxyenv.GetCommentSince,
-			"getCommentParams":  proxyenv.GetCommentParam,
-			"getCommentThrows":  proxyenv.GetCommentThrows,
-			"getCommentReturn":  proxyenv.GetCommentReturn,
+			"getVisibility":   proxyenv.GetVisibility,
+			"getAnnotation":   proxyenv.GetAnnotations,
+			"getReturnType":   proxyenv.GetReturnType,
+			"getName":         proxyenv.GetName,
+			"getArgumentType": proxyenv.GetArgumentTypes,
+			"getArgumentName": proxyenv.GetArgumentNames,
+			"getThrowsType":   proxyenv.GetThrowsTypes,
+			"getDoc":          proxyenv.GetDoc,
 		},
 		classDeclaration: map[string]interface{}{
-			"getSuperClass":     proxyenv.GetSuperClass,
-			"getName":           proxyenv.GetName,
-			"getAnnotation":     proxyenv.GetAnnotations,
-			"getVisibility":     proxyenv.GetVisibility,
-			"getInterface":      proxyenv.GetInterfaces,
-			"getCommentAuthor":  proxyenv.GetCommentAuthor,
-			"getCommentSee":     proxyenv.GetCommentSee,
-			"getCommentVersion": proxyenv.GetCommentVersion,
-			"getCommentSince":   proxyenv.GetCommentSince,
-			"getCommentParams":  proxyenv.GetCommentParam,
-			"getCommentThrows":  proxyenv.GetCommentThrows,
-			"getCommentReturn":  proxyenv.GetCommentReturn,
+			"getSuperClass": proxyenv.GetSuperClass,
+			"getName":       proxyenv.GetName,
+			"getAnnotation": proxyenv.GetAnnotations,
+			"getVisibility": proxyenv.GetVisibility,
+			"getInterface":  proxyenv.GetInterfaces,
+			"getDoc":        proxyenv.GetDoc,
 		},
 		methodInvocation: map[string]interface{}{
-			"getArgumentName":   proxyenv.GetArgumentNames,
-			"getName":           proxyenv.GetName,
-			"getCommentAuthor":  proxyenv.GetCommentAuthor,
-			"getCommentSee":     proxyenv.GetCommentSee,
-			"getCommentVersion": proxyenv.GetCommentVersion,
-			"getCommentSince":   proxyenv.GetCommentSince,
-			"getCommentParams":  proxyenv.GetCommentParam,
-			"getCommentThrows":  proxyenv.GetCommentThrows,
-			"getCommentReturn":  proxyenv.GetCommentReturn,
+			"getArgumentName": proxyenv.GetArgumentNames,
+			"getName":         proxyenv.GetName,
+			"getDoc":          proxyenv.GetDoc,
 		},
 		variableDeclaration: map[string]interface{}{
 			"getName":             proxyenv.GetName,
@@ -224,13 +139,7 @@ func generateProxyEnv(node *GraphNode, query parser.Query) map[string]interface{
 			"getVariableValue":    proxyenv.GetVariableValue,
 			"getVariableDataType": proxyenv.GetVariableDataType,
 			"getScope":            proxyenv.GetScope,
-			"getCommentAuthor":    proxyenv.GetCommentAuthor,
-			"getCommentSee":       proxyenv.GetCommentSee,
-			"getCommentVersion":   proxyenv.GetCommentVersion,
-			"getCommentSince":     proxyenv.GetCommentSince,
-			"getCommentParam":     proxyenv.GetCommentParam,
-			"getCommentThrows":    proxyenv.GetCommentThrows,
-			"getCommentReturn":    proxyenv.GetCommentReturn,
+			"getDoc":              proxyenv.GetDoc,
 		},
 	}
 	return env


### PR DESCRIPTION
Method chaining is powerful feature to write models and expose methods to support runtime method filtering instead of compile time/construction time of AST

from now on 🚀 you'll be able to chain methods for javadoc object and methods. More support for entities and methods coming soon in future PR.

```sql
FIND method_declaration AS md WHERE md.getDoc().GetCommentAuthor() == "shivasurya"
```

## Test

- CI 🟢 