### PR TITLE
pathfinder rules: added unencrypted socket connection detection rule

### DIFF
--- a/pathfinder-rules/java/UnEncryptedSocketConnection.cql
+++ b/pathfinder-rules/java/UnEncryptedSocketConnection.cql
@@ -1,0 +1,15 @@
+/**
+ * @name unencrypted-socket
+ * @description This socket is not encrypted. Use an SSLSocket created by SSLSocketFactory or SSLServerSocketFactory instead.
+ * @kind problem
+ * @id java/UnEncryptedSocketConnection
+ * @problem.severity warning
+ * @security-severity 3.1
+ * @precision medium
+ * @tags security
+ * external/cwe/cwe-319
+ */
+
+FROM ClassInstanceExpr AS cie
+WHERE cie.getClassInstanceExpr().GetClassName() == "Socket" || cie.getClassInstanceExpr().GetClassName() == "ServerSocket"
+SELECT cie.getName(), "This socket is not encrypted. Use an SSLSocket created by SSLSocketFactory or SSLServerSocketFactory instead"

--- a/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java
+++ b/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java
@@ -34,6 +34,12 @@ public class movieDetailActivity extends AppCompatActivity {
         // webview.javascriptEnabled();
         webview.getSettings().setJavaScriptEnabled(true);
 
+        Socket socket = new Socket("www.google.com", 80);
+
+        Socket socket = new Socket();
+
+        ServerSocket serverSocket = new ServerSocket(80);
+
         movieGeneralModal moviegeneralModal = (movieGeneralModal) intent.getSerializableExtra("DATA_MOVIE");
 
         if (savedInstanceState == null) {


### PR DESCRIPTION
This pathfinder rule helps detecting unencrypted socket, serversocket connections in source code.

example:

```java
Socket socket = new Socket("host", 8080)

ServerSocket ss = new ServerSocket("host", 8000)
```

<img width="1549" alt="Screenshot 2024-09-26 at 11 06 19 AM" src="https://github.com/user-attachments/assets/cfe8c72c-0584-4b4b-9734-d21de654adbc">