### PR TITLE
feature(query): introduce to execute queries from `CQL` file 🚀 

### DIFF
--- a/docs/src/content/docs/queries/Android/android-webview-settings.mdx
+++ b/docs/src/content/docs/queries/Android/android-webview-settings.mdx
@@ -28,7 +28,7 @@ result in cross-site scripting attacks.
  * @tags security
  * external/cwe/cwe-079
  */
-FIND method_invocation AS mi WHERE mi.getName() == "setJavaScriptEnabled" && "false" in mi.getArgumentName()
+FIND method_invocation AS mi WHERE mi.getName() == "setJavaScriptEnabled" && "true" in mi.getArgumentName()
 ```
 
 ### setAllowUniversalAccessFromFileURLs Webview API

--- a/pathfinder-rules/android/webview.cql
+++ b/pathfinder-rules/android/webview.cql
@@ -1,0 +1,13 @@
+/**
+ * @name Android WebView JavaScript settings
+ * @description Enabling JavaScript execution in a WebView can result in cross-site scripting attacks.
+ * @kind problem
+ * @id java/Android/webview-javascript-enabled
+ * @problem.severity warning
+ * @security-severity 6.1
+ * @precision medium
+ * @tags security
+ * external/cwe/cwe-079
+ */
+FIND method_invocation AS mi
+WHERE mi.getName() == "setJavaScriptEnabled" && "true" in mi.getArgumentName()

--- a/sourcecode-parser/main_test.go
+++ b/sourcecode-parser/main_test.go
@@ -108,3 +108,17 @@ func TestInitializeProjectConsistency(t *testing.T) {
 		t.Errorf("InitializeProject() should return consistent results for the same project")
 	}
 }
+
+func TestExtractQueryFromFile(t *testing.T) {
+	queryFile := "../pathfinder-rules/android/webview.cql"
+
+	result, err := ExtractQueryFromFile(queryFile)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expected := "FIND method_invocation AS mi WHERE mi.getName() == \"setJavaScriptEnabled\" && \"true\" in mi.getArgumentName()"
+	if result != expected {
+		t.Errorf("Expected query '%s', but got '%s'", expected, result)
+	}
+}

--- a/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java
+++ b/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java
@@ -32,7 +32,7 @@ public class movieDetailActivity extends AppCompatActivity {
         getSupportActionBar().setDisplayShowHomeEnabled(true);
 
         // webview.javascriptEnabled();
-        webview.getSettings().setJavaScriptEnabled(false);
+        webview.getSettings().setJavaScriptEnabled(true);
 
         movieGeneralModal moviegeneralModal = (movieGeneralModal) intent.getSerializableExtra("DATA_MOVIE");
 


### PR DESCRIPTION
From now on, you could execute queries from file named `*.cql` 🥇 

```bash
$ pathfinder --project <PATH_TO_SCAN> --query-file ../pathfinder-rules/android/webview.cql

Worker 1 ....... Done processing file Results.java
Worker 2 ....... Done processing file movieListActivity.java
Worker 1 ....... Done processing file NetworkAPI.java
Worker 2 ....... Done processing file ExampleUnitTest.java
Worker 3 ....... Done processing file movieDetailFragment.java
Worker 4 ....... Done processing file movieListActivity.java
Worker 5 ....... Done processing file Results.java
Progress: 100%
2024/08/23 09:29:13 Elapsed time:  42.888667ms
2024/08/23 09:29:13 Graph built successfully
Executing query: FIND method_invocation AS mi WHERE mi.getName() == "setJavaScriptEnabled" && "true" in mi.getArgumentName()
~/src/code-pathfinder/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java:35
------------
> webview.getSettings().setJavaScriptEnabled(true)
------------


```

- Rulesets will be placed under `pathfinder-rules/` directory as extension `.cql`
- In future this will be moved under subcommand `pathfinder scan -f <RULES_DIRECTORY> --project <SCAN_PATH>`