### PR TITLE
feature: 🍺 Support for  `BreakStmt`

### DIFF
--- a/sourcecode-parser/graph/construct.go
+++ b/sourcecode-parser/graph/construct.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	javalang "github.com/shivasurya/code-pathfinder/sourcecode-parser/graph/java"
+
 	"github.com/shivasurya/code-pathfinder/sourcecode-parser/model"
 	"github.com/smacker/go-tree-sitter/java"
 
@@ -48,6 +50,7 @@ type Node struct {
 	WhileStmt            *model.WhileStmt
 	DoStmt               *model.DoStmt
 	ForStmt              *model.ForStmt
+	BreakStmt            *model.BreakStmt
 }
 
 type Edge struct {
@@ -176,6 +179,20 @@ func parseJavadocTags(commentContent string) *model.Javadoc {
 func buildGraphFromAST(node *sitter.Node, sourceCode []byte, graph *CodeGraph, currentContext *Node, file string) {
 	isJavaSourceFile := isJavaSourceFile(file)
 	switch node.Type() {
+	case "break_statement":
+		breakNode := javalang.ParseBreakStatement(node, sourceCode)
+		breakStmtNode := &Node{
+			ID:               fmt.Sprintf("breakstmt_%d_%d_%s", node.StartPoint().Row+1, node.StartPoint().Column+1, file),
+			Type:             "BreakStmt",
+			LineNumber:       node.StartPoint().Row + 1,
+			Name:             "BreakStmt",
+			IsExternal:       true,
+			CodeSnippet:      node.Content(sourceCode),
+			File:             file,
+			isJavaSourceFile: isJavaSourceFile,
+			BreakStmt:        breakNode,
+		}
+		graph.AddNode(breakStmtNode)
 	case "if_statement":
 		ifNode := model.IfStmt{}
 		// get the condition of the if statement

--- a/sourcecode-parser/graph/construct.go
+++ b/sourcecode-parser/graph/construct.go
@@ -181,8 +181,9 @@ func buildGraphFromAST(node *sitter.Node, sourceCode []byte, graph *CodeGraph, c
 	switch node.Type() {
 	case "break_statement":
 		breakNode := javalang.ParseBreakStatement(node, sourceCode)
+		uniquebreakstmtID := fmt.Sprintf("breakstmt_%d_%d_%s", node.StartPoint().Row+1, node.StartPoint().Column+1, file)
 		breakStmtNode := &Node{
-			ID:               fmt.Sprintf("breakstmt_%d_%d_%s", node.StartPoint().Row+1, node.StartPoint().Column+1, file),
+			ID:               GenerateSha256(uniquebreakstmtID),
 			Type:             "BreakStmt",
 			LineNumber:       node.StartPoint().Row + 1,
 			Name:             "BreakStmt",

--- a/sourcecode-parser/graph/construct_test.go
+++ b/sourcecode-parser/graph/construct_test.go
@@ -753,11 +753,16 @@ func TestBuildGraphFromAST(t *testing.T) {
                         int i = 1 | 1;
                         int j = 1 ^ 1;
                         int l = 1 >>> 1;
+                        outerlabel:
 					    while (a > 0) {
 							a--;
+                            if (a == 0) {
+								break outerlabel;
+							}
 						}
                         for (int i = 0; i < 10; i++) {
 							System.out.println(i);
+                             break;
 						}
 						do {
 							System.out.println("Hello, World!");
@@ -771,9 +776,9 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   63,
+			expectedNodes:   68,
 			expectedEdges:   4,
-			expectedTypes:   []string{"class_declaration", "method_declaration", "binary_expression", "comp_expression", "and_expression", "or_expression", "IfStmt", "ForStmt", "WhileStmt", "DoStmt"},
+			expectedTypes:   []string{"class_declaration", "method_declaration", "binary_expression", "comp_expression", "and_expression", "or_expression", "IfStmt", "ForStmt", "WhileStmt", "DoStmt", "BreakStmt"},
 			unexpectedTypes: []string{""},
 		},
 		{

--- a/sourcecode-parser/graph/java/parse_statement.go
+++ b/sourcecode-parser/graph/java/parse_statement.go
@@ -1,0 +1,17 @@
+package java
+
+import (
+	"github.com/shivasurya/code-pathfinder/sourcecode-parser/model"
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+func ParseBreakStatement(node *sitter.Node, sourcecode []byte) *model.BreakStmt {
+	breakStmt := &model.BreakStmt{}
+	// get identifier if present child
+	for i := 0; i < int(node.ChildCount()); i++ {
+		if node.Child(i).Type() == "identifier" {
+			breakStmt.Label = node.Child(i).Content(sourcecode)
+		}
+	}
+	return breakStmt
+}

--- a/sourcecode-parser/graph/java/parse_statement_test.go
+++ b/sourcecode-parser/graph/java/parse_statement_test.go
@@ -1,0 +1,41 @@
+package java
+
+import (
+	"github.com/smacker/go-tree-sitter/java"
+	"testing"
+
+	"github.com/shivasurya/code-pathfinder/sourcecode-parser/model"
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBreakStatement(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *model.BreakStmt
+	}{
+		{
+			name:     "Simple break statement without label",
+			input:    "break;",
+			expected: &model.BreakStmt{Label: ""},
+		},
+		{
+			name:     "Break statement with label",
+			input:    "break myLabel;",
+			expected: &model.BreakStmt{Label: "myLabel"},
+		},
+	}
+
+	parser := sitter.NewParser()
+	parser.SetLanguage(java.GetLanguage())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := parser.Parse(nil, []byte(tt.input))
+			node := tree.RootNode().Child(0)
+			result := ParseBreakStatement(node, []byte(tt.input))
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/sourcecode-parser/graph/query.go
+++ b/sourcecode-parser/graph/query.go
@@ -135,6 +135,10 @@ func (env *Env) GetForStmt() *model.ForStmt {
 	return env.Node.ForStmt
 }
 
+func (env *Env) GetBreakStmt() *model.BreakStmt {
+	return env.Node.BreakStmt
+}
+
 func QueryEntities(graph *CodeGraph, query parser.Query) (nodes [][]*Node, output [][]interface{}) {
 	result := make([][]*Node, 0)
 
@@ -310,6 +314,7 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 	whileStmt := "WhileStmt"
 	doStmt := "DoStmt"
 	forStmt := "ForStmt"
+	breakStmt := "BreakStmt"
 
 	// print query select list
 	for _, entity := range query.SelectList {
@@ -366,6 +371,8 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 			doStmt = entity.Alias
 		case "ForStmt":
 			forStmt = entity.Alias
+		case "BreakStmt":
+			breakStmt = entity.Alias
 		}
 	}
 	env := map[string]interface{}{
@@ -511,6 +518,10 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 		forStmt: map[string]interface{}{
 			"getForStmt": proxyenv.GetForStmt,
 			"toString":   proxyenv.ToString,
+		},
+		breakStmt: map[string]interface{}{
+			"toString":     proxyenv.ToString,
+			"getBreakStmt": proxyenv.GetBreakStmt,
 		},
 	}
 	return env

--- a/sourcecode-parser/model/stmt.go
+++ b/sourcecode-parser/model/stmt.go
@@ -166,3 +166,64 @@ func (whileStmt *WhileStmt) GetPP() string {
 func (whileStmt *WhileStmt) ToString() string {
 	return fmt.Sprintf("while (%s) %s", whileStmt.Condition.NodeString, whileStmt.Stmt.NodeString)
 }
+
+type ILabeledStmt interface {
+	GetAPrimaryQlClass() string
+	GetHalsteadID() int
+	GetLabel() *LabeledStmt
+	GetPP() string
+	ToString() string
+}
+
+type LabeledStmt struct {
+	Stmt
+	Label *LabeledStmt
+}
+
+type JumpStmt struct {
+	Stmt
+}
+
+type IJumpStmt interface {
+	GetTarget() *StmtParent
+	GetTargetLabel() *LabeledStmt
+}
+
+type IBreakStmt interface {
+	GetAPrimaryQlClass() string
+	GetHalsteadID() int
+	GetLabel() string
+	hasLabel() bool
+	GetPP() string
+	ToString() string
+}
+
+type BreakStmt struct {
+	JumpStmt
+	Label string
+}
+
+func (breakStmt *BreakStmt) GetAPrimaryQlClass() string {
+	return "BreakStmt"
+}
+
+func (breakStmt *BreakStmt) GetHalsteadID() int {
+	// TODO: Implement Halstead ID calculation for BreakStmt
+	return 0
+}
+
+func (breakStmt *BreakStmt) GetPP() string {
+	return fmt.Sprintf("break (%s)", breakStmt.Label)
+}
+
+func (breakStmt *BreakStmt) ToString() string {
+	return fmt.Sprintf("break (%s)", breakStmt.Label)
+}
+
+func (breakStmt *BreakStmt) hasLabel() bool {
+	return breakStmt.Label != ""
+}
+
+func (breakStmt *BreakStmt) GetLabel() string {
+	return breakStmt.Label
+}

--- a/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java
+++ b/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailActivity.java
@@ -49,10 +49,11 @@ public class movieDetailActivity extends AppCompatActivity {
         ServerSocket serverSocket = new ServerSocket(80);
 
         movieGeneralModal moviegeneralModal = (movieGeneralModal) intent.getSerializableExtra("DATA_MOVIE");
-
+        outlabel:
         if (savedInstanceState == null) {
 
             movieDetailFragment fragment = new movieDetailFragment();
+            break outlabel;
             fragment.setMovieData(moviegeneralModal);
             getSupportFragmentManager().beginTransaction()
                     .add(R.id.movie_detail_container, fragment)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This pull request introduces support for parsing and handling Java `break` statements within the code graph. The changes include updates to the parser, model, and tests to incorporate this new feature.

### Parser and Model Updates:
* Added `BreakStmt` to the `Node` struct in `sourcecode-parser/graph/construct.go` to represent break statements in the graph.
* Implemented the `ParseBreakStatement` function in `sourcecode-parser/graph/java/parse_statement.go` to parse Java break statements.
* Introduced the `BreakStmt` struct in `sourcecode-parser/model/stmt.go` to model break statements.

### Graph Construction:
* Updated the `buildGraphFromAST` function in `sourcecode-parser/graph/construct.go` to handle break statements and add them to the graph.

### Query Enhancements:
* Added support for querying `BreakStmt` in `sourcecode-parser/graph/query.go` by adding relevant methods and mappings. [[1]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR138-R141) [[2]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR317) [[3]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR374-R375) [[4]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR522-R525)

### Testing:
* Added tests for parsing break statements in `sourcecode-parser/graph/java/parse_statement_test.go`.
* Updated the test for building the graph from AST in `sourcecode-parser/graph/construct_test.go` to include break statements. [[1]](diffhunk://#diff-0a3c4e201b37c63ddb996c242b9259233f31714f17ff8b86d26ab37397518245R756-R765) [[2]](diffhunk://#diff-0a3c4e201b37c63ddb996c242b9259233f31714f17ff8b86d26ab37397518245L774-R781)

### Checklist:
* [x] Tests passing (`gradle testGo`)?
* [x] Lint passing (`golangci-lint run` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?