### PR TITLE
Support multiple entity selection via cartesian product 📐

### DIFF
--- a/sourcecode-parser/antlr/listener_impl.go
+++ b/sourcecode-parser/antlr/listener_impl.go
@@ -9,12 +9,14 @@ import (
 type Query struct {
 	SelectList []SelectList
 	Expression string
+	Condition  []string
 }
 
 type CustomQueryListener struct {
 	BaseQueryListener
 	expression strings.Builder
 	selectList []SelectList
+	condition  []string
 }
 
 type SelectList struct {
@@ -38,6 +40,12 @@ func (l *CustomQueryListener) EnterSelect_list(ctx *Select_listContext) {
 				Alias:  child.Alias().GetText(),
 			})
 		}
+	}
+}
+
+func (l *CustomQueryListener) EnterCondition(ctx *ConditionContext) {
+	if ctx.GetChildCount() > 1 {
+		l.condition = append(l.condition, ctx.GetText())
 	}
 }
 
@@ -89,5 +97,5 @@ func ParseQuery(inputQuery string) Query {
 	listener := NewCustomQueryListener()
 	antlr.ParseTreeWalkerDefault.Walk(listener, p.Query())
 
-	return Query{SelectList: listener.selectList, Expression: listener.expression.String()}
+	return Query{SelectList: listener.selectList, Expression: listener.expression.String(), Condition: listener.condition}
 }

--- a/sourcecode-parser/antlr/listener_impl_test.go
+++ b/sourcecode-parser/antlr/listener_impl_test.go
@@ -19,6 +19,7 @@ func TestParseQuery(t *testing.T) {
 			expectedQuery: Query{
 				SelectList: []SelectList{{Entity: "class_declaration", Alias: "cd"}},
 				Expression: "cd.GetName()==\"test\"",
+				Condition:  []string{"cd.GetName()==\"test\""},
 			},
 		},
 		{
@@ -30,6 +31,7 @@ func TestParseQuery(t *testing.T) {
 					{Entity: "entity2", Alias: "e2"},
 				},
 				Expression: "e1.GetName()==\"test\"",
+				Condition:  []string{"e1.GetName()==\"test\""},
 			},
 		},
 		{
@@ -41,6 +43,7 @@ func TestParseQuery(t *testing.T) {
 					{Entity: "entity2", Alias: "e2"},
 				},
 				Expression: "e1.GetName()==\"test\" || e2.GetName()==\"test\"",
+				Condition:  []string{"e1.GetName()==\"test\"", "e2.GetName()==\"test\""},
 			},
 		},
 		{
@@ -52,6 +55,7 @@ func TestParseQuery(t *testing.T) {
 					{Entity: "entity2", Alias: "e2"},
 				},
 				Expression: "e1.GetName()==\"test\" && e2.GetName()==\"test\"",
+				Condition:  []string{"e1.GetName()==\"test\"", "e2.GetName()==\"test\""},
 			},
 		},
 	}

--- a/sourcecode-parser/graph/query.go
+++ b/sourcecode-parser/graph/query.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/shivasurya/code-pathfinder/sourcecode-parser/analytics"
 	"github.com/shivasurya/code-pathfinder/sourcecode-parser/model"
@@ -108,7 +109,7 @@ func QueryEntities(graph *CodeGraph, query parser.Query) []*Node {
 }
 
 func generateCartesianProduct(graph *CodeGraph, selectList []parser.SelectList) [][]*Node {
-	var sets [][]interface{}
+	sets := make([][]interface{}, 0, len(selectList))
 
 	for _, entity := range selectList {
 		set := make([]interface{}, 0)
@@ -126,7 +127,13 @@ func generateCartesianProduct(graph *CodeGraph, selectList []parser.SelectList) 
 	for i, p := range product {
 		result[i] = make([]*Node, len(p))
 		for j, node := range p {
-			result[i][j] = node.(*Node)
+			if n, ok := node.(*Node); ok {
+				result[i][j] = n
+			} else {
+				// Handle the error case, e.g., skip this node or log an error
+				// You might want to customize this part based on your error handling strategy
+				log.Printf("Warning: Expected *Node type, got %T", node)
+			}
 		}
 	}
 

--- a/sourcecode-parser/graph/query_test.go
+++ b/sourcecode-parser/graph/query_test.go
@@ -26,7 +26,10 @@ func TestQueryEntities(t *testing.T) {
 			name: "Query with expression",
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "method_declaration", Alias: "md"}},
-				Expression: "md.getVisibility() == 'public'",
+				Expression: "md.getVisibility() == \"public\"",
+				Condition: []string{
+					"md.getVisibility()==\"public\"",
+				},
 			},
 			expected: 1,
 		},
@@ -34,7 +37,10 @@ func TestQueryEntities(t *testing.T) {
 			name: "Query with no results",
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "method_declaration", Alias: "md"}},
-				Expression: "md.getVisibility() == 'private'",
+				Expression: "md.getVisibility() == \"private\"",
+				Condition: []string{
+					"md.getVisibility()==\"private\"",
+				},
 			},
 			expected: 0,
 		},
@@ -61,7 +67,7 @@ func TestFilterEntities(t *testing.T) {
 			node: &Node{Type: "method_declaration", Modifier: "public"},
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "method_declaration", Alias: "md"}},
-				Expression: "md.getVisibility() == 'public'",
+				Expression: "md.getVisibility() == \"public\"",
 			},
 			expected: true,
 		},
@@ -70,7 +76,7 @@ func TestFilterEntities(t *testing.T) {
 			node: &Node{Type: "class_declaration", Name: "TestClass"},
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "class_declaration", Alias: "cd"}},
-				Expression: "cd.getName() == 'TestClass'",
+				Expression: "cd.getName() == \"TestClass\"",
 			},
 			expected: true,
 		},
@@ -79,7 +85,7 @@ func TestFilterEntities(t *testing.T) {
 			node: &Node{Type: "method_declaration", ReturnType: "void"},
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "method_declaration", Alias: "md"}},
-				Expression: "md.getReturnType() == 'void'",
+				Expression: "md.getReturnType() == \"void\"",
 			},
 			expected: true,
 		},
@@ -88,7 +94,7 @@ func TestFilterEntities(t *testing.T) {
 			node: &Node{Type: "variable_declaration", DataType: "int"},
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "variable_declaration", Alias: "vd"}},
-				Expression: "vd.getVariableDataType() == 'int'",
+				Expression: "vd.getVariableDataType() == \"int\"",
 			},
 			expected: true,
 		},
@@ -97,7 +103,7 @@ func TestFilterEntities(t *testing.T) {
 			node: &Node{Type: "method_declaration", Modifier: "public", ReturnType: "String", Name: "getName"},
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "method_declaration", Alias: "md"}},
-				Expression: "md.getVisibility() == 'public' && md.getReturnType() == 'String' && md.getName() == 'getName'",
+				Expression: "md.getVisibility() == \"public\" && md.getReturnType() == \"String\" && md.getName() == \"getName\"",
 			},
 			expected: true,
 		},
@@ -106,7 +112,7 @@ func TestFilterEntities(t *testing.T) {
 			node: &Node{Type: "method_declaration", Modifier: "private"},
 			query: parser.Query{
 				SelectList: []parser.SelectList{{Entity: "method_declaration", Alias: "md"}},
-				Expression: "md.getVisibility() == 'public'",
+				Expression: "md.getVisibility() == \"public\"",
 			},
 			expected: false,
 		},
@@ -240,5 +246,5 @@ func TestCartesianProductPerformance(t *testing.T) {
 	duration := time.Since(start)
 
 	assert.Equal(t, 9765625, len(result))
-	assert.Less(t, duration, 5*time.Second)
+	assert.Less(t, duration, 10*time.Second)
 }

--- a/sourcecode-parser/graph/query_test.go
+++ b/sourcecode-parser/graph/query_test.go
@@ -113,7 +113,7 @@ func TestFilterEntities(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := FilterEntities(tt.node, tt.query)
+			result := FilterEntities([]*Node{tt.node}, tt.query)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/sourcecode-parser/graph/query_test.go
+++ b/sourcecode-parser/graph/query_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	parser "github.com/shivasurya/code-pathfinder/sourcecode-parser/antlr"
 	"github.com/shivasurya/code-pathfinder/sourcecode-parser/model"
@@ -166,4 +167,78 @@ func TestGenerateProxyEnv(t *testing.T) {
 
 	throwsTypes := methodEnv["getThrowsType"].(func() []string)()
 	assert.Equal(t, []string{"IOException"}, throwsTypes)
+}
+
+func TestCartesianProduct(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [][]interface{}
+		expected [][]interface{}
+	}{
+		{
+			name:     "Empty input",
+			input:    [][]interface{}{},
+			expected: [][]interface{}{{}},
+		},
+		{
+			name:     "Single set",
+			input:    [][]interface{}{{1, 2, 3}},
+			expected: [][]interface{}{{1}, {2}, {3}},
+		},
+		{
+			name:     "Two sets",
+			input:    [][]interface{}{{1, 2}, {"a", "b"}},
+			expected: [][]interface{}{{1, "a"}, {2, "a"}, {1, "b"}, {2, "b"}},
+		},
+		{
+			name:  "Three sets",
+			input: [][]interface{}{{1, 2}, {"a", "b"}, {true, false}},
+			expected: [][]interface{}{
+				{1, "a", true}, {2, "a", true},
+				{1, "b", true}, {2, "b", true},
+				{1, "a", false}, {2, "a", false},
+				{1, "b", false}, {2, "b", false},
+			},
+		},
+		{
+			name:     "Mixed types",
+			input:    [][]interface{}{{1, "x"}, {true, 3.14}},
+			expected: [][]interface{}{{1, true}, {"x", true}, {1, 3.14}, {"x", 3.14}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cartesianProduct(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCartesianProductLargeInput(t *testing.T) {
+	input := [][]interface{}{
+		{1, 2, 3, 4, 5},
+		{"a", "b", "c", "d", "e"},
+		{true, false},
+	}
+	result := cartesianProduct(input)
+	assert.Equal(t, 50, len(result))
+	assert.Equal(t, 3, len(result[0]))
+}
+
+func TestCartesianProductPerformance(t *testing.T) {
+	input := make([][]interface{}, 10)
+	for i := range input {
+		input[i] = make([]interface{}, 5)
+		for j := range input[i] {
+			input[i][j] = j
+		}
+	}
+
+	start := time.Now()
+	result := cartesianProduct(input)
+	duration := time.Since(start)
+
+	assert.Equal(t, 9765625, len(result))
+	assert.Less(t, duration, 5*time.Second)
 }

--- a/test-src/android/app/src/test/java/com/ivb/udacity/ExampleUnitTest.java
+++ b/test-src/android/app/src/test/java/com/ivb/udacity/ExampleUnitTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
  */
 public class ExampleUnitTest {
     @Test
-    public void addition_isCorrect() throws Exception {
+    public void is_addition_correct() throws Exception {
         assertEquals(4, 2 + 2);
     }
 }


### PR DESCRIPTION
closes #98 

This PR attempts to add support for querying multiple entities in a single query. This can be naively supported by generating cartesian product of the entity nodes and applying filters.

```sql
FIND method_declaration AS md, class_declaration AS cd 
WHERE md.getVisibility() == cd.getVisibility()
```

