### PR TITLE
feat/secureflow: compact ui styles

### DIFF
--- a/extension/secureflow/packages/secureflow-cli/lib/token-display.js
+++ b/extension/secureflow/packages/secureflow-cli/lib/token-display.js
@@ -114,33 +114,54 @@ class TokenDisplay {
   }
 
   /**
-   * Display final usage summary
+   * Display final usage summary (compact single line)
    */
   static displayFinalSummary(summaryData) {
+    // Validate input
+    if (!summaryData) {
+      console.log(yellow('⚠️  Invalid summary data for token display'));
+      return;
+    }
+
     const { model, summary, limits, percentages, breakdown } = summaryData;
     
-    console.log(magenta('\n📊 FINAL TOKEN USAGE SUMMARY'));
-    console.log('='.repeat(50));
-    console.log(`Model: ${model.name} (${model.provider})`);
-    console.log(`Total iterations: ${summary.totalIterations}`);
-    console.log(`Total input tokens: ${summary.totalInputTokens.toLocaleString()}`);
-    console.log(`Total output tokens: ${summary.totalOutputTokens.toLocaleString()}`);
-    if (summary.totalReasoningTokens > 0) {
-      console.log(`Total reasoning tokens: ${summary.totalReasoningTokens.toLocaleString()}`);
-    }
-    console.log(`Total tokens used: ${summary.totalTokensUsed.toLocaleString()}`);
+    // Validate nested objects with defaults
+    const safeModel = model || {};
+    const safeSummary = summary || {};
+    const safePercentages = percentages || {};
     
-    console.log(`Context window usage: ${percentages.contextUsage.toFixed(1)}% of ${limits.contextWindow.toLocaleString()}`);
-    console.log(`Output limit usage: ${percentages.outputUsage.toFixed(1)}% of ${limits.maxOutput.toLocaleString()}`);
+    // Format numbers compactly
+    const totalInput = this.formatNumber(safeSummary.totalInputTokens || 0);
+    const totalOutput = this.formatNumber(safeSummary.totalOutputTokens || 0);
+    const totalUsed = this.formatNumber(safeSummary.totalTokensUsed || 0);
+    const contextUsage = (safePercentages.contextUsage || 0).toFixed(1);
+    const outputUsage = (safePercentages.outputUsage || 0).toFixed(1);
     
-    if (breakdown.length > 1) {
+    // Reasoning tokens (if present)
+    const reasoningText = (safeSummary.totalReasoningTokens || 0) > 0 
+      ? ` R:${this.formatNumber(safeSummary.totalReasoningTokens)}` : '';
+    
+    console.log();
+    console.log(
+      magenta(`📊 ${safeModel.name || 'Unknown'}`) + ' | ' +
+      cyan(`${safeSummary.totalIterations || 0} iterations`) + ' | ' +
+      green(`I:${totalInput} O:${totalOutput}${reasoningText}`) + ' | ' +
+      yellow(`Total:${totalUsed}`) + ' | ' +
+      red(`${contextUsage}% ${outputUsage}%`)
+    );
+    console.log();
+
+    // TODO: Per-iteration breakdown for cost analysis
+    // Commented out for now to keep output compact
+    /*
+    if (breakdown && breakdown.length > 1) {
       console.log('\nPer-iteration breakdown:');
       breakdown.forEach((usage) => {
-        const reasoningText = usage.reasoningTokens > 0 ? `, Reasoning: ${usage.reasoningTokens.toLocaleString()}` : '';
-        console.log(`  ${usage.iteration}. Input: ${usage.inputTokens.toLocaleString()}, Output: ${usage.outputTokens.toLocaleString()}${reasoningText}`);
+        const reasoningText = usage.reasoningTokens > 0 ? `, Reasoning: ${this.formatNumber(usage.reasoningTokens)}` : '';
+        console.log(`  ${usage.iteration}. Input: ${this.formatNumber(usage.inputTokens)}, Output: ${this.formatNumber(usage.outputTokens)}${reasoningText}`);
       });
     }
-    console.log('='.repeat(50));
+    */
   }
 
   /**

--- a/extension/secureflow/packages/secureflow-cli/scanner/ai-security-analyzer.js
+++ b/extension/secureflow/packages/secureflow-cli/scanner/ai-security-analyzer.js
@@ -217,7 +217,6 @@ class AISecurityAnalyzer {
       
       // Extract content from response object
       const content = response.content || response;
-      console.log(dim(`📥 Received AI response (${content.length} characters)`));
       
       // Record token usage from API response if available
       if (this.tokenTracker && response.usage) {

--- a/extension/secureflow/packages/secureflow-cli/scanner/cli-full-scan-command.js
+++ b/extension/secureflow/packages/secureflow-cli/scanner/cli-full-scan-command.js
@@ -414,8 +414,6 @@ class CLIFullScanCommand {
         console.log(dim(`   Test URL: ${result.testUrl}`));
         console.log(dim(`   Findings imported: ${result.findingsImported}`));
         
-        // Update the summary to include DefectDojo submission info
-        this._displayDefectDojoSubmissionSummary(result, scanResult);
       } else {
         console.error(red('❌ Failed to submit findings to DefectDojo'));
       }
@@ -427,31 +425,6 @@ class CLIFullScanCommand {
         console.error(error.stack);
       }
     }
-  }
-
-  /**
-   * Display DefectDojo submission summary
-   */
-  _displayDefectDojoSubmissionSummary(result, scanResult) {
-    console.log('\n' + '='.repeat(60));
-    console.log(magenta('🔗 DEFECTDOJO SUBMISSION SUMMARY'));
-    console.log('='.repeat(60));
-    
-    console.log(`📅 Submitted: ${new Date().toISOString()}`);
-    console.log(`🔗 DefectDojo URL: ${this.defectDojoOptions.url}`);
-    console.log(`📊 Product ID: ${this.defectDojoOptions.productId}`);
-    console.log(`🎯 Engagement ID: ${this.defectDojoOptions.engagementId}`);
-    console.log(`🧪 Test ID: ${result.testId}`);
-    console.log(`📄 Test URL: ${result.testUrl}`);
-    console.log(`🔍 Findings Imported: ${result.findingsImported}`);
-    
-    console.log('\n📋 NEXT STEPS:');
-    console.log('   1. Visit the test URL above to view findings in DefectDojo');
-    console.log('   2. Review and triage the imported findings');
-    console.log('   3. Assign findings to team members for remediation');
-    console.log('   4. Track remediation progress in DefectDojo');
-    
-    console.log('\n' + '='.repeat(60));
   }
 
   /**


### PR DESCRIPTION
This pull request focuses on making the CLI output more concise and user-friendly by streamlining the display of token usage summaries and removing verbose or redundant summary sections, particularly around DefectDojo integration. The changes also include minor cleanup of console output for clarity.

**CLI Output Improvements:**

* Refactored the `TokenDisplay.displayFinalSummary` method to show a compact, single-line summary of token usage, including input/output tokens, iterations, and usage percentages; added input validation and safer handling of missing data. The detailed per-iteration breakdown and verbose formatting are now commented out to keep output concise.

**DefectDojo Integration Cleanup:**

* Removed the `_displayDefectDojoSubmissionSummary` method and its invocation, eliminating the verbose DefectDojo submission summary from the scan output. Now, only essential submission result information is shown, reducing noise and keeping the output focused. [[1]](diffhunk://#diff-e6670fbe7460940e20c82d71a6715466a4ffb32f54b4f34da6896749ad33fa92L417-L418) [[2]](diffhunk://#diff-e6670fbe7460940e20c82d71a6715466a4ffb32f54b4f34da6896749ad33fa92L432-L456)

**Console Output Simplification:**

* Removed an extra log statement that displayed the length of the AI response content, further decluttering the CLI output.