### PR TITLE
secureflow/feature: Add CLI config command and configuration management system

### DIFF
--- a/extension/secureflow/packages/secureflow-cli/bin/secureflow
+++ b/extension/secureflow/packages/secureflow-cli/bin/secureflow
@@ -6,8 +6,9 @@
  */
 
 const { Command } = require('commander');
-const { yellow, red } = require('colorette');
+const { yellow, red, cyan } = require('colorette');
 const pkg = require('../package.json');
+const { getMaskedConfig, loadConfig, CONFIG_FILE } = require('../lib/config');
 
 const program = new Command();
 
@@ -37,6 +38,25 @@ program
   .action(() => {
     console.log(yellow('SecureFlow CLI scaffold'));
     console.log('Project profiling will be implemented in a future PR.');
+    process.exitCode = 0;
+  });
+
+program
+  .command('config')
+  .description('Show CLI configuration (masked by default)')
+  .option('--show', 'Show configuration summary', false)
+  .option('--raw', 'Do not mask secrets (use with caution)', false)
+  .action((opts) => {
+    if (!opts.show) {
+      console.log('Use --show to display the configuration.');
+      console.log(`Config file path: ${CONFIG_FILE}`);
+      process.exitCode = 0;
+      return;
+    }
+
+    const cfg = opts.raw ? loadConfig() : getMaskedConfig();
+    console.log(cyan('SecureFlow CLI configuration'));
+    console.log(JSON.stringify(cfg, null, 2));
     process.exitCode = 0;
   });
 

--- a/extension/secureflow/packages/secureflow-cli/lib/config.js
+++ b/extension/secureflow/packages/secureflow-cli/lib/config.js
@@ -1,0 +1,89 @@
+// CommonJS config loader for SecureFlow CLI
+// Sources (precedence high->low):
+// 1) Env vars
+// 2) ~/.secureflow/config.json
+// 3) Defaults
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CONFIG_DIR = path.join(os.homedir(), '.secureflow');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+
+function readJsonSafe(file) {
+  try {
+    if (!fs.existsSync(file)) {
+      return {};
+    }
+    const raw = fs.readFileSync(file, 'utf8');
+    return JSON.parse(raw || '{}');
+  } catch (_) {
+    return {};
+  }
+}
+
+function mask(value) {
+  if (!value) {
+    return '';
+  }
+  if (value.length <= 8) {
+    return '*'.repeat(value.length);
+  }
+  return value.slice(0, 4) + '...' + value.slice(-4);
+}
+
+function loadConfig() {
+  const fileCfg = readJsonSafe(CONFIG_FILE);
+  const env = process.env;
+
+  const cfg = {
+    model: env.SECUREFLOW_MODEL || fileCfg.model || 'claude-3-5-sonnet-20241022',
+    apiKey:
+      env.SECUREFLOW_API_KEY || env.ANTHROPIC_API_KEY || env.OPENAI_API_KEY || fileCfg.apiKey || '',
+    provider: env.SECUREFLOW_PROVIDER || fileCfg.provider || inferProvider(env, fileCfg),
+    analytics: {
+      enabled: getBool(env.SECUREFLOW_ANALYTICS_ENABLED, fileCfg?.analytics?.enabled, false)
+    }
+  };
+
+  return cfg;
+}
+
+function inferProvider(env, fileCfg) {
+  if (env.ANTHROPIC_API_KEY || /claude|anthropic/i.test(fileCfg?.model || '')) {
+    return 'anthropic';
+  }
+  if (env.OPENAI_API_KEY || /gpt|o1|o3|openai/i.test(fileCfg?.model || '')) {
+    return 'openai';
+  }
+  if (/gemini/i.test(fileCfg?.model || '')) {
+    return 'google';
+  }
+  return 'anthropic';
+}
+
+function getBool(envVal, fileVal, defVal) {
+  if (typeof envVal === 'string') {
+    return /^(1|true|yes|on)$/i.test(envVal.trim());
+  }
+  if (typeof fileVal === 'boolean') {
+    return fileVal;
+  }
+  return defVal;
+}
+
+function getMaskedConfig() {
+  const cfg = loadConfig();
+  return {
+    ...cfg,
+    apiKey: mask(cfg.apiKey)
+  };
+}
+
+module.exports = {
+  loadConfig,
+  getMaskedConfig,
+  CONFIG_DIR,
+  CONFIG_FILE
+};


### PR DESCRIPTION
Summary
Adds a foundational configuration system for SecureFlow CLI and a new config subcommand to view it.

Changes
- New config loader packages/secureflow-cli/lib/config.js:
  - Precedence: env vars > ~/.secureflow/config.json > defaults.
  - Defaults: model: claude-3-5-sonnet-20241022, provider inferred, analytics.enabled default false.
  - Provider inference: anthropic if ANTHROPIC_API_KEY or model includes claude/anthropic; openai if OPENAI_API_KEY or model includes gpt/o1/o3/openai; google if model includes gemini; fallback anthropic.
  - Secret masking helper for safe display.
- CLI updates packages/secureflow-cli/bin/secureflow:
  - Adds config subcommand with:
    - --show to print configuration summary.
    - --raw to avoid masking (explicitly cautioned).
  - Always prints config file path when not showing values.

Usage
- Show path and hint:
  - secureflow config
- Show masked configuration:
  - secureflow config --show
- Show raw configuration (use with caution):
  - secureflow config --show --raw
- Config sources:
  - Env: SECUREFLOW_MODEL, SECUREFLOW_API_KEY (or ANTHROPIC_API_KEY/OPENAI_API_KEY), SECUREFLOW_PROVIDER, SECUREFLOW_ANALYTICS_ENABLED
  - File: ~/.secureflow/config.json

Implementation Notes
- getMaskedConfig() masks apiKey unless --raw is passed.
- Resilient JSON parsing and existence checks for ~/.secureflow/config.json.

Testing
- With no env or file, verify defaults:
  - secureflow config --show
- With env vars set:
  - SECUREFLOW_MODEL=... SECUREFLOW_API_KEY=... secureflow config --show
- With file:
  - mkdir -p ~/.secureflow && echo '{"model":"gpt-4o","apiKey":"abc123","analytics":{"enabled":true}}' > ~/.secureflow/config.json
  - secureflow config --show should reflect file and mask apiKey.

Future Work
- secureflow config set <key> <value> to persist values.
- Sync with extension SettingsManager for unified experience.
- Validation and helpful provider-specific hints.