### PR TITLE
secureflow/ux: refresh scan list after every security scan review

### DIFF
--- a/extension/secureflow/src/git/git-changes.ts
+++ b/extension/secureflow/src/git/git-changes.ts
@@ -10,6 +10,7 @@ import { ProfileStorageService } from '../services/profile-storage-service';
 import { StoredProfile } from '../models/profile-store';
 import { ScanStorageService } from '../services/scan-storage-service';
 import { loadPrompt } from '../prompts/prompt-loader';
+import { SecureFlowExplorer } from '../ui/secureflow-explorer';
 
 /**
  * Gets the git changes (hunks) for a specific file or all files in the workspace
@@ -405,6 +406,9 @@ export function registerSecureFlowReviewCommand(
                 new Date(savedScan.timestamp),
                 allIssues
               );
+
+              // Refresh the scan list in the main webview
+              SecureFlowExplorer.refreshScanList();
 
               if (allIssues.length > 0) {
                 vscode.window

--- a/extension/secureflow/src/ui/secureflow-explorer.ts
+++ b/extension/secureflow/src/ui/secureflow-explorer.ts
@@ -11,6 +11,7 @@ import { SettingsManager } from '../settings/settings-manager';
 export class SecureFlowExplorer {
   private static instance: SecureFlowExplorer;
   private _view?: vscode.WebviewView;
+  private static _provider?: SecureFlowWebViewProvider;
 
   private constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -28,9 +29,16 @@ export class SecureFlowExplorer {
       context.extensionUri,
       context
     );
+    SecureFlowExplorer._provider = provider;
     context.subscriptions.push(
       vscode.window.registerWebviewViewProvider('secureflow.mainView', provider)
     );
+  }
+
+  public static refreshScanList(): void {
+    if (SecureFlowExplorer._provider) {
+      SecureFlowExplorer._provider.refreshScanList();
+    }
   }
 }
 
@@ -91,6 +99,10 @@ class SecureFlowWebViewProvider implements vscode.WebviewViewProvider {
         });
       }
     }
+  }
+
+  public async refreshScanList() {
+    await this.loadScans();
   }
 
   public resolveWebviewView(


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Refresh scan list after every security scan automatically

### Checklist:
* [x] Tests passing (`gradle testGo`)?
* [x] Lint passing (`golangci-lint run` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
