### PR TITLE
fix: add case-insensitive severity filtering for defect findings summary

### DIFF
--- a/extension/secureflow/packages/secureflow-cli/scanner/cli-full-scan-command.js
+++ b/extension/secureflow/packages/secureflow-cli/scanner/cli-full-scan-command.js
@@ -343,11 +343,11 @@ class CLIFullScanCommand {
     console.log(`📊 Files: ${scanResult.filesAnalyzed}/${scanResult.totalFiles} analyzed`);
     
     const summaryCounts = {
-      critical: defectDojoFindings.findings.filter(f => f.severity === 'critical').length,
-      high: defectDojoFindings.findings.filter(f => f.severity === 'high').length,
-      medium: defectDojoFindings.findings.filter(f => f.severity === 'medium').length,
-      low: defectDojoFindings.findings.filter(f => f.severity === 'low').length,
-      info: defectDojoFindings.findings.filter(f => f.severity === 'info').length
+      critical: defectDojoFindings.findings.filter(f => f.severity.toLowerCase() === 'critical').length,
+      high: defectDojoFindings.findings.filter(f => f.severity.toLowerCase() === 'high').length,
+      medium: defectDojoFindings.findings.filter(f => f.severity.toLowerCase() === 'medium').length,
+      low: defectDojoFindings.findings.filter(f => f.severity.toLowerCase() === 'low').length,
+      info: defectDojoFindings.findings.filter(f => f.severity.toLowerCase() === 'info').length
     };
 
     console.log(


### PR DESCRIPTION
This pull request makes a small but important change to how finding severities are counted in the CLI scan summary. The code now ensures that severity comparisons are case-insensitive, which helps prevent missed findings due to inconsistent casing.

* Severity counts in the scan summary now use `toLowerCase()` when comparing finding severities, making the logic robust against case differences in input data. (`extension/secureflow/packages/secureflow-cli/scanner/cli-full-scan-command.js`)