### PR TITLE
secureflow/enhancement: Enable GeoIP tracking in PostHog analytics

### DIFF
--- a/extension/secureflow/src/services/analytics.ts
+++ b/extension/secureflow/src/services/analytics.ts
@@ -42,7 +42,8 @@ export class AnalyticsService {
         {
           host: 'https://us.i.posthog.com',
           flushAt: 1, // Send events immediately for better debugging
-          flushInterval: 0 // Disable automatic flushing
+          flushInterval: 0, // Disable automatic flushing,
+          disableGeoip: false,
         }
       );
 


### PR DESCRIPTION
Enhancement: Enable GeoIP tracking in PostHog analytics

Summary
- Enables GeoIP enrichment for analytics to provide regional insights for SecureFlow usage.

Changes
- In extension/secureflow/src/services/analytics.ts, set PostHog client option disableGeoip: false.

Rationale
- GeoIP helps understand regional adoption and improves product analytics and rollouts.

Testing
- Verified PostHog client initializes successfully and events flush immediately with GeoIP enabled.
- No functional changes to user-facing features.

Risk/Privacy
- Only anonymous analytics are sent; GeoIP enrichment is handled by PostHog. No PII added.