### PR TITLE
fix docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Code Pathfinder, the open-source alternative to GitHub CodeQL. Built for advance
 ## :tv: Demo
 
 ```bash
-docker run --rm -v "./src:/src" shivasurya/code-pathfinder:stable-latest pathfinder ci --project /src/code-pathfinder/test-src --ruleset cpf/java
+docker run --rm -v "./src:/src" shivasurya/code-pathfinder:stable-latest ci --project /src/code-pathfinder/test-src --ruleset cpf/java
 ```
 
 ## :book: Documentation


### PR DESCRIPTION


### Description:

docker run -v "./src:/src" shivasurya/code-pathfinder:stable-latest **pathfinder** ci --project /src/code-pathfinder/test-src --ruleset cpf/java

```
unknown command "pathfinder" for "pathfinder"
Error: unknown command "pathfinder" for "pathfinder"
Run 'pathfinder --help' for usage.
```

right answer:
`docker run -v "./src:/src" shivasurya/code-pathfinder:stable-latest ci --project /src/code-pathfinder/test-src --ruleset cpf/java`


### Checklist:
* [x] Tests passing (`gradle testGo`)?
* [x] Lint passing (`golangci-lint run` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?