### PR TITLE
feature: 🍺  Support for `BlockStmt` statement

### DIFF
--- a/sourcecode-parser/graph/construct_test.go
+++ b/sourcecode-parser/graph/construct_test.go
@@ -701,9 +701,9 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   3,
+			expectedNodes:   4,
 			expectedEdges:   0,
-			expectedTypes:   []string{"class_declaration", "method_declaration", "variable_declaration"},
+			expectedTypes:   []string{"class_declaration", "method_declaration", "variable_declaration", "BlockStmt"},
 			unexpectedTypes: []string{"method_invocation"},
 		},
 		{
@@ -718,9 +718,9 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   5,
+			expectedNodes:   7,
 			expectedEdges:   2,
-			expectedTypes:   []string{"class_declaration", "method_declaration", "method_invocation"},
+			expectedTypes:   []string{"class_declaration", "method_declaration", "method_invocation", "BlockStmt"},
 			unexpectedTypes: []string{"variable_declaration"},
 		},
 		{
@@ -732,7 +732,7 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   5,
+			expectedNodes:   6,
 			expectedEdges:   0,
 			expectedTypes:   []string{"class_declaration", "method_declaration", "binary_expression", "ReturnStmt"},
 			unexpectedTypes: []string{"variable_declaration"},
@@ -791,9 +791,9 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   74,
+			expectedNodes:   83,
 			expectedEdges:   5,
-			expectedTypes:   []string{"class_declaration", "method_declaration", "binary_expression", "comp_expression", "and_expression", "or_expression", "IfStmt", "ForStmt", "WhileStmt", "DoStmt", "BreakStmt", "ContinueStmt", "YieldStmt", "ReturnStmt"},
+			expectedTypes:   []string{"class_declaration", "method_declaration", "binary_expression", "comp_expression", "and_expression", "or_expression", "IfStmt", "ForStmt", "WhileStmt", "DoStmt", "BreakStmt", "ContinueStmt", "YieldStmt", "ReturnStmt", "BlockStmt"},
 			unexpectedTypes: []string{""},
 		},
 		{
@@ -811,7 +811,7 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   4,
+			expectedNodes:   5,
 			expectedEdges:   0,
 			expectedTypes:   []string{"class_declaration", "method_declaration", "block_comment", "ReturnStmt"},
 			unexpectedTypes: []string{"variable_declaration", "binary_expression"},
@@ -827,7 +827,7 @@ func TestBuildGraphFromAST(t *testing.T) {
 					}
 				}
 			`,
-			expectedNodes:   6,
+			expectedNodes:   7,
 			expectedEdges:   0,
 			expectedTypes:   []string{"class_declaration", "method_declaration", "ClassInstanceExpr"},
 			unexpectedTypes: []string{"binary_expression"},

--- a/sourcecode-parser/graph/java/parse_statement.go
+++ b/sourcecode-parser/graph/java/parse_statement.go
@@ -50,3 +50,13 @@ func ParseReturnStatement(node *sitter.Node, sourcecode []byte) *model.ReturnStm
 	}
 	return returnStmt
 }
+
+func ParseBlockStatement(node *sitter.Node, sourcecode []byte) *model.BlockStmt {
+	blockStmt := &model.BlockStmt{}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		singleBlockStmt := &model.Stmt{}
+		singleBlockStmt.NodeString = node.Child(i).Content(sourcecode)
+		blockStmt.Stmts = append(blockStmt.Stmts, *singleBlockStmt)
+	}
+	return blockStmt
+}

--- a/sourcecode-parser/graph/java/parse_statement_test.go
+++ b/sourcecode-parser/graph/java/parse_statement_test.go
@@ -197,3 +197,83 @@ func TestParseAssertStatement(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBlockStatement(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *model.BlockStmt
+	}{
+		{
+			name:  "Empty block statement",
+			input: "{}",
+			expected: &model.BlockStmt{
+				Stmts: []model.Stmt{
+					{NodeString: "{"},
+					{NodeString: "}"},
+				},
+			},
+		},
+		{
+			name:  "Single statement block",
+			input: "{return true;}",
+			expected: &model.BlockStmt{
+				Stmts: []model.Stmt{
+					{NodeString: "{"},
+					{NodeString: "return true;"},
+					{NodeString: "}"},
+				},
+			},
+		},
+		{
+			name:  "Multiple statement block",
+			input: "{int x = 1; x++; return x;}",
+			expected: &model.BlockStmt{
+				Stmts: []model.Stmt{
+					{NodeString: "{"},
+					{NodeString: "int x = 1;"},
+					{NodeString: "x++;"},
+					{NodeString: "return x;"},
+					{NodeString: "}"},
+				},
+			},
+		},
+		{
+			name:  "Nested block statements",
+			input: "{{int x = 1;}{int y = 2;}}",
+			expected: &model.BlockStmt{
+				Stmts: []model.Stmt{
+					{NodeString: "{"},
+					{NodeString: "{int x = 1;}"},
+					{NodeString: "{int y = 2;}"},
+					{NodeString: "}"},
+				},
+			},
+		},
+		{
+			name:  "Block with complex statements",
+			input: "{System.out.println(\"Hello\"); if(x > 0) { return true; } throw new Exception();}",
+			expected: &model.BlockStmt{
+				Stmts: []model.Stmt{
+					{NodeString: "{"},
+					{NodeString: "System.out.println(\"Hello\");"},
+					{NodeString: "if(x > 0) { return true; }"},
+					{NodeString: "throw new Exception();"},
+					{NodeString: "}"},
+				},
+			},
+		},
+	}
+
+	parser := sitter.NewParser()
+	parser.SetLanguage(java.GetLanguage())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := parser.Parse(nil, []byte(tt.input))
+			node := tree.RootNode().Child(0)
+			result := ParseBlockStatement(node, []byte(tt.input))
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/sourcecode-parser/graph/query.go
+++ b/sourcecode-parser/graph/query.go
@@ -155,6 +155,10 @@ func (env *Env) GetReturnStmt() *model.ReturnStmt {
 	return env.Node.ReturnStmt
 }
 
+func (env *Env) GetBlockStmt() *model.BlockStmt {
+	return env.Node.BlockStmt
+}
+
 func QueryEntities(graph *CodeGraph, query parser.Query) (nodes [][]*Node, output [][]interface{}) {
 	result := make([][]*Node, 0)
 
@@ -335,6 +339,7 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 	yieldStmt := "YieldStmt"
 	assertStmt := "AssertStmt"
 	returnStmt := "ReturnStmt"
+	blockStmt := "BlockStmt"
 
 	// print query select list
 	for _, entity := range query.SelectList {
@@ -401,6 +406,8 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 			assertStmt = entity.Alias
 		case "ReturnStmt":
 			returnStmt = entity.Alias
+		case "BlockStmt":
+			blockStmt = entity.Alias
 		}
 	}
 	env := map[string]interface{}{
@@ -566,6 +573,10 @@ func generateProxyEnv(node *Node, query parser.Query) map[string]interface{} {
 		returnStmt: map[string]interface{}{
 			"toString":      proxyenv.ToString,
 			"getReturnStmt": proxyenv.GetReturnStmt,
+		},
+		blockStmt: map[string]interface{}{
+			"toString":     proxyenv.ToString,
+			"getBlockStmt": proxyenv.GetBlockStmt,
 		},
 	}
 	return env

--- a/sourcecode-parser/model/stmt.go
+++ b/sourcecode-parser/model/stmt.go
@@ -375,3 +375,52 @@ func (returnStmt *ReturnStmt) ToString() string {
 func (returnStmt *ReturnStmt) GetResult() *Expr {
 	return returnStmt.Result
 }
+
+type BlockStmt struct {
+	Stmt
+	Stmts []Stmt
+}
+
+type IBlockStmt interface {
+	GetAPrimaryQlClass() string
+	GetHalsteadID() int
+	GetPP() string
+	ToString() string
+	GetStmt(index int) Stmt
+	GetAStmt() Stmt
+	GetNumStmt() int
+	GetLastStmt() Stmt
+}
+
+func (blockStmt *BlockStmt) GetAPrimaryQlClass() string {
+	return "BlockStmt"
+}
+
+func (blockStmt *BlockStmt) GetHalsteadID() int {
+	// TODO: Implement Halstead ID calculation for BlockStmt
+	return 0
+}
+
+func (blockStmt *BlockStmt) GetPP() string {
+	return fmt.Sprintf("block %s", blockStmt.Stmts)
+}
+
+func (blockStmt *BlockStmt) ToString() string {
+	return fmt.Sprintf("block %s", blockStmt.Stmts)
+}
+
+func (blockStmt *BlockStmt) GetStmt(index int) Stmt {
+	return blockStmt.Stmts[index]
+}
+
+func (blockStmt *BlockStmt) GetAStmt() Stmt {
+	return blockStmt.Stmts[0]
+}
+
+func (blockStmt *BlockStmt) GetNumStmt() int {
+	return len(blockStmt.Stmts)
+}
+
+func (blockStmt *BlockStmt) GetLastStmt() Stmt {
+	return blockStmt.Stmts[len(blockStmt.Stmts)-1]
+}

--- a/sourcecode-parser/model/stmt_test.go
+++ b/sourcecode-parser/model/stmt_test.go
@@ -428,3 +428,61 @@ func TestReturnStmt_GetPP(t *testing.T) {
 		assert.Equal(t, "return x > 0 && y < 10", returnStmt.GetPP())
 	})
 }
+
+func TestBlockStmt(t *testing.T) {
+	t.Run("GetAPrimaryQlClass", func(t *testing.T) {
+		blockStmt := &BlockStmt{}
+		assert.Equal(t, "BlockStmt", blockStmt.GetAPrimaryQlClass())
+	})
+
+	t.Run("GetHalsteadID", func(t *testing.T) {
+		blockStmt := &BlockStmt{}
+		assert.Equal(t, 0, blockStmt.GetHalsteadID())
+	})
+
+	t.Run("GetStmt with valid index", func(t *testing.T) {
+		stmt1 := Stmt{NodeString: "x = 1"}
+		stmt2 := Stmt{NodeString: "y = 2"}
+		blockStmt := &BlockStmt{
+			Stmts: []Stmt{stmt1, stmt2},
+		}
+		assert.Equal(t, stmt2, blockStmt.GetStmt(1))
+	})
+
+	t.Run("GetAStmt with non-empty block", func(t *testing.T) {
+		stmt1 := Stmt{NodeString: "x = 1"}
+		stmt2 := Stmt{NodeString: "y = 2"}
+		blockStmt := &BlockStmt{
+			Stmts: []Stmt{stmt1, stmt2},
+		}
+		assert.Equal(t, stmt1, blockStmt.GetAStmt())
+	})
+
+	t.Run("GetNumStmt with multiple statements", func(t *testing.T) {
+		blockStmt := &BlockStmt{
+			Stmts: []Stmt{
+				{NodeString: "x = 1"},
+				{NodeString: "y = 2"},
+				{NodeString: "z = 3"},
+			},
+		}
+		assert.Equal(t, 3, blockStmt.GetNumStmt())
+	})
+
+	t.Run("GetNumStmt with empty block", func(t *testing.T) {
+		blockStmt := &BlockStmt{
+			Stmts: []Stmt{},
+		}
+		assert.Equal(t, 0, blockStmt.GetNumStmt())
+	})
+
+	t.Run("GetLastStmt with multiple statements", func(t *testing.T) {
+		stmt1 := Stmt{NodeString: "x = 1"}
+		stmt2 := Stmt{NodeString: "y = 2"}
+		stmt3 := Stmt{NodeString: "z = 3"}
+		blockStmt := &BlockStmt{
+			Stmts: []Stmt{stmt1, stmt2, stmt3},
+		}
+		assert.Equal(t, stmt3, blockStmt.GetLastStmt())
+	})
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This pull request introduces support for parsing and handling block statements in the code graph. The most important changes include adding a new `BlockStmt` type, updating the graph construction to recognize block statements, and enhancing the query environment to support this new type.

### Addition of Block Statement Support:

* [`sourcecode-parser/graph/construct.go`](diffhunk://#diff-1774f73dedf66ded4170ae5e8f0988a1782789c07e7224bb863224f037da8f84R58): Added `BlockStmt` to the `Node` struct and updated `buildGraphFromAST` to handle "block" node types by creating and adding `BlockStmt` nodes to the graph. [[1]](diffhunk://#diff-1774f73dedf66ded4170ae5e8f0988a1782789c07e7224bb863224f037da8f84R58) [[2]](diffhunk://#diff-1774f73dedf66ded4170ae5e8f0988a1782789c07e7224bb863224f037da8f84R187-R201)

### Parsing and Handling Block Statements:

* [`sourcecode-parser/graph/java/parse_statement.go`](diffhunk://#diff-e4676849ca99a6418cb0c184d6b747173fa52443fe9b1d8f0137660d56e43680R53-R62): Added `ParseBlockStatement` function to parse block statements from the syntax tree.

### Query Environment Enhancements:

* [`sourcecode-parser/graph/query.go`](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR158-R161): Added `GetBlockStmt` method to the `Env` struct and updated `generateProxyEnv` to include block statements in the environment map. [[1]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR158-R161) [[2]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR342) [[3]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR409-R410) [[4]](diffhunk://#diff-cb57796a432d3a8aaf631a83320a271ea1cab49f1a9053c844d91ad12358a74bR577-R580)

### Block Statement Model:

* [`sourcecode-parser/model/stmt.go`](diffhunk://#diff-d25587eb6182144aaeca2dcc7219b52c3ae7b427e1c8b67de79810e8d05dba73R378-R426): Added a new `BlockStmt` struct and its associated methods to represent block statements in the model.

### Checklist:
* [x] Tests passing (`gradle testGo`)?
* [x] Lint passing (`golangci-lint run` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?