### PR TITLE
chore(release): fix npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.release.latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Latest Release
+name: Publish new npm version
 
 on:
   push:


### PR DESCRIPTION
Npm publish github action is currently being skipped due to extra condition. This should be fixed now.