### PR TITLE
added better error handling for query parsing :star:

### DIFF
--- a/sourcecode-parser/antlr/listener_impl_test.go
+++ b/sourcecode-parser/antlr/listener_impl_test.go
@@ -62,7 +62,11 @@ func TestParseQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ParseQuery(tt.input)
+			result, err := ParseQuery(tt.input)
+			if err != nil {
+				t.Errorf("ParseQuery() error = %v", err)
+				return
+			}
 			if !reflect.DeepEqual(result, tt.expectedQuery) {
 				t.Errorf("ParseQuery() = %v, want %v", result, tt.expectedQuery)
 			}

--- a/sourcecode-parser/cmd/query.go
+++ b/sourcecode-parser/cmd/query.go
@@ -98,18 +98,18 @@ func executeCLIQuery(project, query, output string, stdin bool) (string, error) 
 				return "Okay, Bye!", nil
 			}
 			result, err := processQuery(input, codeGraph, output)
-			fmt.Println(result)
 			if err != nil {
 				analytics.ReportEvent(analytics.ErrorProcessingQuery)
-				return "", fmt.Errorf("error processing query: %w", err)
+				return "", fmt.Errorf("PathFinder Query syntax error: %w", err)
 			}
+			fmt.Println(result)
 		}
 	} else {
 		// read from command line
 		result, err := processQuery(query, codeGraph, output)
 		if err != nil {
 			analytics.ReportEvent(analytics.ErrorProcessingQuery)
-			return "", fmt.Errorf("error processing query: %w", err)
+			return "", fmt.Errorf("PathFinder Query syntax error: %w", err)
 		}
 		return result, nil
 	}
@@ -117,7 +117,10 @@ func executeCLIQuery(project, query, output string, stdin bool) (string, error) 
 
 func processQuery(input string, codeGraph *graph.CodeGraph, output string) (string, error) {
 	fmt.Println("Executing query: " + input)
-	parsedQuery := parser.ParseQuery(input)
+	parsedQuery, err := parser.ParseQuery(input)
+	if err != nil {
+		return "", err
+	}
 	// split the input string if WHERE
 	parsedQuery.Expression = strings.Split(input, "WHERE")[1]
 	entities := graph.QueryEntities(codeGraph, parsedQuery)

--- a/sourcecode-parser/cmd/query.go
+++ b/sourcecode-parser/cmd/query.go
@@ -100,9 +100,11 @@ func executeCLIQuery(project, query, output string, stdin bool) (string, error) 
 			result, err := processQuery(input, codeGraph, output)
 			if err != nil {
 				analytics.ReportEvent(analytics.ErrorProcessingQuery)
-				return "", fmt.Errorf("PathFinder Query syntax error: %w", err)
+				err := fmt.Errorf("PathFinder Query syntax error: %w", err)
+				fmt.Println(err)
+			} else {
+				fmt.Println(result)
 			}
-			fmt.Println(result)
 		}
 	} else {
 		// read from command line


### PR DESCRIPTION
This PR adds better error reporting for query syntax issues instead of crashing the whole application. 🎸 

```bash
Progress: 100%
2024/09/07 22:25:31 Elapsed time:  456.686083ms
2024/09/07 22:25:31 Graph built successfully
Path-Finder Query Console: 
>wdfweldjfgw
Executing query: wdfweldjfgw

PathFinder Query syntax error: 
line 1:0 missing 'FIND' at 'wdfweldjfgw'
line 2:0 mismatched input '<EOF>' expecting 'AS'

```