### PR TITLE
secureflow/enhancement: Introduce SecureFlow CLI scaffold and document extension-only boundaries

### DIFF
--- a/extension/secureflow/packages/secureflow-cli/README.md
+++ b/extension/secureflow/packages/secureflow-cli/README.md
@@ -1,0 +1,26 @@
+# SecureFlow CLI (Scaffold)
+
+Barebones CLI scaffold to prepare for reusing the SecureFlow VS Code extension logic.
+
+- Extension remains unaffected.
+- Commands are placeholders and will be filled in incrementally.
+
+## Install (local)
+
+From repo root after cloning:
+
+```
+node packages/secureflow-cli/bin/secureflow --help
+```
+
+Or add an npm script later to run via workspaces.
+
+## Usage (current scaffold)
+
+```
+secureflow --version
+secureflow scan --file path/to/file --range 10:50 --format json
+secureflow profile
+```
+
+These commands currently print placeholders and exit with code 0.

--- a/extension/secureflow/packages/secureflow-cli/bin/secureflow
+++ b/extension/secureflow/packages/secureflow-cli/bin/secureflow
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/*
+ * SecureFlow CLI (scaffold)
+ * This is a minimal, non-breaking CLI entry that will evolve to reuse extension logic via adapters.
+ */
+
+const { Command } = require('commander');
+const { yellow, red } = require('colorette');
+const pkg = require('../package.json');
+
+const program = new Command();
+
+program
+  .name('secureflow')
+  .description('SecureFlow CLI — security analysis for codebases (scaffold)')
+  .version(pkg.version);
+
+program
+  .command('scan')
+  .description('Scan code for issues (placeholder)')
+  .option('--file <path>', 'File to scan')
+  .option('--range <start:end>', 'Line range, e.g. 10:50')
+  .option('--format <format>', 'Output format: json|text', 'text')
+  .action((opts) => {
+    console.log(yellow('SecureFlow CLI scaffold'));
+    console.log('This command is a placeholder and will be implemented in upcoming PRs.');
+    if (opts.file) console.log('file:', opts.file);
+    if (opts.range) console.log('range:', opts.range);
+    console.log('format:', opts.format);
+    process.exitCode = 0;
+  });
+
+program
+  .command('profile')
+  .description('Profile project (placeholder)')
+  .action(() => {
+    console.log(yellow('SecureFlow CLI scaffold'));
+    console.log('Project profiling will be implemented in a future PR.');
+    process.exitCode = 0;
+  });
+
+program
+  .command('helpall')
+  .description('Show help for all commands')
+  .action(() => {
+    program.commands.forEach((c) => c.outputHelp());
+  });
+
+program.parseAsync(process.argv).catch((err) => {
+  console.error(red('[secureflow] fatal error'));
+  console.error(err?.stack || err?.message || String(err));
+  process.exit(1);
+});

--- a/extension/secureflow/packages/secureflow-cli/package-lock.json
+++ b/extension/secureflow/packages/secureflow-cli/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "@codepathfinder/secureflow-cli",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@codepathfinder/secureflow-cli",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.20",
+        "commander": "^11.1.0"
+      },
+      "bin": {
+        "secureflow": "bin/secureflow"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/extension/secureflow/packages/secureflow-cli/package.json
+++ b/extension/secureflow/packages/secureflow-cli/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@codepathfinder/secureflow-cli",
+  "version": "0.0.1",
+  "description": "SecureFlow CLI (early scaffold) — reuse VS Code extension logic via adapters",
+  "license": "MIT",
+  "bin": {
+    "secureflow": "bin/secureflow"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "start": "node bin/secureflow",
+    "help": "node bin/secureflow --help"
+  },
+  "dependencies": {
+    "commander": "^11.1.0",
+    "colorette": "^2.0.20"
+  }
+}

--- a/extension/secureflow/src/analysis/security-analyzer.ts
+++ b/extension/secureflow/src/analysis/security-analyzer.ts
@@ -52,6 +52,17 @@ function renderMarkdownBasic(md: string): string {
 }
 
 /**
+ * TODO(VS Code): This function is VS Code UI specific and MUST remain extension-only.
+ * TODO(CLI): Extract a UI-free analysis helper for reuse in CLI.
+ * - performSecurityAnalysisAsync is almost pure except for the optional vscode.ExtensionContext
+ *   parameter and analytics/sentry in callers. For CLI, plan to introduce a wrapper:
+ *   runSecurityAnalysis(code, aiModel, apiKey, filePath, { isGitDiff }): Promise<SecurityIssue[]>
+ * - The following functions are VS Code UI specific and MUST remain extension-only:
+ *   - generateSelectionAnalysisHtml()
+ *   - updateSelectionWebview()
+ *   - registerAnalyzeSelectionCommand()
+ */
+/**
  * Performs security analysis on the given code snippet asynchronously,
  * utilizing both pattern-based detection and AI-based analysis if an API key is provided
  * @param code The code to analyze
@@ -110,6 +121,7 @@ export async function performSecurityAnalysisAsync(
  * @param startLine The starting line of the selection
  * @returns HTML string for the webview
  */
+// EXTENSION-ONLY: Webview HTML renderer
 function generateSelectionAnalysisHtml(
   scanNumber: number,
   timestamp: Date,
@@ -345,6 +357,7 @@ function generateSelectionAnalysisHtml(
  * @param filePath The file path
  * @param startLine The starting line
  */
+// EXTENSION-ONLY: Webview panel updater
 function updateSelectionWebview(
   panel: vscode.WebviewPanel,
   scanNumber: number,
@@ -371,6 +384,7 @@ function updateSelectionWebview(
  * @param context The VS Code extension context for profile services
  * @returns Disposable for the registered command
  */
+// EXTENSION-ONLY: Command registration for VS Code
 export function registerAnalyzeSelectionCommand(
   outputChannel: vscode.OutputChannel,
   settingsManager: SettingsManager,

--- a/extension/secureflow/src/extension.ts
+++ b/extension/secureflow/src/extension.ts
@@ -13,6 +13,12 @@ import { SecureFlowExplorer } from './ui/secureflow-explorer';
 import { AnalyticsService } from './services/analytics';
 import { SentryService } from './services/sentry-service';
 
+/**
+ * TODO(CLI): This file is EXTENSION-ONLY. It wires up VS Code activation,
+ * command registration, webviews, analytics, and sentry. The CLI will have
+ * its own entry point and must NOT import this module.
+ */
+
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {

--- a/extension/secureflow/src/git/git-changes.ts
+++ b/extension/secureflow/src/git/git-changes.ts
@@ -13,6 +13,15 @@ import { loadPrompt } from '../prompts/prompt-loader';
 import { SecureFlowExplorer } from '../ui/secureflow-explorer';
 
 /**
+ * TODO(CLI): This module mixes core git parsing with VS Code UI and services.
+ * Extraction plan:
+ * - Create a pure helper: getGitChangesAtRepo(repoPath: string, opts: { staged?: boolean }): Promise<GitChangeInfo[]>
+ *   that replaces usage of vscode.workspace and works in Node.
+ * - Keep Webview-related functions and command registration as EXTENSION-ONLY.
+ * - CLI will reuse only the pure helper and call performSecurityAnalysisAsync directly.
+ */
+
+/**
  * Gets the git changes (hunks) for a specific file or all files in the workspace
  * @param filePath Optional path to a specific file
  * @returns Array of change information objects
@@ -112,6 +121,7 @@ export async function getGitChanges(): Promise<GitChangeInfo[]> {
  * @param cwd Current working directory
  * @returns Command output as string
  */
+// CLI-READY: pure helper used by both extension and CLI
 async function executeCommand(command: string, cwd: string): Promise<string> {
   return new Promise((resolve, reject) => {
     cp.exec(command, { cwd }, (error, stdout, stderr) => {
@@ -130,6 +140,7 @@ async function executeCommand(command: string, cwd: string): Promise<string> {
  * @param outputChannel Output channel for displaying results
  * @param settingsManager Settings manager for the extension
  */
+// EXTENSION-ONLY: Command registration + Webview UI
 export function registerSecureFlowReviewCommand(
   context: vscode.ExtensionContext,
   outputChannel: vscode.OutputChannel,

--- a/extension/secureflow/src/profiler/project-profiler.ts
+++ b/extension/secureflow/src/profiler/project-profiler.ts
@@ -7,6 +7,15 @@ import { loadPrompt } from '../prompts/prompt-loader';
 import { SettingsManager } from '../settings/settings-manager';
 
 /**
+ * TODO(CLI): This module imports VS Code types and uses vscode.WorkspaceFolder.
+ * Refactor plan to enable CLI reuse:
+ * - Introduce a CLI-friendly constructor overload that accepts `rootPath: string` instead of
+ *   `vscode.WorkspaceFolder`, and avoid direct `vscode` dependency in core logic.
+ * - Keep the current class as EXTENSION adapter: it will pass `workspaceFolder.uri.fsPath`
+ *   into a pure profiler that uses only Node's fs/path and AI client.
+ * - The following remain extension-only: anything reading `vscode.workspace` or using VS Code UI.
+ */
+/**
  * Interface representing a detected application in the workspace
  */
 export interface ApplicationProfile {

--- a/extension/secureflow/src/services/analytics.ts
+++ b/extension/secureflow/src/services/analytics.ts
@@ -1,6 +1,16 @@
 import { PostHog } from 'posthog-node';
 import * as vscode from 'vscode';
 
+/**
+ * TODO(CLI): This service depends on VS Code APIs (vscode.ExtensionContext, workspace configuration)
+ * and should NOT be reused directly by the CLI.
+ *
+ * Plan:
+ * - For the CLI, introduce a lightweight analytics adapter (no-op or console logging),
+ *   keeping this file extension-only.
+ * - Keep the public surface unchanged for the extension. The CLI will not import this module.
+ */
+
 export class AnalyticsService {
   private static instance: AnalyticsService;
   private posthog: PostHog | null = null;

--- a/extension/secureflow/src/settings/settings-manager.ts
+++ b/extension/secureflow/src/settings/settings-manager.ts
@@ -1,5 +1,12 @@
 import * as vscode from 'vscode';
 
+/**
+ * TODO(CLI): This settings manager depends on VS Code configuration and secret storage.
+ * - Treat this file as EXTENSION-ONLY.
+ * - The CLI will introduce a separate CLIConfigManager that reads from env/flags/~/.secureflow/config.json.
+ * - Keep API surface unchanged for the extension; do not import this module from the CLI.
+ */
+
 export type AIModel =
   | 'gpt-4o'
   | 'gpt-4o-mini'


### PR DESCRIPTION
## Summary
Introduce the initial SecureFlow CLI scaffold and clarify extension-only modules to enable safe future reuse via adapters.

## Changes
- CLI: Added new package `packages/secureflow-cli/` with executable `bin/secureflow` (Node.js, commander, colorette).
  - Commands: `scan` and `profile` (placeholders), `helpall`.
  - Non-breaking scaffold; prints guidance and exits 0.
- Refactor notes (extension-only boundaries):
  - `src/analysis/security-analyzer.ts`: Documented VS Code UI-only functions; plan for CLI wrapper around `performSecurityAnalysisAsync`.
  - `src/services/analytics.ts`: Kept PostHog + VS Code dependency; plan for CLI analytics adapter.
  - `src/profiler/project-profiler.ts`: Documented plan to decouple from `vscode` by passing root path; keep adapter in extension.
  - `src/settings/settings-manager.ts`: Marked as extension-only; CLI will introduce a separate config manager.

## Motivation
Lay groundwork for a CLI that reuses analysis logic without pulling VS Code dependencies, aligning with a clean adapter strategy.

## Testing
- `node packages/secureflow-cli/bin/secureflow --help` shows commands.
- `secureflow scan --file <path>` outputs scaffold info; no breaking behavior.
- Extension behavior remains unchanged.

## Risks
- Minimal; CLI commands are placeholders. Extension-only code paths unchanged.

## Checklist
- [x] New package isolated under `packages/secureflow-cli/`
- [x] No extension behavior regression
- [ ] Follow-ups: implement CLI adapters for analysis, settings, analytics, profiler
