### PR TITLE
feat/atlas: add playground integration for atlas ruleset

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,15 @@
       "dependencies": {
         "@astrojs/sitemap": "^3.2.1",
         "@astrojs/starlight": "^0.32.2",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/lang-java": "^6.0.1",
+        "@codemirror/lang-sql": "^6.8.0",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.36.5",
+        "@uiw/codemirror-theme-monokai": "^4.23.10",
         "astro": "^5.4.2",
+        "codemirror": "^6.0.1",
         "sharp": "^0.32.5"
       },
       "optionalDependencies": {
@@ -220,6 +228,110 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.1.tgz",
+      "integrity": "sha512-OOnmhH67h97jHzCuFaIEspbmsT98fNdhVhmA3zCxW0cn7l8rChDhZtwiwJ/JOKXgfm4J+ELxQihxaI7bj7mJRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.8.0.tgz",
+      "integrity": "sha512-aGLmY4OwGqN3TdSx3h6QeA1NrvaYtF7kkoWR/+W7/JzB0gQtJ+VJxewlnE3+VImhA4WVlhmkJr109PefOOhjLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
+      "integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
+      "integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.36.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.5.tgz",
+      "integrity": "sha512-cd+FZEUlu3GQCYnguYm3EkhJ8KJVisqqUsCOKedBoAt/d9c76JUUap6U0UrpElln5k6VyrEOYliMuDAKIeDQLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@ctrl/tinycolor": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.0.tgz",
@@ -332,6 +444,47 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
     "node_modules/@mdx-js/mdx": {
@@ -846,6 +999,37 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@uiw/codemirror-theme-monokai": {
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-theme-monokai/-/codemirror-theme-monokai-4.23.10.tgz",
+      "integrity": "sha512-P1KEAiXA6UlQdqwSTpPZwB/VAIaoqtu4oigSUgL9mt+UKzhKyurANFypYSEHmGDuweq80lrOUXCnPc4mOR9xuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/codemirror-themes": "4.23.10"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/@uiw/codemirror-themes": {
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-themes/-/codemirror-themes-4.23.10.tgz",
+      "integrity": "sha512-dU0UgEEgEXCAYpxuVDQ6fovE82XsqgHZckTJOH6Bs8xCi3Z7dwBKO4pXuiA8qGDwTOXOMjSzfi+pRViDm7OfWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -1493,6 +1677,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -1573,6 +1772,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/crossws": {
@@ -5385,6 +5590,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
@@ -5956,6 +6167,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,15 @@
   "dependencies": {
     "@astrojs/sitemap": "^3.2.1",
     "@astrojs/starlight": "^0.32.2",
+    "@codemirror/autocomplete": "^6.18.6",
+    "@codemirror/lang-java": "^6.0.1",
+    "@codemirror/lang-sql": "^6.8.0",
+    "@codemirror/language": "^6.11.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.36.5",
+    "@uiw/codemirror-theme-monokai": "^4.23.10",
     "astro": "^5.4.2",
+    "codemirror": "^6.0.1",
     "sharp": "^0.32.5"
   },
   "optionalDependencies": {

--- a/docs/src/components/Code.astro
+++ b/docs/src/components/Code.astro
@@ -1,0 +1,94 @@
+---
+interface Props {
+  code: string;
+  lang: string;
+  mark?: number[];
+  highlights?: { line: number; message: string }[];
+}
+
+const { code, lang, mark = [], highlights = [] } = Astro.props;
+
+// Convert highlights to line numbers array
+const highlightedLines = highlights.map(h => h.line);
+
+// Combine mark and highlights for the final set of highlighted lines
+const allHighlights = [...new Set([...mark, ...highlightedLines])];
+---
+
+<div class="code-block">
+  <pre
+    class:list={[
+      'astro-code',
+      `language-${lang}`,
+      { 'has-highlights': highlights.length > 0 }
+    ]}
+    style="background-color: var(--astro-code-color-background)"
+    tabindex="0"
+    data-highlights={JSON.stringify(highlights)}
+  ><code>{code}</code></pre>
+</div>
+
+<style>
+  .code-block {
+    position: relative;
+    margin: 1rem 0;
+  }
+
+  pre {
+    margin: 0;
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+  }
+
+  .has-highlights .line-highlight {
+    background-color: var(--sl-color-accent-low);
+    position: absolute;
+    left: 0;
+    right: 0;
+    pointer-events: none;
+  }
+
+  .line-highlight::before {
+    content: attr(data-message);
+    position: absolute;
+    right: 0.5rem;
+    font-size: 0.8rem;
+    color: var(--sl-color-text-accent);
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .line-highlight:hover::before {
+    opacity: 1;
+  }
+</style>
+
+<script>
+  function highlightCode() {
+    const codeBlocks = document.querySelectorAll('pre.has-highlights');
+    
+    codeBlocks.forEach(block => {
+      const highlights = JSON.parse(block.getAttribute('data-highlights') || '[]');
+      const code = block.querySelector('code');
+      if (!code) return;
+
+      // Split code into lines and wrap each in a span
+      const lines = code.textContent?.split('\n') || [];
+      code.innerHTML = lines
+        .map((line, i) => {
+          const highlight = highlights.find(h => h.line === i + 1);
+          const className = highlight ? 'line-highlight' : '';
+          const message = highlight?.message || '';
+          return `<span class="line ${className}" ${message ? `data-message="${message}"` : ''}>${line}</span>`;
+        })
+        .join('\n');
+    });
+  }
+
+  // Run on page load
+  highlightCode();
+
+  // Re-run when content updates (for client routing)
+  document.addEventListener('astro:page-load', highlightCode);
+</script>

--- a/docs/src/components/Code.astro
+++ b/docs/src/components/Code.astro
@@ -1,94 +1,142 @@
 ---
-interface Props {
+export type Props = {
   code: string;
   lang: string;
   mark?: number[];
-  highlights?: { line: number; message: string }[];
 }
 
-const { code, lang, mark = [], highlights = [] } = Astro.props;
-
-// Convert highlights to line numbers array
-const highlightedLines = highlights.map(h => h.line);
-
-// Combine mark and highlights for the final set of highlighted lines
-const allHighlights = [...new Set([...mark, ...highlightedLines])];
+const { code, lang, mark = [] } = Astro.props;
 ---
 
 <div class="code-block">
-  <pre
-    class:list={[
-      'astro-code',
-      `language-${lang}`,
-      { 'has-highlights': highlights.length > 0 }
-    ]}
-    style="background-color: var(--astro-code-color-background)"
-    tabindex="0"
-    data-highlights={JSON.stringify(highlights)}
-  ><code>{code}</code></pre>
+  <div class="editor" data-code={code} data-lang={lang}></div>
 </div>
 
-<style>
-  .code-block {
-    position: relative;
-    margin: 1rem 0;
-  }
-
-  pre {
-    margin: 0;
-    padding: 1rem;
-    border-radius: 0.5rem;
-    overflow-x: auto;
-  }
-
-  .has-highlights .line-highlight {
-    background-color: var(--sl-color-accent-low);
-    position: absolute;
-    left: 0;
-    right: 0;
-    pointer-events: none;
-  }
-
-  .line-highlight::before {
-    content: attr(data-message);
-    position: absolute;
-    right: 0.5rem;
-    font-size: 0.8rem;
-    color: var(--sl-color-text-accent);
-    opacity: 0;
-    transition: opacity 0.2s;
-  }
-
-  .line-highlight:hover::before {
-    opacity: 1;
-  }
-</style>
-
 <script>
-  function highlightCode() {
-    const codeBlocks = document.querySelectorAll('pre.has-highlights');
-    
-    codeBlocks.forEach(block => {
-      const highlights = JSON.parse(block.getAttribute('data-highlights') || '[]');
-      const code = block.querySelector('code');
-      if (!code) return;
+  import { EditorView, minimalSetup } from 'codemirror';
+  import { java } from '@codemirror/lang-java';
+  import { sql } from '@codemirror/lang-sql';
+  import { lineNumbers } from '@codemirror/view';
+  import { monokai } from '@uiw/codemirror-theme-monokai';
+  import { indentUnit } from '@codemirror/language';
+  import { bracketMatching } from '@codemirror/language';
+  import { closeBrackets } from '@codemirror/autocomplete';
 
-      // Split code into lines and wrap each in a span
-      const lines = code.textContent?.split('\n') || [];
-      code.innerHTML = lines
-        .map((line, i) => {
-          const highlight = highlights.find(h => h.line === i + 1);
-          const className = highlight ? 'line-highlight' : '';
-          const message = highlight?.message || '';
-          return `<span class="line ${className}" ${message ? `data-message="${message}"` : ''}>${line}</span>`;
-        })
-        .join('\n');
+  // Store editor instances
+  const editorInstances = new WeakMap();
+
+  function setupCodeMirror() {
+    const editors = document.querySelectorAll('.editor');
+    
+    editors.forEach(editor => {
+      // Clean up existing instance if it exists
+      const existingView = editorInstances.get(editor);
+      if (existingView) {
+        existingView.destroy();
+        editorInstances.delete(editor);
+      }
+
+      // Clear the editor's content
+      editor.innerHTML = '';
+
+      const code = editor.getAttribute('data-code') || '';
+      const lang = editor.getAttribute('data-lang');
+
+      // Get language support
+      const langSupport = lang === 'text/x-java' ? java() : 
+                         lang === 'text/x-sql' ? sql() : [];
+
+      // Create the editor view
+      const view = new EditorView({
+        doc: code,
+        extensions: [
+          minimalSetup,
+          langSupport,
+          EditorView.editable.of(false),
+          lineNumbers(),
+          monokai,
+          indentUnit.of('    '),
+          bracketMatching(),
+          closeBrackets(),
+          EditorView.theme({
+            '&': { 
+              fontSize: '12px',
+              height: 'auto'
+            },
+            '.cm-content': { 
+              padding: '10px',
+              fontFamily: 'var(--font-mono)'
+            },
+            '.cm-gutters': {
+              backgroundColor: 'var(--sl-color-bg-code)',
+              border: 'none',
+              borderRight: '1px solid var(--sl-color-border)'
+            },
+            '.cm-lineNumbers': {
+              color: 'var(--sl-color-text-code)'
+            },
+            '.cm-line': {
+              padding: '0 2px'
+            },
+            '.cm-line.highlight': {
+              backgroundColor: 'var(--sl-color-accent-low)',
+              borderRadius: '2px'
+            }
+          }),
+        ],
+        parent: editor
+      });
+
+      // Store the instance
+      editorInstances.set(editor, view);
     });
   }
 
   // Run on page load
-  highlightCode();
+  setupCodeMirror();
 
   // Re-run when content updates (for client routing)
-  document.addEventListener('astro:page-load', highlightCode);
+  document.addEventListener('astro:page-load', setupCodeMirror);
+
+  // Clean up on page unload
+  document.addEventListener('astro:before-swap', () => {
+    document.querySelectorAll('.editor').forEach(editor => {
+      const view = editorInstances.get(editor);
+      if (view) {
+        view.destroy();
+        editorInstances.delete(editor);
+      }
+    });
+  });
+
+  // Export highlight function for CollapsibleCode
+  window.highlightCodeLines = function(editor, results) {
+    const view = editorInstances.get(editor);
+    if (!view) return;
+
+    // Clear existing highlights
+    const doc = view.state.doc;
+    const lineCount = doc.lines;
+    for (let i = 1; i <= lineCount; i++) {
+      const line = doc.line(i);
+      const { node } = view.domAtPos(line.from);
+      const lineElement = node.nodeType === Node.TEXT_NODE ? node.parentElement.closest('.cm-line') : node.closest('.cm-line');
+      if (lineElement) {
+        lineElement.classList.remove('highlight');
+        lineElement.removeAttribute('title');
+      }
+    }
+
+    // Add new highlights
+    results.forEach(result => {
+      const lineNum = parseInt(result.line);
+      const line = doc.line(lineNum);
+      const { node } = view.domAtPos(line.from);
+      const lineElement = node.nodeType === Node.TEXT_NODE ? node.parentElement.closest('.cm-line') : node.closest('.cm-line');
+      if (lineElement) {
+        lineElement.classList.add('highlight');
+        lineElement.setAttribute('title', result.snippet || 'Potential vulnerability detected');
+      }
+    });
+  };
 </script>

--- a/docs/src/components/Code.astro
+++ b/docs/src/components/Code.astro
@@ -52,36 +52,16 @@ const { code, lang, mark = [] } = Astro.props;
         extensions: [
           minimalSetup,
           langSupport,
-          EditorView.editable.of(false),
+          EditorView.editable.of(true),
           lineNumbers(),
           monokai,
           indentUnit.of('    '),
           bracketMatching(),
           closeBrackets(),
-          EditorView.theme({
-            '&': { 
-              fontSize: '12px',
-              height: 'auto'
-            },
-            '.cm-content': { 
-              padding: '10px',
-              fontFamily: 'var(--font-mono)'
-            },
-            '.cm-gutters': {
-              backgroundColor: 'var(--sl-color-bg-code)',
-              border: 'none',
-              borderRight: '1px solid var(--sl-color-border)'
-            },
-            '.cm-lineNumbers': {
-              color: 'var(--sl-color-text-code)'
-            },
-            '.cm-line': {
-              padding: '0 2px'
-            },
-            '.cm-line.highlight': {
-              backgroundColor: 'var(--sl-color-accent-low)',
-              borderRadius: '2px'
-            }
+          EditorView.contentAttributes.of({
+            'spellcheck': 'false',
+            'autocorrect': 'off',
+            'autocapitalize': 'off'
           }),
         ],
         parent: editor

--- a/docs/src/components/CodeViewer.astro
+++ b/docs/src/components/CodeViewer.astro
@@ -9,36 +9,14 @@ const { filePath } = Astro.props;
 export const ruleContent = new Map([
   [
     '/pathfinder-rules/java/InsecureRandom.cql',
-    `/**
- * @name InsecureRandom
- * @description Usage of Math.random() which is not cryptographically secure
- * @kind problem
- * @id java/insecure-random
- * @problem.severity high
- * @security-severity 8.9
- * @precision high
- * @tags security
- */
-
-FROM method_invocation AS mi
+    `FROM method_invocation AS mi
 WHERE mi.getName() == "Math.random"
 SELECT mi.getName(), "Usage of Math.random() detected. Use SecureRandom.nextBytes() instead
   which is cryptographically secure."`
   ],
   [
     '/pathfinder-rules/java/BlowfishUsage.cql',
-    `/**
- * @name BlowfishUsage
- * @description Use of Blowfish was detected. Blowfish uses a 64-bit block size
- * @kind problem
- * @id java/BlowfishUsage
- * @problem.severity warning
- * @security-severity 3.1
- * @precision medium
- * @tags security
- *       external/cwe/cwe-327
- */
-
+    `
 FROM method_invocation AS mi
 WHERE mi.getName() == "Cipher.getInstance"
 && "Blowfish" in mi.getArgumentName()
@@ -47,17 +25,7 @@ SELECT mi.getName(), "Use of Blowfish was detected. Blowfish uses a 64-bit block
   ],
   [
     '/pathfinder-rules/java/DefaultHttpClient.cql',
-    `/**
- * @name DefaultHttpClient
- * @description Usage of DefaultHttpClient which lacks modern security features
- * @kind problem
- * @id java/default-http-client
- * @problem.severity warning
- * @security-severity 4.0
- * @precision high
- * @tags security
- */
-
+    `
 FROM class_instance_creation AS cic
 WHERE cic.getType().getName() == "DefaultHttpClient"
 SELECT cic, "Usage of DefaultHttpClient detected. Use HttpClientBuilder instead
@@ -65,17 +33,7 @@ SELECT cic, "Usage of DefaultHttpClient detected. Use HttpClientBuilder instead
   ],
   [
     '/pathfinder-rules/java/RC4Usage.cql',
-    `/**
- * @name RC4Usage
- * @description Use of RC4 encryption was detected
- * @kind problem
- * @id java/rc4-usage
- * @problem.severity warning
- * @security-severity 5.0
- * @precision high
- * @tags security
- */
-
+    `
 FROM method_invocation AS mi
 WHERE mi.getName() == "Cipher.getInstance"
 && "RC4" in mi.getArgumentName()
@@ -84,17 +42,7 @@ SELECT mi, "Use of RC4 encryption detected. RC4 is cryptographically broken
   ],
   [
     '/pathfinder-rules/java/SHA1Usage.cql',
-    `/**
- * @name SHA1Usage
- * @description Use of SHA-1 hash function was detected
- * @kind problem
- * @id java/sha1-usage
- * @problem.severity warning
- * @security-severity 4.0
- * @precision high
- * @tags security
- */
-
+    `
 FROM method_invocation AS mi
 WHERE mi.getName() == "MessageDigest.getInstance"
 && "SHA-1" in mi.getArgumentName()
@@ -103,17 +51,7 @@ SELECT mi, "Use of SHA-1 hash function detected. SHA-1 is cryptographically brok
   ],
   [
     '/pathfinder-rules/java/UnencryptedSocket.cql',
-    `/**
- * @name UnencryptedSocket
- * @description Use of unencrypted Socket instead of SSLSocket
- * @kind problem
- * @id java/unencrypted-socket
- * @problem.severity warning
- * @security-severity 6.0
- * @precision high
- * @tags security
- */
-
+    `
 FROM class_instance_creation AS cic
 WHERE cic.getType().getName() == "Socket"
 SELECT cic, "Use of unencrypted Socket detected. Consider using SSLSocket
@@ -121,17 +59,7 @@ SELECT cic, "Use of unencrypted Socket detected. Consider using SSLSocket
   ],
   [
     '/pathfinder-rules/java/XXE.cql',
-    `/**
- * @name XXE
- * @description XML parsing vulnerable to XXE attacks
- * @kind problem
- * @id java/xxe
- * @problem.severity high
- * @security-severity 8.0
- * @precision high
- * @tags security
- */
-
+    `
 FROM method_invocation AS mi
 WHERE mi.getName() == "DocumentBuilderFactory.newInstance"
 SELECT mi, "XML parsing may be vulnerable to XXE attacks. Set feature 'http://apache.org/xml/features/disallow-doctype-decl'

--- a/docs/src/components/CodeViewer.astro
+++ b/docs/src/components/CodeViewer.astro
@@ -1,0 +1,211 @@
+---
+interface Props {
+  filePath: string;
+}
+
+const { filePath } = Astro.props;
+
+// Hardcoded rule content mapping
+export const ruleContent = new Map([
+  [
+    '/pathfinder-rules/java/InsecureRandom.cql',
+    `/**
+ * @name InsecureRandom
+ * @description Usage of Math.random() which is not cryptographically secure
+ * @kind problem
+ * @id java/insecure-random
+ * @problem.severity high
+ * @security-severity 8.9
+ * @precision high
+ * @tags security
+ */
+
+FROM method_invocation AS mi
+WHERE mi.getName() == "Math.random"
+SELECT mi.getName(), "Usage of Math.random() detected. Use SecureRandom.nextBytes() instead
+  which is cryptographically secure."`
+  ],
+  [
+    '/pathfinder-rules/java/BlowfishUsage.cql',
+    `/**
+ * @name BlowfishUsage
+ * @description Use of Blowfish was detected. Blowfish uses a 64-bit block size
+ * @kind problem
+ * @id java/BlowfishUsage
+ * @problem.severity warning
+ * @security-severity 3.1
+ * @precision medium
+ * @tags security
+ *       external/cwe/cwe-327
+ */
+
+FROM method_invocation AS mi
+WHERE mi.getName() == "Cipher.getInstance"
+&& "Blowfish" in mi.getArgumentName()
+SELECT mi.getName(), "Use of Blowfish was detected. Blowfish uses a 64-bit block size
+  that makes it vulnerable to birthday attacks."`
+  ],
+  [
+    '/pathfinder-rules/java/DefaultHttpClient.cql',
+    `/**
+ * @name DefaultHttpClient
+ * @description Usage of DefaultHttpClient which lacks modern security features
+ * @kind problem
+ * @id java/default-http-client
+ * @problem.severity warning
+ * @security-severity 4.0
+ * @precision high
+ * @tags security
+ */
+
+FROM class_instance_creation AS cic
+WHERE cic.getType().getName() == "DefaultHttpClient"
+SELECT cic, "Usage of DefaultHttpClient detected. Use HttpClientBuilder instead
+  which provides better security features and certificate validation."`
+  ],
+  [
+    '/pathfinder-rules/java/RC4Usage.cql',
+    `/**
+ * @name RC4Usage
+ * @description Use of RC4 encryption was detected
+ * @kind problem
+ * @id java/rc4-usage
+ * @problem.severity warning
+ * @security-severity 5.0
+ * @precision high
+ * @tags security
+ */
+
+FROM method_invocation AS mi
+WHERE mi.getName() == "Cipher.getInstance"
+&& "RC4" in mi.getArgumentName()
+SELECT mi, "Use of RC4 encryption detected. RC4 is cryptographically broken
+  and should not be used in new applications."`
+  ],
+  [
+    '/pathfinder-rules/java/SHA1Usage.cql',
+    `/**
+ * @name SHA1Usage
+ * @description Use of SHA-1 hash function was detected
+ * @kind problem
+ * @id java/sha1-usage
+ * @problem.severity warning
+ * @security-severity 4.0
+ * @precision high
+ * @tags security
+ */
+
+FROM method_invocation AS mi
+WHERE mi.getName() == "MessageDigest.getInstance"
+&& "SHA-1" in mi.getArgumentName()
+SELECT mi, "Use of SHA-1 hash function detected. SHA-1 is cryptographically broken
+  and should not be used for security-critical operations."`
+  ],
+  [
+    '/pathfinder-rules/java/UnencryptedSocket.cql',
+    `/**
+ * @name UnencryptedSocket
+ * @description Use of unencrypted Socket instead of SSLSocket
+ * @kind problem
+ * @id java/unencrypted-socket
+ * @problem.severity warning
+ * @security-severity 6.0
+ * @precision high
+ * @tags security
+ */
+
+FROM class_instance_creation AS cic
+WHERE cic.getType().getName() == "Socket"
+SELECT cic, "Use of unencrypted Socket detected. Consider using SSLSocket
+  for encrypted communication."`
+  ],
+  [
+    '/pathfinder-rules/java/XXE.cql',
+    `/**
+ * @name XXE
+ * @description XML parsing vulnerable to XXE attacks
+ * @kind problem
+ * @id java/xxe
+ * @problem.severity high
+ * @security-severity 8.0
+ * @precision high
+ * @tags security
+ */
+
+FROM method_invocation AS mi
+WHERE mi.getName() == "DocumentBuilderFactory.newInstance"
+SELECT mi, "XML parsing may be vulnerable to XXE attacks. Set feature 'http://apache.org/xml/features/disallow-doctype-decl'
+  to true and disable external entity processing to prevent XXE attacks."`
+  ]
+]);
+
+const content = ruleContent.get(filePath) || '// Rule content not found';
+
+---
+
+<div class="code-viewer">
+  <div class="code-header">
+    <span class="file-name">{filePath.split('/').pop()}</span>
+  </div>
+  <pre><code class="language-cql" set:html={content} /></pre>
+</div>
+
+<style>
+  .code-viewer {
+    width: 100%;
+    overflow: hidden;
+    background: var(--sl-color-bg-nav);
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-gray-5);
+  }
+
+  .code-header {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background: var(--sl-color-bg-sidebar);
+    border-bottom: 1px solid var(--sl-color-gray-5);
+  }
+
+  .file-name {
+    font-family: var(--sl-font-mono);
+    font-size: 0.85em;
+    color: var(--sl-color-gray-2);
+  }
+
+  .code-viewer pre {
+    margin: 0;
+    padding: 1rem;
+    overflow-x: auto;
+  }
+
+  .code-viewer code {
+    font-family: var(--sl-font-mono);
+    font-size: 0.9em;
+    line-height: 1.4;
+    color: var(--sl-color-text);
+  }
+
+  /* Syntax highlighting */
+  .code-viewer :global(.comment),
+  .code-viewer :global(.docstring) {
+    color: var(--sl-color-gray-3);
+    font-style: italic;
+  }
+
+  .code-viewer :global(.keyword) {
+    color: var(--sl-color-accent);
+  }
+
+  .code-viewer :global(.string) {
+    color: var(--sl-color-green);
+  }
+
+  .code-viewer :global(.function) {
+    color: var(--sl-color-blue);
+  }
+
+  .code-viewer :global(.tag) {
+    color: var(--sl-color-red);
+  }
+</style>

--- a/docs/src/components/CodeViewer.astro
+++ b/docs/src/components/CodeViewer.astro
@@ -11,59 +11,54 @@ export const ruleContent = new Map([
     '/pathfinder-rules/java/InsecureRandom.cql',
     `FROM method_invocation AS mi
 WHERE mi.getName() == "Math.random"
-SELECT mi.getName(), "Usage of Math.random() detected. Use SecureRandom.nextBytes() instead
-  which is cryptographically secure."`
+SELECT mi.getName(), "Math.random() is not cryptographically secure. Use SecureRandom instead."`
   ],
   [
     '/pathfinder-rules/java/BlowfishUsage.cql',
-    `
-FROM method_invocation AS mi
+    `FROM method_invocation AS mi
 WHERE mi.getName() == "Cipher.getInstance"
 && "Blowfish" in mi.getArgumentName()
 SELECT mi.getName(), "Use of Blowfish was detected. Blowfish uses a 64-bit block size
-  that makes it vulnerable to birthday attacks."`
+    that  makes it vulnerable to birthday attacks, and is therefore considered
+      non-compliant."`
   ],
   [
     '/pathfinder-rules/java/DefaultHttpClient.cql',
-    `
-FROM class_instance_creation AS cic
-WHERE cic.getType().getName() == "DefaultHttpClient"
-SELECT cic, "Usage of DefaultHttpClient detected. Use HttpClientBuilder instead
-  which provides better security features and certificate validation."`
+    `FROM ClassInstanceExpr AS cie
+ WHERE cie.getClassInstanceExpr().GetClassName() == "DefaultHttpClient"
+ SELECT cie.getName(), "The DefaultHttpClient is deprecated. Use HttpClientBuilder instead."`
   ],
   [
     '/pathfinder-rules/java/RC4Usage.cql',
-    `
-FROM method_invocation AS mi
+    `FROM method_invocation AS mi
 WHERE mi.getName() == "Cipher.getInstance"
-&& "RC4" in mi.getArgumentName()
-SELECT mi, "Use of RC4 encryption detected. RC4 is cryptographically broken
-  and should not be used in new applications."`
+&& ("RC4" in mi.getArgumentName() || "RC2" in mi.getArgumentName())
+SELECT mi.getName(), "RC4/RC2 is insecure. Use an alternative cipher suite."`
   ],
   [
     '/pathfinder-rules/java/SHA1Usage.cql',
-    `
-FROM method_invocation AS mi
+    `FROM method_invocation AS mi
 WHERE mi.getName() == "MessageDigest.getInstance"
-&& "SHA-1" in mi.getArgumentName()
-SELECT mi, "Use of SHA-1 hash function detected. SHA-1 is cryptographically broken
-  and should not be used for security-critical operations."`
+&& ("SHA1" in mi.getArgumentName() || "SHA-1" in mi.getArgumentName())
+SELECT mi.getName(), "SHA1 is not collision resistant and is therefore not suitable as a cryptographic signature"`
   ],
   [
     '/pathfinder-rules/java/UnencryptedSocket.cql',
-    `
-FROM class_instance_creation AS cic
-WHERE cic.getType().getName() == "Socket"
-SELECT cic, "Use of unencrypted Socket detected. Consider using SSLSocket
-  for encrypted communication."`
+    `FROM ClassInstanceExpr AS cie
+WHERE cie.getClassInstanceExpr().GetClassName() == "Socket" || cie.getClassInstanceExpr().GetClassName() == "ServerSocket"
+SELECT cie.getName(), "This socket is not encrypted. Use an SSLSocket created by SSLSocketFactory or SSLServerSocketFactory instead"`
   ],
   [
     '/pathfinder-rules/java/XXE.cql',
-    `
-FROM method_invocation AS mi
-WHERE mi.getName() == "DocumentBuilderFactory.newInstance"
-SELECT mi, "XML parsing may be vulnerable to XXE attacks. Set feature 'http://apache.org/xml/features/disallow-doctype-decl'
-  to true and disable external entity processing to prevent XXE attacks."`
+    `FROM method_invocation AS mi
+WHERE mi.getName() == "setFeature" &&
+    ("http://xml.org/sax/features/external-parameter-entities" in mi.getArgumentName() &&
+     "true" in mi.getArgumentName()) ||
+    ("http://xml.org/sax/features/external-general-entities" in mi.getArgumentName() && 
+     "true" in mi.getArgumentName()) ||
+    ("http://apache.org/xml/features/disallow-doctype-decl" in mi.getArgumentName() &&
+     "false" in mi.getArgumentName())
+SELECT mi.getName(), "XML External Entity (XXE) attack vulnerability"`
   ]
 ]);
 

--- a/docs/src/components/CollapsibleCode.astro
+++ b/docs/src/components/CollapsibleCode.astro
@@ -250,7 +250,7 @@ const exampleTab = tabs.find(tab => tab.label === 'Example');
           button.disabled = true;
           button.innerHTML = '<svg class="spin" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="6"></line><line x1="12" y1="18" x2="12" y2="22"></line><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"></line><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"></line><line x1="2" y1="12" x2="6" y2="12"></line><line x1="18" y1="12" x2="22" y2="12"></line><line x1="4.93" y1="19.07" x2="7.76" y2="16.24"></line><line x1="16.24" y1="7.76" x2="19.07" y2="4.93"></line></svg> Running...';
           
-          const response = await fetch('http://localhost:8080/api/analyze', {
+          const response = await fetch('http://play.codepathfinder.dev/api/analyze', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/docs/src/components/CollapsibleCode.astro
+++ b/docs/src/components/CollapsibleCode.astro
@@ -53,7 +53,12 @@ const [firstTab] = tabs;
             data-tab-index={index}
             hidden={index !== 0}
           >
-            <Code code={tab.code} lang={tab.lang} mark={tab.marks} />
+            <Code 
+              code={tab.code} 
+              lang={tab.lang} 
+              mark={tab.marks} 
+              highlights={tab.label === 'Example' ? [] : undefined}
+            />
           </div>
         ))}
       </div>
@@ -214,15 +219,14 @@ const [firstTab] = tabs;
           button.disabled = true;
           button.innerHTML = '<svg class="spin" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="6"></line><line x1="12" y1="18" x2="12" y2="22"></line><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"></line><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"></line><line x1="2" y1="12" x2="6" y2="12"></line><line x1="18" y1="12" x2="22" y2="12"></line><line x1="4.93" y1="19.07" x2="7.76" y2="16.24"></line><line x1="16.24" y1="7.76" x2="19.07" y2="4.93"></line></svg> Running...';
           
-          const response = await fetch('https://playground.codepathfinder.dev/api/query', {
+          const response = await fetch('http://localhost:8080/api/analyze', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-              code,
-              rule,
-              language: 'java'
+              javaSource: code,
+              query: rule
             })
           });
 
@@ -230,11 +234,22 @@ const [firstTab] = tabs;
             throw new Error('Failed to run query');
           }
 
-          const result = await response.json();
-          console.log('Query result:', result);
-
-          // TODO: Show results in UI
+          const data = await response.json();
+          console.log('Query result:', data);
           
+          // Update code block with highlights
+          const codeBlock = button.closest('.tab-content').querySelector('pre');
+          if (codeBlock) {
+            codeBlock.setAttribute('data-highlights', JSON.stringify(data.results.map(r => ({
+              line: r.line,
+              message: r.snippet || 'Potential vulnerability detected'
+            }))));
+            // Re-run highlighting
+            document.dispatchEvent(new Event('astro:page-load'));
+          }
+
+          button.innerHTML = 'Run';
+          button.disabled = false;
         } catch (error) {
           console.error('Error running query:', error);
           button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg> Error';

--- a/docs/src/components/CollapsibleCode.astro
+++ b/docs/src/components/CollapsibleCode.astro
@@ -1,5 +1,5 @@
 ---
-import { Code } from '@astrojs/starlight/components';
+import Code from './Code.astro';
 
 interface CodeTab {
   label: string;
@@ -14,6 +14,7 @@ interface Props {
 
 const { tabs } = Astro.props;
 const [firstTab] = tabs;
+const exampleTab = tabs.find(tab => tab.label === 'Example');
 ---
 
 <div class="collapsible-code">
@@ -180,23 +181,52 @@ const [firstTab] = tabs;
 </style>
 
 <script>
+  // Store event handlers for cleanup
+  const eventHandlers = new WeakMap();
+
   function setupCollapsibleCode() {
     const toggles = document.querySelectorAll('.code-toggle');
     const tabButtons = document.querySelectorAll('.tab-button');
     const runButtons = document.querySelectorAll('.run-button');
     
+    // Clean up existing handlers
+    function cleanupHandlers(elements) {
+      elements.forEach(el => {
+        const handlers = eventHandlers.get(el);
+        if (handlers) {
+          handlers.forEach(({ event, handler }) => {
+            el.removeEventListener(event, handler);
+          });
+          eventHandlers.delete(el);
+        }
+      });
+    }
+
+    cleanupHandlers(toggles);
+    cleanupHandlers(tabButtons);
+    cleanupHandlers(runButtons);
+
+    // Helper to store event handlers
+    function addHandler(element, event, handler) {
+      element.addEventListener(event, handler);
+      const handlers = eventHandlers.get(element) || [];
+      handlers.push({ event, handler });
+      eventHandlers.set(element, handlers);
+    }
+
     toggles.forEach(toggle => {
-      toggle.addEventListener('click', () => {
+      const toggleHandler = () => {
         const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
         const content = toggle.nextElementSibling;
         
         toggle.setAttribute('aria-expanded', !isExpanded);
         content.hidden = isExpanded;
-      });
+      };
+      addHandler(toggle, 'click', toggleHandler);
     });
 
     tabButtons.forEach(button => {
-      button.addEventListener('click', () => {
+      const tabHandler = () => {
         const tabIndex = button.dataset.tabIndex;
         const tabsContainer = button.closest('.code-tabs');
         const allButtons = tabsContainer.querySelectorAll('.tab-button');
@@ -207,11 +237,12 @@ const [firstTab] = tabs;
 
         button.setAttribute('aria-selected', 'true');
         tabsContainer.querySelector(`.tab-panel[data-tab-index="${tabIndex}"]`).hidden = false;
-      });
+      };
+      addHandler(button, 'click', tabHandler);
     });
 
     runButtons.forEach(button => {
-      button.addEventListener('click', async () => {
+      const runHandler = async () => {
         const code = button.dataset.code;
         const rule = button.dataset.rule;
         
@@ -238,17 +269,13 @@ const [firstTab] = tabs;
           console.log('Query result:', data);
           
           // Update code block with highlights
-          const codeBlock = button.closest('.tab-content').querySelector('pre');
-          if (codeBlock) {
-            codeBlock.setAttribute('data-highlights', JSON.stringify(data.results.map(r => ({
-              line: r.line,
-              message: r.snippet || 'Potential vulnerability detected'
-            }))));
-            // Re-run highlighting
-            document.dispatchEvent(new Event('astro:page-load'));
+          const tabPanel = button.closest('.tab-header').nextElementSibling.querySelector('.tab-panel:not([hidden])');
+          const editor = tabPanel?.querySelector('.editor');
+          if (editor && window.highlightCodeLines) {
+            window.highlightCodeLines(editor, data.results);
           }
 
-          button.innerHTML = 'Run';
+          button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg> Run';
           button.disabled = false;
         } catch (error) {
           console.error('Error running query:', error);
@@ -259,7 +286,8 @@ const [firstTab] = tabs;
             button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg> Run';
           }, 2000);
         }
-      });
+      };
+      addHandler(button, 'click', runHandler);
     });
   }
 

--- a/docs/src/components/CollapsibleCode.astro
+++ b/docs/src/components/CollapsibleCode.astro
@@ -1,14 +1,19 @@
 ---
 import { Code } from '@astrojs/starlight/components';
 
-interface Props {
+interface CodeTab {
+  label: string;
   code: string;
   lang: string;
-  title: string;
   marks?: string[];
 }
 
-const { code, lang, title, marks } = Astro.props;
+interface Props {
+  tabs: CodeTab[];
+}
+
+const { tabs } = Astro.props;
+const [firstTab] = tabs;
 ---
 
 <div class="collapsible-code">
@@ -19,7 +24,40 @@ const { code, lang, title, marks } = Astro.props;
     <span>View Code</span>
   </button>
   <div class="code-content" hidden>
-    <Code code={code} lang={lang} title={title} mark={marks} />
+    <div class="code-tabs">
+      <div class="tab-header not-content">
+        <div class="tab-buttons">
+          {tabs.map((tab, index) => (
+            <button 
+              class="tab-button not-content" 
+              data-tab-index={index}
+              aria-selected={index === 0}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        {tabs[0].label === "Example" && (
+          <button class="run-button not-content" data-code={tabs[0].code} data-rule={tabs[1]?.code}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polygon points="5 3 19 12 5 21 5 3"></polygon>
+            </svg>
+            Run
+          </button>
+        )}
+      </div>
+      <div class="tab-panels">
+        {tabs.map((tab, index) => (
+          <div 
+            class="tab-panel" 
+            data-tab-index={index}
+            hidden={index !== 0}
+          >
+            <Code code={tab.code} lang={tab.lang} mark={tab.marks} />
+          </div>
+        ))}
+      </div>
+    </div>
   </div>
 </div>
 
@@ -62,11 +100,85 @@ const { code, lang, title, marks } = Astro.props;
   .code-content[hidden] {
     display: none;
   }
+
+  .code-tabs {
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  .tab-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--sl-color-bg-sidebar);
+    border-bottom: 1px solid var(--sl-color-gray-5);
+    padding-right: 0.5rem;
+  }
+
+  .tab-buttons {
+    display: flex;
+    border-bottom: 1px solid transparent;
+  }
+
+  .tab-button {
+    padding: 0.75rem 1.25rem;
+    border: none;
+    background: none;
+    color: var(--sl-color-gray-2);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+  }
+
+  .tab-button[aria-selected="true"] {
+    color: var(--sl-color-text);
+    background: var(--sl-color-bg);
+  }
+
+  .tab-button[aria-selected="true"]::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--sl-color-accent);
+  }
+
+  .tab-button:hover {
+    color: var(--sl-color-text);
+  }
+
+  .run-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--sl-color-accent);
+    border-radius: 0.25rem;
+    background: var(--sl-color-accent);
+    color: var(--sl-color-white);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .run-button:hover {
+    background: var(--sl-color-accent-high);
+  }
+
+  .tab-panel[hidden] {
+    display: none;
+  }
 </style>
 
 <script>
   function setupCollapsibleCode() {
     const toggles = document.querySelectorAll('.code-toggle');
+    const tabButtons = document.querySelectorAll('.tab-button');
+    const runButtons = document.querySelectorAll('.run-button');
     
     toggles.forEach(toggle => {
       toggle.addEventListener('click', () => {
@@ -77,6 +189,63 @@ const { code, lang, title, marks } = Astro.props;
         content.hidden = isExpanded;
       });
     });
+
+    tabButtons.forEach(button => {
+      button.addEventListener('click', () => {
+        const tabIndex = button.dataset.tabIndex;
+        const tabsContainer = button.closest('.code-tabs');
+        const allButtons = tabsContainer.querySelectorAll('.tab-button');
+        const allPanels = tabsContainer.querySelectorAll('.tab-panel');
+
+        allButtons.forEach(btn => btn.setAttribute('aria-selected', 'false'));
+        allPanels.forEach(panel => panel.hidden = true);
+
+        button.setAttribute('aria-selected', 'true');
+        tabsContainer.querySelector(`.tab-panel[data-tab-index="${tabIndex}"]`).hidden = false;
+      });
+    });
+
+    runButtons.forEach(button => {
+      button.addEventListener('click', async () => {
+        const code = button.dataset.code;
+        const rule = button.dataset.rule;
+        
+        try {
+          button.disabled = true;
+          button.innerHTML = '<svg class="spin" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="2" x2="12" y2="6"></line><line x1="12" y1="18" x2="12" y2="22"></line><line x1="4.93" y1="4.93" x2="7.76" y2="7.76"></line><line x1="16.24" y1="16.24" x2="19.07" y2="19.07"></line><line x1="2" y1="12" x2="6" y2="12"></line><line x1="18" y1="12" x2="22" y2="12"></line><line x1="4.93" y1="19.07" x2="7.76" y2="16.24"></line><line x1="16.24" y1="7.76" x2="19.07" y2="4.93"></line></svg> Running...';
+          
+          const response = await fetch('https://playground.codepathfinder.dev/api/query', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              code,
+              rule,
+              language: 'java'
+            })
+          });
+
+          if (!response.ok) {
+            throw new Error('Failed to run query');
+          }
+
+          const result = await response.json();
+          console.log('Query result:', result);
+
+          // TODO: Show results in UI
+          
+        } catch (error) {
+          console.error('Error running query:', error);
+          button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg> Error';
+        } finally {
+          setTimeout(() => {
+            button.disabled = false;
+            button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg> Run';
+          }, 2000);
+        }
+      });
+    });
   }
 
   // Setup on initial load
@@ -84,4 +253,17 @@ const { code, lang, title, marks } = Astro.props;
 
   // Setup on client-side navigation
   document.addEventListener('astro:page-load', setupCollapsibleCode);
+</script>
+
+<style is:global>
+  .spin {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+</style>
 </script>

--- a/docs/src/content/docs/atlas/java/index.mdx
+++ b/docs/src/content/docs/atlas/java/index.mdx
@@ -4,10 +4,11 @@ template: splash
 description: Detect cryptographic vulnerabilities and secure coding issues in Java applications
 ---
 
-import { Card, CardGrid, Icon } from '@astrojs/starlight/components';
-import PostHogLayout from '../../../../layouts/PostHogLayout.astro';
+import { Card, CardGrid, Icon, Tabs, TabItem } from '@astrojs/starlight/components';
 import CollapsibleCode from '../../../../components/CollapsibleCode.astro';
 import RuleSearch from '../../../../components/RuleSearch.astro';
+import { ruleContent } from '../../../../components/CodeViewer.astro';
+import PostHogLayout from '../../../../layouts/PostHogLayout.astro';
 
 <PostHogLayout/>
 
@@ -23,111 +24,338 @@ codepathfinder ci --project /src/project --ruleset cpf/java
 
 #### Rules (7)
 
+Browse our collection of Java security rules. Each rule includes example code and the actual rule implementation.
+
 <RuleSearch placeholder="Search security rules and patterns..." />
 
 <div class="rule-cards-grid">
 <div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
   <Card title="Insecure Random" icon="warning">
-      <div class="description">
+    <div class="description">
       **Severity: High** | **OWASP: Cryptographic Failures**  
       Identifies usage of Math.random() which is not cryptographically secure and could lead to predictable values in security-critical contexts.
-      </div>
-      <div class="code-section">
-        <CollapsibleCode 
-            code={`// ❌ Vulnerable: Not cryptographically secure
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Not cryptographically secure
 double value = Math.random();
 
 // ✅ Safe: Using SecureRandom
 SecureRandom secureRandom = new SecureRandom();
-double value = secureRandom.nextDouble();`}
-            lang="java"
-            title="Insecure Random Example"
-            marks={['Vulnerable', 'Safe']}
-        />
-      </div>
+double value = secureRandom.nextDouble();`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/InsecureRandom.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
   </Card>
 </div>
 
 <div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
-  <Card title="Weak Cryptography" icon="warning">
-      <div class="description">
+  <Card title="Blowfish Usage" icon="warning">
+    <div class="description">
       **Severity: High** | **OWASP: Cryptographic Failures**  
-      Detects usage of deprecated or weak cryptographic algorithms (RC4, RC2, SHA1, Blowfish) that are vulnerable to known attacks.
-      </div>
-      <div class="code-section">
-        <CollapsibleCode 
-            code={`// ❌ Vulnerable: Weak algorithms
-Cipher rc4Cipher = Cipher.getInstance("RC4");
-MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
-Cipher blowfish = Cipher.getInstance("Blowfish");
+      Detects usage of Blowfish encryption which uses a 64-bit block size, making it vulnerable to birthday attacks.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Using Blowfish
+Cipher cipher = Cipher.getInstance("Blowfish");
 
-// ✅ Safe: Strong algorithms
-Cipher aesCipher = Cipher.getInstance("AES/GCM/NoPadding");
-MessageDigest sha256 = MessageDigest.getInstance("SHA-256");`}
-            lang="java"
-            title="Weak Cryptography Example"
-            marks={['Vulnerable', 'Safe']}
-        />
-      </div>
+// ✅ Safe: Using AES
+Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/BlowfishUsage.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
   </Card>
 </div>
 
 <div class="rule-card" data-severity="high" data-type="security" data-owasp="identification-and-authentication-failures">
-  <Card title="Insecure HTTP Client" icon="warning">
-      <div class="description">
+  <Card title="Default HTTP Client" icon="warning">
+    <div class="description">
       **Severity: High** | **OWASP: Identification and Authentication Failures**  
       Identifies usage of deprecated DefaultHttpClient which lacks modern security features and proper certificate validation.
-      </div>
-      <div class="code-section">
-        <CollapsibleCode 
-            code={`// ❌ Vulnerable: Deprecated client
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Deprecated client
 HttpClient client = new DefaultHttpClient();
 
 // ✅ Safe: Modern HTTP client
 HttpClient client = HttpClientBuilder.create()
     .setSSLContext(SSLContexts.createDefault())
-    .build();`}
-            lang="java"
-            title="HTTP Client Example"
-            marks={['Vulnerable', 'Safe']}
-        />
-      </div>
+    .build();`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/DefaultHttpClient.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
+  </Card>
+</div>
+
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
+  <Card title="RC4 Usage" icon="warning">
+    <div class="description">
+      **Severity: High** | **OWASP: Cryptographic Failures**  
+      Detects usage of RC4 cipher which is cryptographically broken and should not be used.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Using RC4
+Cipher cipher = Cipher.getInstance("RC4");
+
+// ✅ Safe: Using AES
+Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/RC4Usage.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
+  </Card>
+</div>
+
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
+  <Card title="SHA-1 Usage" icon="warning">
+    <div class="description">
+      **Severity: High** | **OWASP: Cryptographic Failures**  
+      Identifies usage of SHA-1 hash function which is cryptographically broken and should not be used.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Using SHA-1
+MessageDigest md = MessageDigest.getInstance("SHA-1");
+
+// ✅ Safe: Using SHA-256
+MessageDigest md = MessageDigest.getInstance("SHA-256");`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/SHA1Usage.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
   </Card>
 </div>
 
 <div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
   <Card title="Unencrypted Socket" icon="warning">
-      <div class="description">
+    <div class="description">
       **Severity: High** | **OWASP: Cryptographic Failures**  
-      Detects usage of unencrypted socket connections that could expose sensitive data to network-level attacks.
-      </div>
-      <div class="code-section">
-        <CollapsibleCode 
-            code={`// ❌ Vulnerable: Unencrypted socket
+      Detects usage of unencrypted Socket instead of SSLSocket for network communication.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Unencrypted socket
 Socket socket = new Socket("example.com", 80);
 
-// ✅ Safe: SSL/TLS socket
+// ✅ Safe: Using SSL socket
 SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
-SSLSocket socket = (SSLSocket) factory.createSocket("example.com", 443);`}
-            lang="java"
-            title="Socket Connection Example"
-            marks={['Vulnerable', 'Safe']}
-        />
-      </div>
+SSLSocket socket = (SSLSocket) factory.createSocket("example.com", 443);`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/UnencryptedSocket.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
   </Card>
 </div>
 
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="injection">
+  <Card title="XML External Entity (XXE)" icon="warning">
+    <div class="description">
+      **Severity: High** | **OWASP: Injection**  
+      Identifies XML parsers that may be vulnerable to XXE attacks due to insecure configuration.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Default parser configuration
+DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+DocumentBuilder builder = factory.newDocumentBuilder();
+
+// ✅ Safe: Secure parser configuration
+DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+DocumentBuilder builder = factory.newDocumentBuilder();`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/XXE.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
+  </Card>
+</div>
+
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
+  <Card title="Weak Cryptography" icon="warning">
+    <div class="description">
+      **Severity: High** | **OWASP: Cryptographic Failures**  
+      Detects usage of deprecated or weak cryptographic algorithms (RC4, RC2, SHA1, Blowfish) that are vulnerable to known attacks.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Using weak algorithms
+Cipher rc4 = Cipher.getInstance("RC4");
+MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+Cipher bf = Cipher.getInstance("Blowfish");
+
+// ✅ Safe: Using strong algorithms
+Cipher aes = Cipher.getInstance("AES/GCM/NoPadding");
+MessageDigest sha256 = MessageDigest.getInstance("SHA-256");`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/RC4Usage.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
+  </Card>
+</div>
+
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="identification-and-authentication-failures">
+  <Card title="Insecure HTTP Client" icon="warning">
+    <div class="description">
+      **Severity: High** | **OWASP: Identification and Authentication Failures**  
+      Identifies usage of deprecated DefaultHttpClient which lacks modern security features and proper certificate validation.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Using deprecated client
+HttpClient client = new DefaultHttpClient();
+
+// ✅ Safe: Modern HTTP client
+HttpClient client = HttpClientBuilder.create()
+    .setSSLContext(SSLContexts.createDefault())
+    .build();`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/DefaultHttpClient.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
+  </Card>
+</div>
+
+<div class="rule-card" data-severity="high" data-type="security" data-owasp="cryptographic-failures">
+  <Card title="Unencrypted Socket" icon="warning">
+    <div class="description">
+      **Severity: High** | **OWASP: Cryptographic Failures**  
+      Detects usage of unencrypted socket connections that could expose sensitive data to network-level attacks.
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Unencrypted socket
+Socket socket = new Socket("example.com", 80);
+
+// ✅ Safe: SSL socket
+SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+SSLSocket socket = (SSLSocket) factory.createSocket("example.com", 443);`,
+            lang: "java",
+            marks: ['Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/UnencryptedSocket.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
+  </Card>
+</div>
 
 <div class="rule-card" data-severity="high" data-type="security" data-owasp="xml-external-entities">
   <Card title="XML External Entity (XXE) Vulnerability" icon="warning">
-      <div class="description">
+    <div class="description">
       **Severity: High** | **OWASP: XML External Entities (XXE)**  
       Identifies insecure XML parser configurations that could allow XXE attacks, potentially leading to data disclosure, denial of service, or server-side request forgery.
-      </div>
-      <div class="code-section">
-        <CollapsibleCode 
-            code={`
-// ❌ Vulnerable: Disabling protection
+    </div>
+    <div class="code-section">
+      <CollapsibleCode 
+        tabs={[
+          {
+            label: "Example",
+            code: `// ❌ Vulnerable: Disabling protection
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
 DocumentBuilder builder = dbf.newDocumentBuilder();
@@ -139,12 +367,18 @@ dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 dbf.setXIncludeAware(false);
 dbf.setExpandEntityReferences(false);
-DocumentBuilder builder = dbf.newDocumentBuilder();`}
-            lang="java"
-            title="XML Parser Configuration Example"
-            marks={['Vulnerable', 'Vulnerable', 'Safe']}
-        />
-      </div>
+DocumentBuilder builder = dbf.newDocumentBuilder();`,
+            lang: "java",
+            marks: ['Vulnerable', 'Vulnerable', 'Safe']
+          },
+          {
+            label: "Rule",
+            code: ruleContent.get('/pathfinder-rules/java/XXE.cql'),
+            lang: "cql"
+          }
+        ]}
+      />
+    </div>
   </Card>
 </div>
 

--- a/docs/src/content/docs/atlas/java/index.mdx
+++ b/docs/src/content/docs/atlas/java/index.mdx
@@ -46,13 +46,13 @@ double value = Math.random();
 // ✅ Safe: Using SecureRandom
 SecureRandom secureRandom = new SecureRandom();
 double value = secureRandom.nextDouble();`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/InsecureRandom.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -76,13 +76,13 @@ Cipher cipher = Cipher.getInstance("Blowfish");
 
 // ✅ Safe: Using AES
 Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/BlowfishUsage.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -108,13 +108,13 @@ HttpClient client = new DefaultHttpClient();
 HttpClient client = HttpClientBuilder.create()
     .setSSLContext(SSLContexts.createDefault())
     .build();`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/DefaultHttpClient.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -138,13 +138,13 @@ Cipher cipher = Cipher.getInstance("RC4");
 
 // ✅ Safe: Using AES
 Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/RC4Usage.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -168,13 +168,13 @@ MessageDigest md = MessageDigest.getInstance("SHA-1");
 
 // ✅ Safe: Using SHA-256
 MessageDigest md = MessageDigest.getInstance("SHA-256");`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/SHA1Usage.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -199,13 +199,13 @@ Socket socket = new Socket("example.com", 80);
 // ✅ Safe: Using SSL socket
 SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 SSLSocket socket = (SSLSocket) factory.createSocket("example.com", 443);`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/UnencryptedSocket.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -234,13 +234,13 @@ factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
 factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 DocumentBuilder builder = factory.newDocumentBuilder();`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/XXE.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -267,13 +267,13 @@ Cipher bf = Cipher.getInstance("Blowfish");
 // ✅ Safe: Using strong algorithms
 Cipher aes = Cipher.getInstance("AES/GCM/NoPadding");
 MessageDigest sha256 = MessageDigest.getInstance("SHA-256");`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/RC4Usage.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -299,13 +299,13 @@ HttpClient client = new DefaultHttpClient();
 HttpClient client = HttpClientBuilder.create()
     .setSSLContext(SSLContexts.createDefault())
     .build();`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/DefaultHttpClient.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -330,13 +330,13 @@ Socket socket = new Socket("example.com", 80);
 // ✅ Safe: SSL socket
 SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 SSLSocket socket = (SSLSocket) factory.createSocket("example.com", 443);`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/UnencryptedSocket.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />
@@ -368,13 +368,13 @@ dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
 dbf.setXIncludeAware(false);
 dbf.setExpandEntityReferences(false);
 DocumentBuilder builder = dbf.newDocumentBuilder();`,
-            lang: "java",
+            lang: "text/x-java",
             marks: ['Vulnerable', 'Vulnerable', 'Safe']
           },
           {
             label: "Rule",
             code: ruleContent.get('/pathfinder-rules/java/XXE.cql'),
-            lang: "cql"
+            lang: "text/x-sql"
           }
         ]}
       />

--- a/docs/src/styles/layout.css
+++ b/docs/src/styles/layout.css
@@ -201,7 +201,7 @@
     .technology-grid :global(.card:hover) {
       transform: none;
     }
-  }
+}
 
   .features-section {
     padding: 4rem 2rem;
@@ -433,6 +433,8 @@
   .rule-card:not(:last-child) {
     margin-bottom: 0.5rem;
   }
+
+
 
   .rule-card[data-owasp="cryptographic-failures"] {
     background: linear-gradient(

--- a/docs/src/styles/layout.css
+++ b/docs/src/styles/layout.css
@@ -203,6 +203,61 @@
     }
 }
 
+  /* CodeMirror Editor Styles */
+  .code-block {
+    position: relative;
+    margin: 1rem 0;
+  }
+
+  .code-block .editor {
+    height: auto;
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  .cm-editor {
+    height: 100%;
+    font-family: var(--font-mono);
+    background: var(--sl-color-bg-code);
+  }
+
+  .cm-line.highlight {
+    background-color: var(--sl-color-accent-low);
+    position: relative;
+    border-left: 3px solid var(--sl-color-accent);
+    padding-left: 1px !important;
+  }
+
+  .cm-line.highlight:hover::after {
+    content: attr(title);
+    position: absolute;
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--sl-color-bg);
+    color: var(--sl-color-text);
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--sl-color-accent);
+    font-size: 0.9em;
+    white-space: nowrap;
+    z-index: 10;
+    margin-left: 8px;
+  }
+
+  .cm-tooltip {
+    background-color: var(--sl-color-bg);
+    color: var(--sl-color-text);
+    border: 1px solid var(--sl-color-border);
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem;
+  }
+
+  .cm-content {
+    padding: 1rem !important;
+  }
+
   .features-section {
     padding: 4rem 2rem;
     text-align: center;

--- a/playground/main.go
+++ b/playground/main.go
@@ -20,9 +20,9 @@ func main() {
 	fs := http.FileServer(http.Dir("public/static"))
 	mux.Handle("/", middleware.LoggingMiddleware(fs))
 
-	// API endpoints with security and logging middleware
-	mux.Handle("/api/analyze", middleware.LoggingMiddleware(http.HandlerFunc(handlers.AnalyzeHandler)))
-	mux.Handle("/api/parse", middleware.LoggingMiddleware(http.HandlerFunc(handlers.ParseHandler)))
+	// API endpoints with security, logging, and CORS middleware
+	mux.Handle("/api/analyze", middleware.CorsMiddleware(middleware.LoggingMiddleware(http.HandlerFunc(handlers.AnalyzeHandler))))
+	mux.Handle("/api/parse", middleware.CorsMiddleware(middleware.LoggingMiddleware(http.HandlerFunc(handlers.ParseHandler))))
 
 	// Get port from environment variable or use default
 	port := os.Getenv("PORT")

--- a/playground/pkg/handlers/query.go
+++ b/playground/pkg/handlers/query.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type QueryRequest struct {
+	Code     string `json:"code"`
+	Rule     string `json:"rule"`
+	Language string `json:"language"`
+}
+
+type QueryResponse struct {
+	Results []QueryResult `json:"results"`
+}
+
+type QueryResult struct {
+	Line    int    `json:"line"`
+	Message string `json:"message"`
+}
+
+// QueryHandler handles requests to analyze code against a CodeQL query
+func QueryHandler(w http.ResponseWriter, r *http.Request) {
+	// Only allow POST requests
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse request body
+	var req QueryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Printf("Error decoding request: %v", err)
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: Implement actual CodeQL analysis
+	// For now, return mock results
+	results := []QueryResult{
+		{
+			Line:    3,
+			Message: "Found potential security issue",
+		},
+	}
+
+	// Return response
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(QueryResponse{
+		Results: results,
+	})
+}

--- a/playground/pkg/middleware/cors.go
+++ b/playground/pkg/middleware/cors.go
@@ -1,0 +1,21 @@
+package middleware
+
+import "net/http"
+
+// CorsMiddleware adds CORS headers to allow requests from localhost:4321 during development
+func CorsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Allow requests from localhost:4321 during development
+		w.Header().Set("Access-Control-Allow-Origin", "http://localhost:4321")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		// Handle preflight requests
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
### Description:

From now on `atlas` rules page will be able to natively run code-pathfinder (codeql) queries directly on the code and return output. 🛳️

Edit Code -> Apply rule -> Run from the browser 🚀 

This pull request introduces significant updates to the `docs` package, focusing on enhancing code visualization and syntax highlighting capabilities. The most important changes include the addition of new dependencies for CodeMirror and related packages, the creation of new components for code display, and the integration of CodeMirror for syntax highlighting.

### Checklist:
* [x] Tests passing (`gradle testGo`)?
* [x] Lint passing (`golangci-lint run` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?