### PR TITLE
feat: release/latest.json manifest and publish workflow

### DIFF
--- a/.github/scripts/smoke-update-check.sh
+++ b/.github/scripts/smoke-update-check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Smoke test for the version-update-check chain.
+# Usage: smoke-update-check.sh <expected-tag>
+# Run manually after PR-01..PR-05 have all merged and the binary is on main.
+set -euo pipefail
+
+CDN_URL="https://assets.codepathfinder.dev/pathfinder/latest.json"
+EXPECTED_TAG="${1:?usage: smoke-update-check.sh <expected-tag>}"
+
+echo "1. Checking CDN serves the expected tag..."
+ACTUAL=$(curl -fsSL "$CDN_URL" | jq -r '.latest.version')
+if [[ "$ACTUAL" != "$EXPECTED_TAG" ]]; then
+  echo "FAIL: CDN says $ACTUAL, expected $EXPECTED_TAG"
+  exit 1
+fi
+echo "  OK ($ACTUAL)"
+
+echo "2. Checking a stale binary sees an upgrade notice..."
+go build -ldflags="-X github.com/shivasurya/code-pathfinder/sast-engine/cmd.Version=0.0.1" \
+  -o /tmp/pathfinder-stale ./sast-engine
+output=$(/tmp/pathfinder-stale version 2>&1)
+if ! grep -q "Update available" <<< "$output"; then
+  echo "FAIL: stale binary did not render upgrade notice"
+  echo "$output"
+  exit 1
+fi
+echo "  OK"
+
+echo "3. Checking a current binary sees no notice..."
+go build -ldflags="-X github.com/shivasurya/code-pathfinder/sast-engine/cmd.Version=$EXPECTED_TAG" \
+  -o /tmp/pathfinder-current ./sast-engine
+output=$(/tmp/pathfinder-current version 2>&1)
+if grep -q "Update available" <<< "$output"; then
+  echo "FAIL: current binary rendered upgrade notice"
+  echo "$output"
+  exit 1
+fi
+echo "  OK"
+
+echo "All automated smoke checks passed."

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -1,0 +1,57 @@
+name: Publish update manifest
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'release/latest.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate schema
+        run: |
+          jq -e '
+            .schema == 1
+            and (.latest.version    | type == "string")
+            and (.latest.released_at | type == "string")
+            and (.latest.release_url | type == "string")
+            and (.channels.stable    | type == "string")
+            and (.message.level      | IN("info", "warn"))
+            and (.message.text       | type == "string")
+            and (.announcements      | type == "array")
+            and (.announcements      | all(
+                  .id    and (.id    | type == "string")
+              and .level and (.level | IN("info", "warn", "critical"))
+              and .title and (.title | type == "string")
+              and .text  and (.text  | type == "string")
+            ))
+          ' release/latest.json
+
+      - name: Upload to Cloudflare R2
+        env:
+          R2_ACCOUNT_ID:        ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID:     ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+          R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          aws s3 cp release/latest.json \
+            s3://codepathfinder-assets/pathfinder/latest.json \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "public, max-age=300" \
+            --content-type "application/json"
+
+      - name: Verify upload
+        run: |
+          curl -fsSL "https://assets.codepathfinder.dev/pathfinder/latest.json" \
+            | jq -e '.schema == 1' > /dev/null

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
     paths:
       - 'release/latest.json'
-  pull_request:
-    branches: [feat/publish-manifest]
-    paths:
-      - 'release/latest.json'
-      - '.github/workflows/publish-manifest.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
     paths:
       - 'release/latest.json'
+  pull_request:
+    branches: [feat/publish-manifest]
+    paths:
+      - 'release/latest.json'
+      - '.github/workflows/publish-manifest.yml'
   workflow_dispatch:
 
 permissions:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Critical files — require @shivasurya review
+/release/latest.json    @shivasurya

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,8 @@ RUN chmod +x /usr/bin/entrypoint.sh
 LABEL maintainer="shiva@shivasurya.me"
 LABEL io.modelcontextprotocol.server.name="dev.codepathfinder/pathfinder"
 
+# Disable in-product update notices for Docker users — they upgrade by
+# pulling a new image tag, so an in-container nudge would be noise.
+ENV PATHFINDER_NO_UPDATE_CHECK=1
+
 ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -40,6 +40,10 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
 LABEL maintainer="shiva@shivasurya.me"
 LABEL io.modelcontextprotocol.server.name="dev.codepathfinder/pathfinder"
 
+# Disable in-product update notices for Docker users — they upgrade by
+# pulling a new image tag, so an in-container nudge would be noise.
+ENV PATHFINDER_NO_UPDATE_CHECK=1
+
 # MCP serve mode: stdio transport, indexing the mounted /project directory
 # To disable analytics, add --disable-metrics flag
 ENTRYPOINT ["/usr/bin/pathfinder", "serve", "--project", "/project"]

--- a/README.md
+++ b/README.md
@@ -301,6 +301,14 @@ Either `rules` or `ruleset` is required.
 
 Contributions are welcome. Read the [Contributing Guide](./CONTRIBUTING.md) for setup instructions, how to run tests locally, and the PR process.
 
+### Pushing an in-product announcement
+
+In-product announcements (workshops, blog posts, security advisories) are
+managed via `release/latest.json`. Add an entry to `announcements[]`,
+open a PR, and once it merges to `main` the publish workflow uploads the
+manifest to the CDN within ~60 seconds. See the version-update-check tech
+spec for the schema and `version_range` semantics.
+
 All contributors must sign the [Contributor License Agreement (CLA)](./CLA.md) before any pull request can be merged.
 
 - [Report bugs or request features](https://github.com/shivasurya/code-pathfinder/issues)

--- a/release/latest.json
+++ b/release/latest.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "latest": {
+    "version": "2.0.2",
+    "released_at": "2026-04-03T00:00:00Z",
+    "release_url": "https://github.com/shivasurya/code-pathfinder/releases/tag/v2.0.2"
+  },
+  "channels": {
+    "stable": "2.0.2"
+  },
+  "message": {
+    "level": "info",
+    "text": "Code Pathfinder static analysis engine."
+  },
+  "announcements": [],
+  "min_supported": "1.9.0"
+}

--- a/release/latest.json
+++ b/release/latest.json
@@ -1,32 +1,17 @@
 {
   "schema": 1,
   "latest": {
-    "version": "2.0.3",
-    "released_at": "2026-04-12T00:00:00Z",
-    "release_url": "https://github.com/shivasurya/code-pathfinder/releases/tag/v2.0.3"
+    "version": "2.0.2",
+    "released_at": "2026-04-03T00:00:00Z",
+    "release_url": "https://github.com/shivasurya/code-pathfinder/releases/tag/v2.0.2"
   },
   "channels": {
-    "stable": "2.0.3"
+    "stable": "2.0.2"
   },
   "message": {
     "level": "info",
-    "text": "Code Pathfinder 2.0.3 — upgrade for the latest improvements."
+    "text": "Code Pathfinder static analysis engine."
   },
-  "announcements": [
-    {
-      "id": "test-targeted-ann",
-      "level": "warn",
-      "title": "Version-Targeted Announcement Test",
-      "text": "This notice only shows on builds older than 2.0.0.",
-      "version_range": "<2.0.0"
-    },
-    {
-      "id": "test-generic-ann",
-      "level": "info",
-      "title": "Generic Announcement Test",
-      "text": "This notice shows on all versions regardless of upgrade state.",
-      "url": "https://codepathfinder.dev"
-    }
-  ],
+  "announcements": [],
   "min_supported": "1.9.0"
 }

--- a/release/latest.json
+++ b/release/latest.json
@@ -1,17 +1,32 @@
 {
   "schema": 1,
   "latest": {
-    "version": "2.0.2",
-    "released_at": "2026-04-03T00:00:00Z",
-    "release_url": "https://github.com/shivasurya/code-pathfinder/releases/tag/v2.0.2"
+    "version": "2.0.3",
+    "released_at": "2026-04-12T00:00:00Z",
+    "release_url": "https://github.com/shivasurya/code-pathfinder/releases/tag/v2.0.3"
   },
   "channels": {
-    "stable": "2.0.2"
+    "stable": "2.0.3"
   },
   "message": {
     "level": "info",
-    "text": "Code Pathfinder static analysis engine."
+    "text": "Code Pathfinder 2.0.3 — upgrade for the latest improvements."
   },
-  "announcements": [],
+  "announcements": [
+    {
+      "id": "test-targeted-ann",
+      "level": "warn",
+      "title": "Version-Targeted Announcement Test",
+      "text": "This notice only shows on builds older than 2.0.0.",
+      "version_range": "<2.0.0"
+    },
+    {
+      "id": "test-generic-ann",
+      "level": "info",
+      "title": "Generic Announcement Test",
+      "text": "This notice shows on all versions regardless of upgrade state.",
+      "url": "https://codepathfinder.dev"
+    }
+  ],
   "min_supported": "1.9.0"
 }


### PR DESCRIPTION
## Summary

PR-05 of the version-update-check stack. Adds the single publishing path so that `release/latest.json` on `main` is the source of truth for update notices and announcements, and any merge that touches it publishes to the CDN within ~60 seconds.

**Stack**: PR-01 (merged) → PR-02 (#652) → PR-03 (#653) → PR-04 (#654) → PR-05 (this)

### Changes

- **`release/latest.json`** — bootstrap manifest at v2.0.2, empty `announcements: []`; human-edited on each release
- **`.github/workflows/publish-manifest.yml`** — `push`/`workflow_dispatch` trigger; `jq` schema gate → R2 upload (`Cache-Control: public, max-age=300`) → post-hoc CDN verify
- **`CODEOWNERS`** — restricts `/release/latest.json` edits to `@shivasurya`; creates the file (didn't exist before)
- **`.github/scripts/smoke-update-check.sh`** — manual end-to-end smoke: checks CDN version, builds stale binary, verifies upgrade banner, verifies current binary is silent. Not wired into CI.
- **`Dockerfile` / `Dockerfile.mcp`** — add `ENV PATHFINDER_NO_UPDATE_CHECK=1`; Docker users upgrade by pulling a new tag, so an in-container nudge would be noise
- **`README.md`** — adds "Pushing an in-product announcement" paragraph under Contributing

### Notes

- First-merge chicken-and-egg is intentional: GitHub evaluates the workflow from the commit being pushed, so the first run *is* the bootstrap publish.
- Reuses existing R2 secrets (`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) already used by `stdlib-r2-upload.yml` — no new credentials.
- `assets.codepathfinder.dev` already fronts the bucket; no DNS changes needed.

## Test plan

- [x] `jq -e '...'` validation passes against `release/latest.json` locally
- [ ] `workflow_dispatch` smoke run on the branch confirms R2 upload succeeds
- [ ] `curl https://assets.codepathfinder.dev/pathfinder/latest.json` returns bootstrap JSON after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)