### PR TITLE
fixed release script variable arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           $gitCommit = (git describe --tags).Trim()
           $projectVersion = Get-Content VERSION
           $posthogkey=$env:POSTHOG_WEB_ANALYTICS          
-          go build -ldflags="-s -w -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.Version=${projectVersion} -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.GitCommit=${gitCommit} github.com/shivasurya/code-pathfinder/sourcecode-parser/analytics.PublicKey=${posthogkey}" -v -o pathfinder-windows-amd64.exe .
+          go build -ldflags="-s -w -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.Version=${projectVersion} -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.GitCommit=${gitCommit} -X github.com/shivasurya/code-pathfinder/sourcecode-parser/analytics.PublicKey=${posthogkey}" -v -o pathfinder-windows-amd64.exe .
 
       - name: Calculate SHA256
         run: |
@@ -111,7 +111,7 @@ jobs:
           gitCommit=$(git describe --tags)
           projectVersion=$(cat VERSION)
           posthogkey=$(echo $POSTHOG_WEB_ANALYTICS)
-          go build -ldflags="-s -w -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.Version=${projectVersion} -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.GitCommit=${gitCommit} github.com/shivasurya/code-pathfinder/sourcecode-parser/analytics.PublicKey=${posthogkey}" -v -o pathfinder-darwin-arm64 .
+          go build -ldflags="-s -w -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.Version=${projectVersion} -X github.com/shivasurya/code-pathfinder/sourcecode-parser/cmd.GitCommit=${gitCommit} -X github.com/shivasurya/code-pathfinder/sourcecode-parser/analytics.PublicKey=${posthogkey}" -v -o pathfinder-darwin-arm64 .
           chmod +x pathfinder-darwin-arm64
 
       - name: Calculate SHA256


### PR DESCRIPTION
The release script for macos, windows had missed -X param while building the binary. 