### PR TITLE
feat: Support for `ClassInstanceExpr`

### DIFF
--- a/pathfinder-rules/test/ClassInstanceExpr.cql
+++ b/pathfinder-rules/test/ClassInstanceExpr.cql
@@ -1,0 +1,3 @@
+FROM ClassInstanceExpr AS cie
+WHERE cie.getClassInstanceExpr().GetClassName() == "Intent"
+SELECT cie.getClassInstanceExpr().GetArgs(), cie.getClassInstanceExpr().GetNumArgs(), cie.getClassInstanceExpr().GetArg(0)

--- a/sourcecode-parser/cmd/query.go
+++ b/sourcecode-parser/cmd/query.go
@@ -154,9 +154,17 @@ func processQuery(input string, codeGraph *graph.CodeGraph, output string) (stri
 	verticalLine := "|"
 	yellowCode := color.New(color.FgYellow).SprintFunc()
 	greenCode := color.New(color.FgGreen).SprintFunc()
-	for _, entity := range entities {
+	for i, entity := range entities {
 		for _, entityObject := range entity {
 			header := fmt.Sprintf("\tFile: %s, Line: %s \n", greenCode(entityObject.File), greenCode(entityObject.LineNumber))
+			// add formatted output to result
+			output := "\tResult: "
+			for _, outputObject := range formattedOutput[i] {
+				output += graph.FormatType(outputObject)
+				output += " "
+				output += verticalLine + " "
+			}
+			header += output + "\n"
 			result += header
 			result += "\n"
 			codeSnippetArray := strings.Split(entityObject.CodeSnippet, "\n")

--- a/sourcecode-parser/cmd/query_test.go
+++ b/sourcecode-parser/cmd/query_test.go
@@ -29,7 +29,7 @@ func TestExecuteCLIQuery(t *testing.T) {
 			query:          "FROM method_declaration AS md WHERE md.getName() == \"onCreateOptionsMenu\" SELECT md.getName()",
 			output:         "",
 			stdin:          false,
-			expectedOutput: "File: ../../test-src/android/app/src/main/java/com/ivb/udacity/movieListActivity.java, Line: 96 \n\n\t\t  96 | @Override\n\t\t  97 |     public boolean onCreateOptionsMenu(Menu menu) {\n\t\t  98 |         MenuInflater inflater = getMenuInflater();\n\t\t  99 |         inflater.inflate(R.menu.main, menu);\n\t\t 100 |         return true;\n\t\t 101 |     }",
+			expectedOutput: "File: ../../test-src/android/app/src/main/java/com/ivb/udacity/movieListActivity.java, Line: 96 \n\tResult: onCreateOptionsMenu | \n\n\t\t  96 | @Override\n\t\t  97 |     public boolean onCreateOptionsMenu(Menu menu) {\n\t\t  98 |         MenuInflater inflater = getMenuInflater();\n\t\t  99 |         inflater.inflate(R.menu.main, menu);\n\t\t 100 |         return true;\n\t\t 101 |     }",
 			expectedError:  "",
 		},
 		{
@@ -79,7 +79,7 @@ func TestProcessQuery(t *testing.T) {
 			name:           "Basic query",
 			input:          "FROM method_declaration AS md WHERE md.getName() == \"testFunc\" SELECT md.getName()",
 			output:         "",
-			expectedResult: "\tFile: test.java, Line: 5 \n\n\t\t   5 | public void testFunc() {}\n\n",
+			expectedResult: "\tFile: test.java, Line: 5 \n\tResult: testFunc | \n\n\t\t   5 | public void testFunc() {}\n\n",
 			expectedError:  "",
 		},
 		{

--- a/sourcecode-parser/graph/construct_test.go
+++ b/sourcecode-parser/graph/construct_test.go
@@ -782,6 +782,22 @@ func TestBuildGraphFromAST(t *testing.T) {
 			expectedTypes:   []string{"class_declaration", "method_declaration", "block_comment"},
 			unexpectedTypes: []string{"variable_declaration", "binary_expression"},
 		},
+		// add testcase for object creation expression
+		{
+			name: "Class with object creation expression",
+			sourceCode: `
+				public class ObjectCreationClass {
+					public static void main(String[] args) {
+						ObjectCreationClass obj = new ObjectCreationClass();
+						Socket socket = new Socket("www.google.com", 80);
+					}
+				}
+			`,
+			expectedNodes:   6,
+			expectedEdges:   0,
+			expectedTypes:   []string{"class_declaration", "method_declaration", "ClassInstanceExpr"},
+			unexpectedTypes: []string{"binary_expression"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sourcecode-parser/graph/query.go
+++ b/sourcecode-parser/graph/query.go
@@ -119,7 +119,7 @@ func (env *Env) GetClassInstanceExprName() string {
 	return env.Node.ClassInstanceExpr.ClassName
 }
 
-func QueryEntities(graph *CodeGraph, query parser.Query) (nodes [][]*Node, output [][]string) {
+func QueryEntities(graph *CodeGraph, query parser.Query) (nodes [][]*Node, output [][]interface{}) {
 	result := make([][]*Node, 0)
 
 	// log query select list alone
@@ -139,10 +139,10 @@ func QueryEntities(graph *CodeGraph, query parser.Query) (nodes [][]*Node, outpu
 	return nodes, output
 }
 
-func generateOutput(nodeSet [][]*Node, query parser.Query) [][]string {
-	results := make([][]string, 0, len(nodeSet))
+func generateOutput(nodeSet [][]*Node, query parser.Query) [][]interface{} {
+	results := make([][]interface{}, 0, len(nodeSet))
 	for _, nodeSet := range nodeSet {
-		var result []string
+		var result []interface{}
 		for _, outputFormat := range query.SelectOutput {
 			switch outputFormat.Type {
 			case "string":
@@ -164,7 +164,7 @@ func generateOutput(nodeSet [][]*Node, query parser.Query) [][]string {
 	return results
 }
 
-func evaluateExpression(node []*Node, expression string, query parser.Query) (string, error) {
+func evaluateExpression(node []*Node, expression string, query parser.Query) (interface{}, error) {
 	env := generateProxyEnvForSet(node, query)
 
 	program, err := expr.Compile(expression, expr.Env(env))
@@ -177,7 +177,7 @@ func evaluateExpression(node []*Node, expression string, query parser.Query) (st
 		fmt.Println("Error evaluating expression: ", err)
 		return "", err
 	}
-	return output.(string), nil
+	return output, nil
 }
 
 func generateCartesianProduct(graph *CodeGraph, selectList []parser.SelectList, conditions []string) [][]*Node {
@@ -216,8 +216,6 @@ func generateCartesianProduct(graph *CodeGraph, selectList []parser.SelectList, 
 			typeIndex[node.Type] = append(typeIndex[node.Type], node)
 		}
 	}
-
-	fmt.Println(len(conditions))
 
 	sets := make([][]interface{}, 0, len(selectList))
 
@@ -469,7 +467,6 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 			"getDoc":               proxyenv.GetDoc,
 			"toString":             proxyenv.ToString,
 			"getClassInstanceExpr": proxyenv.GetClassInstanceExpr,
-			"getClassName":         proxyenv.GetClassInstanceExprName,
 		},
 	}
 	return env

--- a/sourcecode-parser/graph/util.go
+++ b/sourcecode-parser/graph/util.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 )
 
@@ -25,4 +26,21 @@ func appendUnique(slice []*Node, node *Node) []*Node {
 		}
 	}
 	return append(slice, node)
+}
+
+func FormatType(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case int, int64:
+		return fmt.Sprintf("%d", val)
+	case float32, float64:
+		return fmt.Sprintf("%.2f", val)
+	case []interface{}:
+		//nolint:all
+		jsonBytes, _ := json.Marshal(val)
+		return string(jsonBytes)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }

--- a/sourcecode-parser/graph/util_test.go
+++ b/sourcecode-parser/graph/util_test.go
@@ -113,3 +113,71 @@ func isValidHexString(s string) bool {
 	_, err := hex.DecodeString(s)
 	return err == nil
 }
+
+func TestFormatType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  string
+	}{
+		{
+			name:  "String input",
+			input: "test string",
+			want:  "test string",
+		},
+		{
+			name:  "Integer input",
+			input: 42,
+			want:  "42",
+		},
+		{
+			name:  "Int64 input",
+			input: int64(9223372036854775807),
+			want:  "9223372036854775807",
+		},
+		{
+			name:  "Float32 input",
+			input: float32(3.14),
+			want:  "3.14",
+		},
+		{
+			name:  "Float64 input",
+			input: 2.71828,
+			want:  "2.72",
+		},
+		{
+			name:  "Slice of integers",
+			input: []interface{}{1, 2, 3},
+			want:  "[1,2,3]",
+		},
+		{
+			name:  "Slice of mixed types",
+			input: []interface{}{"a", 1, true},
+			want:  `["a",1,true]`,
+		},
+		{
+			name:  "Boolean input",
+			input: true,
+			want:  "true",
+		},
+		{
+			name:  "Nil input",
+			input: nil,
+			want:  "<nil>",
+		},
+		{
+			name:  "Struct input",
+			input: struct{ Name string }{"John"},
+			want:  "{John}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatType(tt.input)
+			if got != tt.want {
+				t.Errorf("FormatType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sourcecode-parser/model/expr.go
+++ b/sourcecode-parser/model/expr.go
@@ -22,9 +22,10 @@ func (e *ExprParent) GetNumChildExpr() int64 {
 
 type Expr struct {
 	ExprParent
-	kind       int
+	Kind       int
 	Node       sitter.Node
 	NodeString string
+	Type       string
 }
 
 func (e *Expr) GetAChildExpr() *Expr {
@@ -43,7 +44,7 @@ func (e *Expr) GetBoolValue() {
 }
 
 func (e *Expr) GetKind() int {
-	return e.kind
+	return e.Kind
 }
 
 type BinaryExpr struct {
@@ -277,4 +278,26 @@ type XorBitwiseExpr struct {
 
 func (e *XorBitwiseExpr) GetOp() string {
 	return e.op
+}
+
+type ClassInstanceExpr struct {
+	Expr
+	ClassName string
+	Args      []*Expr
+}
+
+func (e *ClassInstanceExpr) GetClassName() string {
+	return e.ClassName
+}
+
+func (e *ClassInstanceExpr) GetArgs() []*Expr {
+	return e.Args
+}
+
+func (e *ClassInstanceExpr) GetArg(i int) *Expr {
+	return e.Args[i]
+}
+
+func (e *ClassInstanceExpr) GetNumArgs() int {
+	return len(e.Args)
 }

--- a/sourcecode-parser/model/expr.go
+++ b/sourcecode-parser/model/expr.go
@@ -301,3 +301,7 @@ func (e *ClassInstanceExpr) GetArg(i int) *Expr {
 func (e *ClassInstanceExpr) GetNumArgs() int {
 	return len(e.Args)
 }
+
+func (e *ClassInstanceExpr) String() string {
+	return fmt.Sprintf("ClassInstanceExpr(%s, %v)", e.ClassName, e.Args)
+}

--- a/sourcecode-parser/model/expr.go
+++ b/sourcecode-parser/model/expr.go
@@ -28,6 +28,10 @@ type Expr struct {
 	Type       string
 }
 
+func (e *Expr) String() string {
+	return fmt.Sprintf("Expr(%s)", e.NodeString)
+}
+
 func (e *Expr) GetAChildExpr() *Expr {
 	return e
 }

--- a/sourcecode-parser/model/expr_test.go
+++ b/sourcecode-parser/model/expr_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestBinaryExpr(t *testing.T) {
-	leftExpr := &Expr{kind: 0}
-	rightExpr := &Expr{kind: 0}
+	leftExpr := &Expr{Kind: 0}
+	rightExpr := &Expr{Kind: 0}
 	binaryExpr := &BinaryExpr{
 		Op:           "+",
 		LeftOperand:  leftExpr,
@@ -59,7 +59,7 @@ func TestComparisonExpr(t *testing.T) {
 }
 
 func TestExpr(t *testing.T) {
-	expr := &Expr{kind: 42}
+	expr := &Expr{Kind: 42}
 
 	t.Run("GetAChildExpr", func(t *testing.T) {
 		assert.Equal(t, expr, expr.GetAChildExpr())

--- a/sourcecode-parser/model/expr_test.go
+++ b/sourcecode-parser/model/expr_test.go
@@ -85,3 +85,36 @@ func TestExprParent(t *testing.T) {
 	assert.Nil(t, parent.GetChildExpr(0))
 	assert.Equal(t, int64(0), parent.GetNumChildExpr())
 }
+
+func TestClassInstanceExpr(t *testing.T) {
+	t.Run("GetClassName", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			expr     *ClassInstanceExpr
+			expected string
+		}{
+			{
+				name:     "Normal class name",
+				expr:     &ClassInstanceExpr{ClassName: "MyClass"},
+				expected: "MyClass",
+			},
+			{
+				name:     "Empty class name",
+				expr:     &ClassInstanceExpr{ClassName: ""},
+				expected: "",
+			},
+			{
+				name:     "Class name with special characters",
+				expr:     &ClassInstanceExpr{ClassName: "My_Class$123"},
+				expected: "My_Class$123",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := tc.expr.GetClassName()
+				assert.Equal(t, tc.expected, result)
+			})
+		}
+	})
+}


### PR DESCRIPTION
This PR adds support for indexing and querying `ClassInstanceExpr` 

Example:

Source:
```java
Socket so = new Socket("www.google.com", 80)
```

Query:
```sql
FROM ClassInstanceExpr AS cie
WHERE cie.getClassName() == "Socket"
SELECT cie, "Insecure Socket connection found"
```