### PR TITLE
fix: correct R2 bucket name and install AWS CLI in publish-manifest

### DIFF
--- a/.github/workflows/publish-manifest.yml
+++ b/.github/workflows/publish-manifest.yml
@@ -35,6 +35,13 @@ jobs:
             ))
           ' release/latest.json
 
+      - name: Install AWS CLI
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
+
       - name: Upload to Cloudflare R2
         env:
           R2_ACCOUNT_ID:        ${{ secrets.R2_ACCOUNT_ID }}
@@ -46,7 +53,7 @@ jobs:
           R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
           aws s3 cp release/latest.json \
-            s3://codepathfinder-assets/pathfinder/latest.json \
+            s3://code-pathfinder-assets/pathfinder/latest.json \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "public, max-age=300" \
             --content-type "application/json"


### PR DESCRIPTION
## Summary

Fixes two bugs in `.github/workflows/publish-manifest.yml` found by comparing against the working R2 upload workflows (`stdlib-r2-upload.yml`, `go-stdlib-r2-upload.yml`, `go-thirdparty-r2-upload.yml`):

- **Wrong bucket name**: `codepathfinder-assets` → `code-pathfinder-assets` — this caused `AccessDenied` on the first workflow run after merge
- **Missing AWS CLI install**: all other R2 workflows explicitly `curl + install` the latest AWS CLI before use; relying on the pre-installed runner version is inconsistent and fragile

## Root cause

The bucket name typo in the original PR (#655) was not caught because the workflow only runs on push to `main` (no PR-level test path existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)