### PR TITLE
feat: MCP server integration for version update check (PR-03)

### DIFF
--- a/sast-engine/mcp/server.go
+++ b/sast-engine/mcp/server.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,7 +11,12 @@ import (
 
 	"github.com/shivasurya/code-pathfinder/sast-engine/graph"
 	"github.com/shivasurya/code-pathfinder/sast-engine/graph/callgraph/core"
+	"github.com/shivasurya/code-pathfinder/sast-engine/updatecheck"
 )
+
+// mcpManifestURL overrides the CDN URL used by fetchUpdateInfo. Empty string
+// means use the updatecheck package default. Overridable in tests.
+var mcpManifestURL string
 
 // Server handles MCP protocol communication.
 type Server struct {
@@ -31,6 +37,11 @@ type Server struct {
 	// Set via SetGoContext after the Go call graph is built.
 	goVersion        string
 	goModuleRegistry *core.GoModuleRegistry
+
+	// updateInfo is populated once at server construction via a synchronous
+	// updatecheck.Check call (5 s timeout). It is immutable for the lifetime
+	// of the process — no goroutine, no locking, no Close() needed.
+	updateInfo *updatecheck.Result
 }
 
 // SetVersion sets the server version reported in MCP initialize responses.
@@ -77,7 +88,7 @@ func NewServer(
 	mcpAnalytics := NewAnalytics("stdio", disableAnalytics)
 	mcpAnalytics.ReportIndexingComplete(stats)
 
-	return &Server{
+	s := &Server{
 		projectPath:      projectPath,
 		pythonVersion:    pythonVersion,
 		callGraph:        callGraph,
@@ -90,6 +101,8 @@ func NewServer(
 		analytics:        mcpAnalytics,
 		disableAnalytics: disableAnalytics,
 	}
+	s.fetchUpdateInfo()
+	return s
 }
 
 // NewServerWithBackgroundIndexing creates a server that will be populated via background indexing.
@@ -97,7 +110,7 @@ func NewServerWithBackgroundIndexing(projectPath, pythonVersion string, disableA
 	tracker := NewStatusTracker()
 	// Starts in StateUninitialized
 
-	return &Server{
+	s := &Server{
 		projectPath:      projectPath,
 		pythonVersion:    pythonVersion,
 		callGraph:        nil, // Will be set later
@@ -108,6 +121,21 @@ func NewServerWithBackgroundIndexing(projectPath, pythonVersion string, disableA
 		analytics:        NewAnalytics("stdio", disableAnalytics),
 		disableAnalytics: disableAnalytics,
 	}
+	s.fetchUpdateInfo()
+	return s
+}
+
+// fetchUpdateInfo performs a single synchronous update-check fetch with a
+// 5-second ceiling. Failures are silently swallowed — s.updateInfo stays nil
+// and every downstream consumer handles nil gracefully.
+// No goroutine is spawned; this is the entire lifecycle for update-check state.
+func (s *Server) fetchUpdateInfo() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s.updateInfo = updatecheck.Check(ctx, s.version, "mcp", updatecheck.Options{
+		HTTPTimeout: 5 * time.Second,
+		ManifestURL: mcpManifestURL,
+	})
 }
 
 // UpdateIndexingStatus updates the indexing progress.
@@ -256,12 +284,37 @@ func (s *Server) handleInitialize(req *JSONRPCRequest) *JSONRPCResponse {
 		version = "dev"
 	}
 
+	si := ServerInfo{
+		Name:    "dev.codepathfinder/pathfinder",
+		Version: version,
+	}
+
+	// Populate metadata from the update-check result (nil-safe).
+	if r := s.updateInfo; r != nil {
+		md := &ServerMetadata{}
+		if r.Upgrade != nil {
+			md.LatestVersion = r.Upgrade.Latest
+			md.UpdateMessage = r.Upgrade.Message
+			md.ReleaseURL = r.Upgrade.ReleaseURL
+		}
+		if r.Announcement != nil {
+			md.Announcement = &AnnouncementInfo{
+				ID:    r.Announcement.ID,
+				Level: r.Announcement.Level,
+				Title: r.Announcement.Title,
+				Text:  r.Announcement.Text,
+				URL:   r.Announcement.URL,
+			}
+		}
+		// Only set Metadata when at least one field is non-empty.
+		if *md != (ServerMetadata{}) {
+			si.Metadata = md
+		}
+	}
+
 	return SuccessResponse(req.ID, InitializeResult{
 		ProtocolVersion: "2024-11-05",
-		ServerInfo: ServerInfo{
-			Name:    "dev.codepathfinder/pathfinder",
-			Version: version,
-		},
+		ServerInfo:      si,
 		Capabilities: Capabilities{
 			Tools: &ToolsCapability{
 				ListChanged: false,
@@ -270,9 +323,18 @@ func (s *Server) handleInitialize(req *JSONRPCRequest) *JSONRPCResponse {
 	})
 }
 
-// handleToolsList returns the list of available tools.
+// handleToolsList returns the list of available tools, with the status tool
+// description enriched with an upgrade or announcement hint when available.
 func (s *Server) handleToolsList(req *JSONRPCRequest) *JSONRPCResponse {
 	tools := s.getToolDefinitions()
+	if s.updateInfo != nil {
+		for i := range tools {
+			if tools[i].Name == "status" {
+				tools[i].Description = formatStatusDescription(tools[i].Description, s.updateInfo)
+				break
+			}
+		}
+	}
 	return SuccessResponse(req.ID, ToolsListResult{
 		Tools: tools,
 	})
@@ -307,9 +369,35 @@ func (s *Server) handleToolsCall(req *JSONRPCRequest) *JSONRPCResponse {
 	})
 }
 
-// handleStatus returns the current indexing status.
+// handleStatus returns the current indexing status, enriched with any
+// available update-check fields.
 func (s *Server) handleStatus(req *JSONRPCRequest) *JSONRPCResponse {
-	return SuccessResponse(req.ID, s.degradation.GetStatusJSON())
+	result := s.degradation.GetStatusJSON()
+	s.injectUpdateInfo(result)
+	return SuccessResponse(req.ID, result)
+}
+
+// injectUpdateInfo merges update-check fields into a status map in-place.
+// It is a no-op when s.updateInfo is nil.
+func (s *Server) injectUpdateInfo(result map[string]any) {
+	r := s.updateInfo
+	if r == nil {
+		return
+	}
+	if r.Upgrade != nil {
+		result["latest_version"] = r.Upgrade.Latest  //nolint:tagliatelle
+		result["update_message"] = r.Upgrade.Message //nolint:tagliatelle
+		result["release_url"] = r.Upgrade.ReleaseURL //nolint:tagliatelle
+	}
+	if r.Announcement != nil {
+		result["announcement"] = map[string]any{
+			"id":    r.Announcement.ID,
+			"level": r.Announcement.Level,
+			"title": r.Announcement.Title,
+			"text":  r.Announcement.Text,
+			"url":   r.Announcement.URL,
+		}
+	}
 }
 
 // GetStatusTracker returns the status tracker for external use.

--- a/sast-engine/mcp/server_test.go
+++ b/sast-engine/mcp/server_test.go
@@ -388,7 +388,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	result, ok := resp.Result.(ToolsListResult)
 	require.True(t, ok)
-	assert.Equal(t, 12, len(result.Tools)) // Docker MCP: 12 tools (added find_dockerfile_instructions, find_compose_services, get_dockerfile_details, get_docker_dependencies)
+	assert.Equal(t, 13, len(result.Tools)) // PR-03: 13 tools (added status)
 }
 
 func TestHandleToolsCall_GetIndexInfo(t *testing.T) {

--- a/sast-engine/mcp/server_updatecheck_test.go
+++ b/sast-engine/mcp/server_updatecheck_test.go
@@ -1,0 +1,164 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/updatecheck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startFakeManifestCDN starts an httptest.Server that returns a manifest with a
+// stale version (so the running binary will always appear to need an upgrade).
+func startFakeManifestCDN(t *testing.T) *httptest.Server {
+	t.Helper()
+	m := updatecheck.Manifest{
+		Schema: 1,
+		Latest: updatecheck.ManifestLatest{
+			Version:    "99.0.0",
+			ReleasedAt: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC),
+			ReleaseURL: "https://example.com/releases/v99.0.0",
+		},
+	}
+	body, err := json.Marshal(m)
+	require.NoError(t, err)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+}
+
+// withMCPManifestURL temporarily overrides the package-level manifest URL and
+// restores it on test cleanup.
+func withMCPManifestURL(t *testing.T, url string) {
+	t.Helper()
+	old := mcpManifestURL
+	mcpManifestURL = url
+	t.Cleanup(func() { mcpManifestURL = old })
+}
+
+// --- NewServer update-check tests -------------------------------------------
+
+func TestNewServer_FetchesUpdateInfo(t *testing.T) {
+	srv := startFakeManifestCDN(t)
+	defer srv.Close()
+	withMCPManifestURL(t, srv.URL)
+	t.Setenv("PATHFINDER_NO_UPDATE_CHECK", "")
+
+	server := createTestServer()
+	// Set a real semver so the Compare logic sees current < 99.0.0.
+	server.version = "1.0.0"
+	// Re-run fetchUpdateInfo now that version is set.
+	server.fetchUpdateInfo()
+
+	require.NotNil(t, server.updateInfo, "updateInfo should be non-nil when CDN returns a stale manifest")
+	require.NotNil(t, server.updateInfo.Upgrade)
+	assert.Equal(t, "99.0.0", server.updateInfo.Upgrade.Latest)
+}
+
+func TestNewServer_FetchError_UpdateInfoNil(t *testing.T) {
+	// Point at an unreachable URL — the fetch returns an error immediately
+	// (connection refused), so fetchUpdateInfo sets s.updateInfo = nil.
+	withMCPManifestURL(t, "http://127.0.0.1:1") // port 1 is never listening
+	t.Setenv("PATHFINDER_NO_UPDATE_CHECK", "")
+
+	server := createTestServer()
+	server.version = "1.0.0"
+	server.fetchUpdateInfo()
+
+	// On connection refused, Check returns nil; server must still construct.
+	assert.NotNil(t, server)
+	assert.Nil(t, server.updateInfo, "updateInfo should be nil when the fetch fails")
+}
+
+// --- handleInitialize metadata tests ----------------------------------------
+
+func TestHandleInitialize_NoMetadataWhenUpdateInfoNil(t *testing.T) {
+	server := createTestServer()
+	server.updateInfo = nil
+
+	req := makeJSONRPCRequest("initialize", nil)
+	resp := server.handleInitialize(req)
+
+	require.NotNil(t, resp)
+	result := extractInitResult(t, resp)
+	assert.Nil(t, result.ServerInfo.Metadata, "Metadata should be absent when updateInfo is nil")
+}
+
+func TestHandleInitialize_PopulatesMetadata(t *testing.T) {
+	server := createTestServer()
+	server.updateInfo = &updatecheck.Result{
+		Upgrade: &updatecheck.UpgradeNotice{
+			Current:    "1.0.0",
+			Latest:     "2.0.0",
+			ReleaseURL: "https://example.com/releases/v2.0.0",
+			Message:    "big release",
+		},
+		Announcement: &updatecheck.Announcement{
+			ID:    "ann-1",
+			Level: "info",
+			Title: "New docs",
+			Text:  "docs updated",
+			URL:   "https://example.com/docs",
+		},
+	}
+
+	req := makeJSONRPCRequest("initialize", nil)
+	resp := server.handleInitialize(req)
+
+	require.NotNil(t, resp)
+	result := extractInitResult(t, resp)
+	require.NotNil(t, result.ServerInfo.Metadata, "Metadata should be populated")
+
+	md := result.ServerInfo.Metadata
+	assert.Equal(t, "2.0.0", md.LatestVersion)
+	assert.Equal(t, "big release", md.UpdateMessage)
+	assert.Equal(t, "https://example.com/releases/v2.0.0", md.ReleaseURL)
+
+	require.NotNil(t, md.Announcement)
+	assert.Equal(t, "ann-1", md.Announcement.ID)
+	assert.Equal(t, "info", md.Announcement.Level)
+	assert.Equal(t, "New docs", md.Announcement.Title)
+}
+
+func TestHandleInitialize_MetadataOmittedWhenEmpty(t *testing.T) {
+	// A Result with neither Upgrade nor Announcement yields an empty ServerMetadata
+	// — the Metadata field should remain nil (omitempty in JSON, not set at all).
+	server := createTestServer()
+	server.updateInfo = &updatecheck.Result{} // both fields nil
+
+	req := makeJSONRPCRequest("initialize", nil)
+	resp := server.handleInitialize(req)
+
+	result := extractInitResult(t, resp)
+	assert.Nil(t, result.ServerInfo.Metadata)
+}
+
+// --- helpers used by these tests --------------------------------------------
+
+func makeJSONRPCRequest(method string, params any) *JSONRPCRequest { //nolint:unparam
+	var raw json.RawMessage
+	if params != nil {
+		b, _ := json.Marshal(params)
+		raw = b
+	}
+	return &JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  method,
+		Params:  raw,
+	}
+}
+
+func extractInitResult(t *testing.T, resp *JSONRPCResponse) InitializeResult {
+	t.Helper()
+	b, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var r InitializeResult
+	require.NoError(t, json.Unmarshal(b, &r))
+	return r
+}

--- a/sast-engine/mcp/tools.go
+++ b/sast-engine/mcp/tools.go
@@ -430,6 +430,18 @@ Examples:
 			},
 		},
 		{
+			Name: "status",
+			Description: `Returns the current server state: indexing phase, progress, and readiness.
+
+Use when: Checking whether the index is ready before making queries, or diagnosing slow startup.
+
+Returns: state (uninitialized/indexing/ready/failed), progress details, stats (when ready), and optional update-check fields (latest_version, update_message, announcement) when a newer version or operator announcement is available.`,
+			InputSchema: InputSchema{
+				Type:       "object",
+				Properties: map[string]Property{},
+			},
+		},
+		{
 			Name: "get_docker_dependencies",
 			Description: `Retrieves dependency information for Docker entities (compose services or Dockerfile stages).
 
@@ -521,9 +533,23 @@ func (s *Server) executeTool(name string, args map[string]any) (string, bool) {
 		return s.toolGetDockerfileDetails(args)
 	case "get_docker_dependencies":
 		return s.toolGetDockerDependencies(args)
+	case "status":
+		return s.toolStatus()
 	default:
 		return fmt.Sprintf(`{"error": "Unknown tool: %s"}`, name), true
 	}
+}
+
+// toolStatus returns the current server status as a JSON string, enriched with
+// any available update-check fields.
+func (s *Server) toolStatus() (string, bool) {
+	result := s.degradation.GetStatusJSON()
+	s.injectUpdateInfo(result)
+	data, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "marshal failed: %s"}`, err.Error()), true
+	}
+	return string(data), false
 }
 
 // ============================================================================

--- a/sast-engine/mcp/tools_test.go
+++ b/sast-engine/mcp/tools_test.go
@@ -509,7 +509,7 @@ func TestGetToolDefinitions(t *testing.T) {
 
 	tools := server.getToolDefinitions()
 
-	assert.Len(t, tools, 12) // Updated for Docker MCP: added find_dockerfile_instructions, find_compose_services, get_dockerfile_details, get_docker_dependencies
+	assert.Len(t, tools, 13) // Updated for PR-03: added status tool
 
 	// Verify each tool has required fields.
 	for _, tool := range tools {
@@ -534,6 +534,7 @@ func TestGetToolDefinitions(t *testing.T) {
 	assert.True(t, toolNames["find_dockerfile_instructions"])
 	assert.True(t, toolNames["find_compose_services"])
 	assert.True(t, toolNames["get_dockerfile_details"])
+	assert.True(t, toolNames["status"])
 }
 
 // ============================================================================

--- a/sast-engine/mcp/tools_updatecheck_test.go
+++ b/sast-engine/mcp/tools_updatecheck_test.go
@@ -1,0 +1,207 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/updatecheck"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- handleToolsList update-check tests -------------------------------------
+
+func TestHandleToolsList_StatusDescriptionUnchangedWithoutUpdateInfo(t *testing.T) {
+	server := createTestServer()
+	server.updateInfo = nil
+
+	req := makeJSONRPCRequest("tools/list", nil)
+	resp := server.handleToolsList(req)
+
+	tools := extractToolsListResult(t, resp)
+	statusDesc := findToolDescription(t, tools, "status")
+
+	// When updateInfo is nil the description must not start with an upgrade hint.
+	assert.False(t, strings.HasPrefix(statusDesc, "⚠"), "no upgrade prefix expected without updateInfo")
+	assert.False(t, strings.HasPrefix(statusDesc, "ℹ"), "no announcement prefix expected without updateInfo")
+}
+
+func TestHandleToolsList_StatusDescriptionInjectedWithUpgrade(t *testing.T) {
+	server := createTestServer()
+	server.updateInfo = &updatecheck.Result{
+		Upgrade: &updatecheck.UpgradeNotice{
+			Current:    "1.0.0",
+			Latest:     "2.0.0",
+			ReleaseURL: "https://example.com/releases/v2.0.0",
+		},
+	}
+
+	req := makeJSONRPCRequest("tools/list", nil)
+	resp := server.handleToolsList(req)
+
+	tools := extractToolsListResult(t, resp)
+	statusDesc := findToolDescription(t, tools, "status")
+
+	assert.Contains(t, statusDesc, "Upgrade available")
+	assert.Contains(t, statusDesc, "2.0.0")
+	assert.Contains(t, statusDesc, "https://example.com/releases/v2.0.0")
+}
+
+func TestHandleToolsList_StatusDescriptionInjectedWithAnnouncement(t *testing.T) {
+	server := createTestServer()
+	server.updateInfo = &updatecheck.Result{
+		Announcement: &updatecheck.Announcement{
+			Title: "Workshop",
+			Text:  "Join us for a live walkthrough.",
+			URL:   "https://example.com/workshop",
+		},
+	}
+
+	req := makeJSONRPCRequest("tools/list", nil)
+	resp := server.handleToolsList(req)
+
+	tools := extractToolsListResult(t, resp)
+	statusDesc := findToolDescription(t, tools, "status")
+
+	assert.Contains(t, statusDesc, "Workshop")
+	assert.Contains(t, statusDesc, "Join us for a live walkthrough.")
+}
+
+func TestHandleToolsList_DescriptionTruncatedAt200(t *testing.T) {
+	server := createTestServer()
+	longURL := "https://example.com/releases/v2.0.0/" + strings.Repeat("x", 200)
+	server.updateInfo = &updatecheck.Result{
+		Upgrade: &updatecheck.UpgradeNotice{
+			Current:    "1.0.0",
+			Latest:     "2.0.0",
+			ReleaseURL: longURL,
+		},
+	}
+
+	req := makeJSONRPCRequest("tools/list", nil)
+	resp := server.handleToolsList(req)
+
+	tools := extractToolsListResult(t, resp)
+	statusDesc := findToolDescription(t, tools, "status")
+
+	// Extract the first line (before \n\n).
+	parts := strings.SplitN(statusDesc, "\n\n", 2)
+	require.Len(t, parts, 2, "expected separator between prefix and base")
+	assert.LessOrEqual(t, len(parts[0]), 200, "prefix must be ≤200 bytes")
+}
+
+func TestHandleToolsList_OtherToolDescriptionsUntouched(t *testing.T) {
+	server := createTestServer()
+
+	// Capture descriptions without upgrade info.
+	server.updateInfo = nil
+	req := makeJSONRPCRequest("tools/list", nil)
+	toolsWithout := extractToolsListResult(t, server.handleToolsList(req))
+
+	// Now set an upgrade and re-fetch.
+	server.updateInfo = &updatecheck.Result{
+		Upgrade: &updatecheck.UpgradeNotice{
+			Current: "1.0.0", Latest: "2.0.0",
+			ReleaseURL: "https://example.com/releases/v2.0.0",
+		},
+	}
+	toolsWith := extractToolsListResult(t, server.handleToolsList(req))
+
+	require.Len(t, toolsWith, len(toolsWithout))
+
+	for i, with := range toolsWith {
+		without := toolsWithout[i]
+		if with.Name == "status" {
+			// Only the status tool should differ.
+			assert.NotEqual(t, with.Description, without.Description, "status description should be mutated")
+		} else {
+			assert.Equal(t, with.Description, without.Description,
+				"description for %q must not change", with.Name)
+		}
+	}
+}
+
+// --- status tool structured fields test -------------------------------------
+
+func TestStatusTool_IncludesStructuredUpgradeFields(t *testing.T) {
+	server := createTestServer()
+	server.statusTracker.StartIndexing()
+	server.statusTracker.CompleteIndexing(&IndexingStats{Functions: 10})
+
+	server.updateInfo = &updatecheck.Result{
+		Upgrade: &updatecheck.UpgradeNotice{
+			Current:    "1.0.0",
+			Latest:     "2.0.0",
+			ReleaseURL: "https://example.com/releases/v2.0.0",
+			Message:    "big release",
+		},
+		Announcement: &updatecheck.Announcement{
+			ID:    "ann-1",
+			Level: "info",
+			Title: "Workshop",
+			Text:  "Join us.",
+			URL:   "https://example.com/workshop",
+		},
+	}
+
+	req := makeJSONRPCRequest("status", nil)
+	resp := server.handleStatus(req)
+
+	require.NotNil(t, resp)
+	b, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(b, &result))
+
+	assert.Equal(t, "2.0.0", result["latest_version"])
+	assert.Equal(t, "big release", result["update_message"])
+	assert.Equal(t, "https://example.com/releases/v2.0.0", result["release_url"])
+
+	ann, ok := result["announcement"].(map[string]any)
+	require.True(t, ok, "announcement should be a map")
+	assert.Equal(t, "ann-1", ann["id"])
+	assert.Equal(t, "info", ann["level"])
+	assert.Equal(t, "Workshop", ann["title"])
+}
+
+func TestStatusTool_NoUpdateFieldsWhenUpdateInfoNil(t *testing.T) {
+	server := createTestServer()
+	server.statusTracker.StartIndexing()
+	server.statusTracker.CompleteIndexing(&IndexingStats{})
+	server.updateInfo = nil
+
+	req := makeJSONRPCRequest("status", nil)
+	resp := server.handleStatus(req)
+
+	b, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(b, &result))
+
+	assert.NotContains(t, result, "latest_version")
+	assert.NotContains(t, result, "update_message")
+	assert.NotContains(t, result, "announcement")
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func extractToolsListResult(t *testing.T, resp *JSONRPCResponse) []Tool {
+	t.Helper()
+	b, err := json.Marshal(resp.Result)
+	require.NoError(t, err)
+	var r ToolsListResult
+	require.NoError(t, json.Unmarshal(b, &r))
+	return r.Tools
+}
+
+func findToolDescription(t *testing.T, tools []Tool, name string) string { //nolint:unparam
+	t.Helper()
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool.Description
+		}
+	}
+	t.Fatalf("tool %q not found in tools list", name)
+	return ""
+}

--- a/sast-engine/mcp/types.go
+++ b/sast-engine/mcp/types.go
@@ -54,8 +54,29 @@ type InitializeResult struct {
 
 // ServerInfo identifies this MCP server.
 type ServerInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name     string          `json:"name"`
+	Version  string          `json:"version"`
+	Metadata *ServerMetadata `json:"metadata,omitempty"`
+}
+
+// ServerMetadata carries optional update-check information in the initialize
+// response. All fields use omitempty so the payload stays compact when nothing
+// is available.
+type ServerMetadata struct {
+	LatestVersion string            `json:"latest_version,omitempty"`  //nolint:tagliatelle
+	UpdateMessage string            `json:"update_message,omitempty"`  //nolint:tagliatelle
+	ReleaseURL    string            `json:"release_url,omitempty"`     //nolint:tagliatelle
+	Announcement  *AnnouncementInfo `json:"announcement,omitempty"`
+}
+
+// AnnouncementInfo is the wire shape of a single operator announcement
+// embedded in ServerMetadata and in the structured status tool result.
+type AnnouncementInfo struct {
+	ID    string `json:"id"`
+	Level string `json:"level"`
+	Title string `json:"title"`
+	Text  string `json:"text"`
+	URL   string `json:"url,omitempty"`
 }
 
 // Capabilities advertises server features.

--- a/sast-engine/mcp/updatecheck.go
+++ b/sast-engine/mcp/updatecheck.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/updatecheck"
+)
+
+// noticeMaxLen is the maximum byte length of the upgrade/announcement prefix
+// prepended to the status tool description. MCP clients truncate long
+// descriptions aggressively; 200 bytes keeps the hint well within limits.
+const noticeMaxLen = 200
+
+// formatStatusDescription prepends a one-line upgrade or announcement hint to
+// the existing status tool description. The hint is capped at 200 visible
+// characters (including the trailing URL) to stay within MCP client truncation
+// limits.
+//
+// When both an upgrade and an announcement are present the upgrade wins —
+// it is the higher-leverage nudge. The announcement still appears in
+// serverInfo.metadata and in the structured status tool result.
+//
+// Returns base unchanged when r is nil or neither Upgrade nor Announcement is
+// set.
+func formatStatusDescription(base string, r *updatecheck.Result) string {
+	if r == nil {
+		return base
+	}
+
+	var prefix string
+	switch {
+	case r.Upgrade != nil:
+		prefix = fmt.Sprintf("⚠ Upgrade available: pathfinder %s → %s. %s",
+			r.Upgrade.Current, r.Upgrade.Latest, r.Upgrade.ReleaseURL)
+	case r.Announcement != nil:
+		prefix = fmt.Sprintf("ℹ %s — %s %s",
+			r.Announcement.Title, r.Announcement.Text, r.Announcement.URL)
+	default:
+		return base
+	}
+
+	return TruncateNotice(prefix, noticeMaxLen) + "\n\n" + base
+}
+
+// TruncateNotice caps s at n bytes, appending "…" (a single UTF-8 ellipsis
+// character, 3 bytes) when truncation is needed. The total result is always
+// ≤ n bytes. Exported for testing.
+func TruncateNotice(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	const ellipsis = "…" // 3 UTF-8 bytes
+	if n <= 3 {
+		return ellipsis
+	}
+	return s[:n-3] + ellipsis
+}

--- a/sast-engine/mcp/updatecheck_test.go
+++ b/sast-engine/mcp/updatecheck_test.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/updatecheck"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- formatStatusDescription -------------------------------------------------
+
+func makeUpgradeResult(current, latest, releaseURL, message string) *updatecheck.Result {
+	return &updatecheck.Result{
+		Upgrade: &updatecheck.UpgradeNotice{
+			Current:    current,
+			Latest:     latest,
+			ReleaseURL: releaseURL,
+			Message:    message,
+		},
+	}
+}
+
+func makeAnnouncementResult(id, level, title, text, url string) *updatecheck.Result {
+	return &updatecheck.Result{
+		Announcement: &updatecheck.Announcement{
+			ID:    id,
+			Level: level,
+			Title: title,
+			Text:  text,
+			URL:   url,
+		},
+	}
+}
+
+func TestFormatStatusDescription_Nil_NoOp(t *testing.T) {
+	base := "some base description"
+	got := formatStatusDescription(base, nil)
+	assert.Equal(t, base, got)
+}
+
+func TestFormatStatusDescription_NeitherPresent(t *testing.T) {
+	base := "some base description"
+	got := formatStatusDescription(base, &updatecheck.Result{})
+	assert.Equal(t, base, got)
+}
+
+func TestFormatStatusDescription_UpgradeOnly(t *testing.T) {
+	base := "base desc"
+	r := makeUpgradeResult("1.0.0", "2.0.0", "https://example.com/releases/v2.0.0", "")
+	got := formatStatusDescription(base, r)
+
+	assert.Contains(t, got, "Upgrade available")
+	assert.Contains(t, got, "1.0.0")
+	assert.Contains(t, got, "2.0.0")
+	assert.Contains(t, got, "https://example.com/releases/v2.0.0")
+	// Base is appended after a blank line.
+	assert.Contains(t, got, "\n\n"+base)
+}
+
+func TestFormatStatusDescription_AnnouncementOnly(t *testing.T) {
+	base := "base desc"
+	r := makeAnnouncementResult("ann-1", "info", "Q2 Release", "New features landed.", "https://example.com/blog/q2")
+	got := formatStatusDescription(base, r)
+
+	assert.Contains(t, got, "ℹ")
+	assert.Contains(t, got, "Q2 Release")
+	assert.Contains(t, got, "New features landed.")
+	assert.Contains(t, got, "https://example.com/blog/q2")
+	assert.Contains(t, got, "\n\n"+base)
+}
+
+func TestFormatStatusDescription_BothPresent_UpgradeWins(t *testing.T) {
+	base := "base desc"
+	r := makeUpgradeResult("1.0.0", "2.0.0", "https://example.com/releases/v2.0.0", "")
+	r.Announcement = &updatecheck.Announcement{
+		Title: "Should not appear in prefix",
+		Text:  "announcement text",
+	}
+	got := formatStatusDescription(base, r)
+
+	// Upgrade prefix wins.
+	assert.Contains(t, got, "Upgrade available")
+	assert.Contains(t, got, "2.0.0")
+	// Announcement title must NOT appear as the leading prefix (upgrade wins).
+	lines := got[:len(got)-len("\n\n"+base)]
+	assert.NotContains(t, lines, "Should not appear in prefix")
+}
+
+func TestFormatStatusDescription_TruncatedAt200(t *testing.T) {
+	// Build a release URL long enough to push the formatted string past 200 bytes.
+	longURL := "https://example.com/releases/" + string(make([]byte, 200))
+	for i := range longURL {
+		_ = i // just to silence the linter; longURL is deliberately long
+	}
+	longURL = "https://example.com/releases/v9.9.9/" + repeatStr("x", 180)
+	r := makeUpgradeResult("1.0.0", "9.9.9", longURL, "")
+	got := formatStatusDescription("base", r)
+
+	// The prefix portion (everything before "\n\n") must be ≤ 200 bytes.
+	parts := splitOnce(got, "\n\n")
+	assert.LessOrEqual(t, len(parts[0]), 200)
+	// Must end with the ellipsis rune (UTF-8: 3 bytes).
+	assert.True(t, len(parts[0]) > 0)
+	last := []rune(parts[0])
+	assert.Equal(t, '…', last[len(last)-1])
+}
+
+// --- TruncateNotice ----------------------------------------------------------
+
+func TestTruncateNotice_NoOpWhenShort(t *testing.T) {
+	s := "short string"
+	assert.Equal(t, s, TruncateNotice(s, 200))
+}
+
+func TestTruncateNotice_NoOpExactLength(t *testing.T) {
+	s := repeatStr("a", 200)
+	assert.Equal(t, s, TruncateNotice(s, 200))
+}
+
+func TestTruncateNotice_AppendsEllipsis(t *testing.T) {
+	s := repeatStr("a", 201)
+	got := TruncateNotice(s, 200)
+	assert.LessOrEqual(t, len(got), 200)
+	assert.True(t, len(got) > 0)
+	last := []rune(got)
+	assert.Equal(t, '…', last[len(last)-1])
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func repeatStr(s string, n int) string {
+	out := make([]byte, n*len(s))
+	for i := range n {
+		copy(out[i*len(s):], s)
+	}
+	return string(out)
+}
+
+// splitOnce splits s on the first occurrence of sep into at most 2 parts.
+func splitOnce(s, sep string) []string {
+	idx := indexOf(s, sep)
+	if idx < 0 {
+		return []string{s}
+	}
+	return []string{s[:idx], s[idx+len(sep):]}
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

PR-03 of the version-update-check stack (PR-01 merged → PR-02 #652 → **PR-03** → PR-04).

Surfaces upgrade notices and announcements through the MCP server so AI coding assistants see them on every reconnect. One synchronous fetch at server startup (5 s ceiling) stores an immutable `*updatecheck.Result` on the `Server` struct for the process lifetime — no goroutines, no `Close()`, no refresher.

### Integration points

- **`handleInitialize`** — populates `serverInfo.metadata` (`latest_version`, `update_message`, `release_url`, `announcement`) when an upgrade or announcement is available; field is omitted entirely when empty (JSON `omitempty`)
- **`handleToolsList`** — injects a truncated upgrade/announcement hint (≤ 200 bytes) into the `status` tool description via `formatStatusDescription`; all other tool descriptions are byte-identical to the no-update case
- **`handleStatus`** — merges `latest_version`, `update_message`, `release_url`, and `announcement` into the structured status result map via `injectUpdateInfo`

### New files

| File | Purpose |
|---|---|
| `mcp/updatecheck.go` | `formatStatusDescription`, `TruncateNotice` helpers |
| `mcp/updatecheck_test.go` | 9 golden tests for helpers |
| `mcp/server_updatecheck_test.go` | `NewServer` fetch tests + `handleInitialize` metadata tests |
| `mcp/tools_updatecheck_test.go` | `handleToolsList` description injection + `handleStatus` structured fields |

### Modified files

- `mcp/server.go` — `updateInfo` field, `fetchUpdateInfo()`, `mcpManifestURL` override var, enriched `handleInitialize`/`handleToolsList`/`handleStatus`
- `mcp/types.go` — `ServerInfo.Metadata`, `ServerMetadata`, `AnnouncementInfo` structs
- `mcp/tools.go` — `status` tool definition added to `getToolDefinitions`

## Test plan

- [x] `go test -race ./mcp/...` — all passing, no data races
- [x] `golangci-lint run ./mcp/...` — 0 issues
- [x] `TestHandleToolsList_OtherToolDescriptionsUntouched` — verifies only `status` description changes
- [x] `TestHandleInitialize_MetadataOmittedWhenEmpty` — verifies no empty `metadata` field in JSON
- [x] `TestNewServer_FetchError_UpdateInfoNil` — verifies server constructs cleanly on CDN failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)