### PR TITLE
atlas/rule: add basic xxe rule for java xml parser

### DIFF
--- a/docs/src/content/docs/atlas/index.mdx
+++ b/docs/src/content/docs/atlas/index.mdx
@@ -32,7 +32,7 @@ import Footer from '../../../components/Footer.astro';
     <CardGrid>
       {/* Java Card */}
       <Card title="Java" icon="seti:java">
-        6 rules for Java applications
+        7 rules for Java applications
         <div>
           <a href="/atlas/java" class="view-docs-link">View Rules</a>
         </div>

--- a/docs/src/content/docs/atlas/java/index.mdx
+++ b/docs/src/content/docs/atlas/java/index.mdx
@@ -21,7 +21,7 @@ To run these rules against your Java codebase:
 codepathfinder ci --project /src/project --ruleset cpf/java
 ```
 
-#### Rules (4)
+#### Rules (7)
 
 <RuleSearch placeholder="Search security rules and patterns..." />
 
@@ -116,6 +116,38 @@ SSLSocket socket = (SSLSocket) factory.createSocket("example.com", 443);`}
       </div>
   </Card>
 </div>
+
+
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="xml-external-entities">
+  <Card title="XML External Entity (XXE) Vulnerability" icon="warning">
+      <div class="description">
+      **Severity: High** | **OWASP: XML External Entities (XXE)**  
+      Identifies insecure XML parser configurations that could allow XXE attacks, potentially leading to data disclosure, denial of service, or server-side request forgery.
+      </div>
+      <div class="code-section">
+        <CollapsibleCode 
+            code={`
+// ❌ Vulnerable: Disabling protection
+DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+DocumentBuilder builder = dbf.newDocumentBuilder();
+
+// ✅ Safe: Properly configured XML parser
+DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+dbf.setXIncludeAware(false);
+dbf.setExpandEntityReferences(false);
+DocumentBuilder builder = dbf.newDocumentBuilder();`}
+            lang="java"
+            title="XML Parser Configuration Example"
+            marks={['Vulnerable', 'Vulnerable', 'Safe']}
+        />
+      </div>
+  </Card>
+</div>
+
 
 </div>
 

--- a/pathfinder-rules/java/XMLExternalEntity.cql
+++ b/pathfinder-rules/java/XMLExternalEntity.cql
@@ -1,0 +1,22 @@
+/**
+ * @name XXEConfig
+ * @description Detects insecure XML parsers and configurations that could lead to XXE attacks
+ * @kind problem
+ * @id java/XXEConfig
+ * @problem.severity warning
+ * @security-severity 8.0
+ * @precision high
+ * @tags security
+ * external/cwe/cwe-611
+ * @ruleprovider java
+ */
+
+FROM method_invocation AS mi
+WHERE mi.getName() == "setFeature" &&
+    ("http://xml.org/sax/features/external-parameter-entities" in mi.getArgumentName() &&
+     "true" in mi.getArgumentName()) ||
+    ("http://xml.org/sax/features/external-general-entities" in mi.getArgumentName() && 
+     "true" in mi.getArgumentName()) ||
+    ("http://apache.org/xml/features/disallow-doctype-decl" in mi.getArgumentName() &&
+     "false" in mi.getArgumentName())
+SELECT mi.getName(), "XML External Entity (XXE) attack vulnerability"

--- a/sourcecode-parser/cmd/ci_test.go
+++ b/sourcecode-parser/cmd/ci_test.go
@@ -122,7 +122,7 @@ func TestLoadRules(t *testing.T) {
 			name:           "Local rules directory",
 			rulesDirectory: "../../pathfinder-rules",
 			isHosted:       false,
-			expectedRules:  12,
+			expectedRules:  13,
 			expectError:    false,
 		},
 		{

--- a/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailFragment.java
+++ b/test-src/android/app/src/main/java/com/ivb/udacity/movieDetailFragment.java
@@ -173,6 +173,10 @@ public class movieDetailFragment extends Fragment {
             @Override
             public void success(movieYoutubeModal movieYoutubeModal, Response response) {
                 youtubeViewHolder.setPadding(5, 10, 5, 0);
+                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+                dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", true);
+                dbf.newDocumentBuilder();
                 com.ivb.udacity.modal.trailer.Results[] trailer = movieYoutubeModal.getResults();
                 if (trailer.length > 0) {
                     shareYoutubeID = trailer[0].getKey();
@@ -211,6 +215,14 @@ public class movieDetailFragment extends Fragment {
                     errmsg.setLayoutParams(params);
                     errmsg.setText("That's Bad Luck,No Trailers Found!Check later");
                     youtubeViewHolder.addView(errmsg);
+
+                    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                    dbf.setFeature("http://xml.org/sax/features/external-general-entities", true);
+                    dbf.newDocumentBuilder();
+
+                    DocumentBuilderFactory dbf2 = DocumentBuilderFactory.newInstance();
+                    dbf2.setFeature("http://xml.org/sax/features/external-parameter-entities", true);
+                    dbf2.newDocumentBuilder();
                 }
             }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This pull request includes updates to the Java documentation and introduces a new rule for detecting XML External Entity (XXE) vulnerabilities. Additionally, it modifies some Java code examples to highlight secure configurations.

## New Rule Addition:

* [`pathfinder-rules/java/XMLExternalEntity.cql`](diffhunk://#diff-ba6a47aa1826e349f7e8d7dfcf5e2b30e3bd6d02c4620518e83ab9e0e4b4e3b6R1-R22): Added a new rule to detect insecure XML parser configurations that could lead to XXE attacks.

## Java Code Examples:

* [`test-src/android/app/src/main/java/com/ivb/udacity/movieDetailFragment.java`](diffhunk://#diff-77fa05a55906fc45875c4f4411e2a4f5b0ac9ecfeaccc9e4f078ea3ecbe28a44R176-R179): Added insecure XML parser configurations in two methods to demonstrate potential vulnerabilities. [[1]](diffhunk://#diff-77fa05a55906fc45875c4f4411e2a4f5b0ac9ecfeaccc9e4f078ea3ecbe28a44R176-R179) [[2]](diffhunk://#diff-77fa05a55906fc45875c4f4411e2a4f5b0ac9ecfeaccc9e4f078ea3ecbe28a44R218-R225)

### Checklist:
* [x] Tests passing (`gradle testGo`)?
* [x] Lint passing (`golangci-lint run` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?