### PR TITLE
secureflow-cli: release v0.0.2

### DIFF
--- a/extension/secureflow/packages/secureflow-cli/README.md
+++ b/extension/secureflow/packages/secureflow-cli/README.md
@@ -11,7 +11,6 @@ SecureFlow CLI is a powerful command-line tool that performs comprehensive secur
 - 🎯 **Comprehensive Scanning** - Full project security analysis with context-aware insights
 - 📊 **Multiple Output Formats** - Text, JSON, and DefectDojo integration
 - 🏗️ **Project Profiling** - Technology stack detection and application type identification
-- 🔒 **Security-First** - Built-in protections against directory traversal and hidden file exposure
 - 🎨 **Beautiful TUI** - Claude-style terminal interface with colored output and progress indicators
 
 ## 🚀 Quick Start

--- a/extension/secureflow/packages/secureflow-cli/package-lock.json
+++ b/extension/secureflow/packages/secureflow-cli/package-lock.json
@@ -1,19 +1,22 @@
 {
   "name": "@codepathfinder/secureflow-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codepathfinder/secureflow-cli",
-      "version": "0.0.1",
-      "license": "MIT",
+      "version": "0.0.2",
+      "license": "AGPL-3.0",
       "dependencies": {
         "colorette": "^2.0.20",
         "commander": "^11.1.0"
       },
       "bin": {
         "secureflow": "bin/secureflow"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/colorette": {

--- a/extension/secureflow/packages/secureflow-cli/package.json
+++ b/extension/secureflow/packages/secureflow-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codepathfinder/secureflow-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "AI-powered security analysis CLI tool with intelligent file discovery and comprehensive vulnerability scanning",
   "license": "AGPL-3.0",
   "bin": {


### PR DESCRIPTION
This pull request updates the `secureflow-cli` package with a new version, adjusts licensing, and makes minor documentation changes. The most important changes are grouped below:

**Release and Licensing Updates:**

* Bumped the package version from `0.0.1` to `0.0.2` in both `package.json` and `package-lock.json` to indicate a new release. [[1]](diffhunk://#diff-38c4dc2fbd0ecfe756343be72b2729126fc0e80cf676fb48d85c8378117a8447L3-R3) [[2]](diffhunk://#diff-54cfd254beaa6b9f156d91d40ce9727a48c9f5dd209c3fb3de06f95cefe5efa2L3-R19)
* Changed the package license from `MIT` to `AGPL-3.0` in `package-lock.json` to match `package.json` and reflect a stronger copyleft license.

**Platform Requirements:**

* Added an `engines` field to `package-lock.json` specifying Node.js version `>=16.0.0` as a requirement for running the CLI.

**Documentation:**

* Removed the "Security-First" bullet point from the feature list in `README.md` to update the documented features.