### PR TITLE
secureflow/chore: Add PR creation workflow for consistent CLI-based PRs

### DIFF
--- a/extension/secureflow/.windsurf/workflows/pr.md
+++ b/extension/secureflow/.windsurf/workflows/pr.md
@@ -1,0 +1,20 @@
+---
+description: Pull request creation workflow
+auto_execution_mode: 1
+---
+
+This workflow is dedicated for creating github pull request from command line.
+
+Follow the instruction below to create a descriptive pull request based on commits comparing to main
+
+1. Ensure you're in a branch apart from main
+2. Go through the commits in the branch comparing to main (or default branch)
+3. Go through the commit message, code changes
+4. Come up with good decent pull request message body
+5. use gh label list command to learn about available labels
+6. Always choose the perfect label for the pull request
+7. Assign the pull request to me `shivasurya` always
+8. Follow pr title format as secureflow/{feature/release/chore/bugfix/enhancement/RELEVANT one}: contextual title
+    for example: secureflow/bugfix: Add sentry filtering to reduce noise for reported issues 
+9. Using gh pr create command fillup the details as per the above collected context
+10. finally give me the pr link


### PR DESCRIPTION
Summary
- Add `/pr` workflow at [extension/secureflow/.windsurf/workflows/pr.md](cci:7://file:///Users/shiva/src/shivasurya/code-pathfinder/extension/secureflow/.windsurf/workflows/pr.md:0:0-0:0) to standardize PR creation from the CLI.

Details
- Documents steps to review commits vs main, craft title/body, select labels, assign, and create the PR using `gh`.
- Reinforces naming convention: `secureflow/{feature/release/chore/bugfix/enhancement}: ...`.

Why
- Improves contributor velocity and PR quality with a clear, repeatable checklist.
