### PR TITLE
feat(python-sdk): SDK metadata + CDN-indexed stubs for Go and Python classes

### DIFF
--- a/python-sdk/codepathfinder/go_rule_meta.py
+++ b/python-sdk/codepathfinder/go_rule_meta.py
@@ -95,10 +95,18 @@ def detect_gorm_sqli():
         scope="global",
     )
 """,
-        "rules_using": ["GO-GORM-SQLI-001", "GO-GORM-SQLI-002", "GO-SEC-001", "GO-SQLI-003",
-                        "GO-SSRF-001", "GO-SEC-002", "GO-XSS-001", "GO-PATH-001", "GO-REDIRECT-001"],
+        "rules_using": [
+            "GO-GORM-SQLI-001",
+            "GO-GORM-SQLI-002",
+            "GO-SEC-001",
+            "GO-SQLI-003",
+            "GO-SSRF-001",
+            "GO-SEC-002",
+            "GO-XSS-001",
+            "GO-PATH-001",
+            "GO-REDIRECT-001",
+        ],
     },
-
     "GoEchoContext": {
         "description": (
             "Represents echo.Context in the Echo HTTP framework (v4). "
@@ -141,7 +149,6 @@ def detect_gorm_sqli():
         },
         "rules_using": ["GO-SEC-001", "GO-SEC-002", "GO-SSRF-001"],
     },
-
     "GoFiberCtx": {
         "description": (
             "Represents fiber.Ctx in the Fiber HTTP framework (v2), inspired by Express.js. "
@@ -183,7 +190,6 @@ def detect_gorm_sqli():
         },
         "rules_using": ["GO-SEC-001", "GO-SEC-002"],
     },
-
     "GoGormDB": {
         "description": (
             "Represents gorm.DB, the primary database handle in GORM v2. "
@@ -249,7 +255,6 @@ def detect_gorm_sqli_concat():
 """,
         "rules_using": ["GO-GORM-SQLI-001", "GO-GORM-SQLI-002"],
     },
-
     "GoSqlxDB": {
         "description": (
             "Represents sqlx.DB and sqlx.Tx from the sqlx library, which extends database/sql "
@@ -286,7 +291,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-SQLI-003"],
     },
-
     "GoSQLDB": {
         "description": (
             "Represents database/sql.DB and database/sql.Tx from the Go standard library. "
@@ -323,7 +327,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-SEC-001"],
     },
-
     "GoStrconv": {
         "description": (
             "The strconv standard library package. Atoi, ParseInt, ParseFloat, and related "
@@ -350,13 +353,12 @@ def detect_gorm_sqli_concat():
             },
             "ParseBool": {
                 "signature": "ParseBool(str string) (bool, error)",
-                "description": "Parses \"true\"/\"false\" string to bool. Sanitizes by constraining to boolean domain.",
+                "description": 'Parses "true"/"false" string to bool. Sanitizes by constraining to boolean domain.',
                 "role": "sanitizer",
             },
         },
         "rules_using": ["GO-GORM-SQLI-001", "GO-SEC-001"],
     },
-
     "GoOSExec": {
         "description": (
             "The os/exec standard library package. exec.Command and exec.CommandContext "
@@ -381,7 +383,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-SEC-002"],
     },
-
     "GoHTTPRequest": {
         "description": (
             "Represents *http.Request from the net/http standard library. "
@@ -418,7 +419,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-SEC-001", "GO-SEC-002", "GO-XSS-001", "GO-SSRF-002"],
     },
-
     "GoRestyClient": {
         "description": (
             "Represents resty.Client and resty.Request from go-resty/resty v2. "
@@ -455,7 +455,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-SSRF-001"],
     },
-
     "GoJWTToken": {
         "description": (
             "Represents jwt.Token from github.com/golang-jwt/jwt v5. "
@@ -479,640 +478,1117 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-JWT-002"],
     },
-
     # ── stdlib already in go_rule.py but not yet in meta ──────────────────────
-
     "GoHTTPResponseWriter": {
         "description": "Represents net/http.ResponseWriter. Write() and WriteString() are XSS sinks when writing unsanitized user input into the HTTP response body.",
         "category": "stdlib",
         "fqns": ["net/http.ResponseWriter"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Write": {"signature": "Write(b []byte) (int, error)", "description": "Writes raw bytes to response. XSS sink when b contains user input.", "role": "sink", "tracks": [0]},
-            "WriteHeader": {"signature": "WriteHeader(statusCode int)", "description": "Sets HTTP status code. Not a taint sink.", "role": "neutral"},
+            "Write": {
+                "signature": "Write(b []byte) (int, error)",
+                "description": "Writes raw bytes to response. XSS sink when b contains user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "WriteHeader": {
+                "signature": "WriteHeader(statusCode int)",
+                "description": "Sets HTTP status code. Not a taint sink.",
+                "role": "neutral",
+            },
         },
         "rules_using": ["GO-XSS-001"],
     },
-
     "GoHTTPClient": {
         "description": "Represents net/http.Client. Do(), Get(), Post() are SSRF sinks when the URL comes from user input.",
         "category": "stdlib",
         "fqns": ["net/http.Client"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Get": {"signature": "Get(url string) (*Response, error)", "description": "Makes GET request. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
-            "Post": {"signature": "Post(url, contentType string, body io.Reader) (*Response, error)", "description": "Makes POST request. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
-            "Do": {"signature": "Do(req *Request) (*Response, error)", "description": "Executes arbitrary HTTP request. SSRF sink.", "role": "sink", "tracks": [0]},
+            "Get": {
+                "signature": "Get(url string) (*Response, error)",
+                "description": "Makes GET request. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Post": {
+                "signature": "Post(url, contentType string, body io.Reader) (*Response, error)",
+                "description": "Makes POST request. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Do": {
+                "signature": "Do(req *Request) (*Response, error)",
+                "description": "Executes arbitrary HTTP request. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": ["GO-SSRF-002"],
     },
-
     "GoOS": {
         "description": "The os standard library package. Getenv() is a source of environment variable data. Open(), Create(), Remove() are file operation sinks for path traversal.",
         "category": "stdlib",
         "fqns": ["os"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Getenv": {"signature": "Getenv(key string) string", "description": "Returns environment variable value. Source of external data.", "role": "source", "tracks": ["return"]},
-            "Open": {"signature": "Open(name string) (*File, error)", "description": "Opens file for reading. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [0]},
-            "Create": {"signature": "Create(name string) (*File, error)", "description": "Creates file. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [0]},
-            "Remove": {"signature": "Remove(name string) error", "description": "Removes file. Dangerous sink when name is user-controlled.", "role": "sink", "tracks": [0]},
-            "ReadFile": {"signature": "ReadFile(name string) ([]byte, error)", "description": "Reads entire file. Path traversal sink.", "role": "sink", "tracks": [0]},
+            "Getenv": {
+                "signature": "Getenv(key string) string",
+                "description": "Returns environment variable value. Source of external data.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Open": {
+                "signature": "Open(name string) (*File, error)",
+                "description": "Opens file for reading. Path traversal sink when name is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Create": {
+                "signature": "Create(name string) (*File, error)",
+                "description": "Creates file. Path traversal sink when name is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Remove": {
+                "signature": "Remove(name string) error",
+                "description": "Removes file. Dangerous sink when name is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "ReadFile": {
+                "signature": "ReadFile(name string) ([]byte, error)",
+                "description": "Reads entire file. Path traversal sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": ["GO-PATH-001"],
     },
-
     "GoFilepath": {
         "description": "The path/filepath standard library package. Join(), Abs(), Clean() are used as sanitizers in path traversal rules when combined with containment checks.",
         "category": "stdlib",
         "fqns": ["path/filepath"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Join": {"signature": "Join(elem ...string) string", "description": "Joins path elements. Sanitizer when followed by a prefix containment check.", "role": "sanitizer"},
-            "Abs": {"signature": "Abs(path string) (string, error)", "description": "Returns absolute path. Sanitizer when result is checked against allowed root.", "role": "sanitizer"},
-            "Clean": {"signature": "Clean(path string) string", "description": "Lexically cleans path. Partial sanitizer — still needs containment check.", "role": "sanitizer"},
-            "Base": {"signature": "Base(path string) string", "description": "Returns last element of path. Strips directory traversal sequences.", "role": "sanitizer"},
+            "Join": {
+                "signature": "Join(elem ...string) string",
+                "description": "Joins path elements. Sanitizer when followed by a prefix containment check.",
+                "role": "sanitizer",
+            },
+            "Abs": {
+                "signature": "Abs(path string) (string, error)",
+                "description": "Returns absolute path. Sanitizer when result is checked against allowed root.",
+                "role": "sanitizer",
+            },
+            "Clean": {
+                "signature": "Clean(path string) string",
+                "description": "Lexically cleans path. Partial sanitizer — still needs containment check.",
+                "role": "sanitizer",
+            },
+            "Base": {
+                "signature": "Base(path string) string",
+                "description": "Returns last element of path. Strips directory traversal sequences.",
+                "role": "sanitizer",
+            },
         },
         "rules_using": ["GO-PATH-001"],
     },
-
     "GoFmt": {
         "description": "The fmt standard library package. Sprintf, Fprintf, Sscanf are sources of formatted string data. Fprintf to http.ResponseWriter is an XSS sink.",
         "category": "stdlib",
         "fqns": ["fmt"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Sprintf": {"signature": "Sprintf(format string, a ...any) string", "description": "Formats string. Propagates taint from arguments into the return value.", "role": "neutral"},
-            "Fprintf": {"signature": "Fprintf(w io.Writer, format string, a ...any) (n int, err error)", "description": "Writes to w. XSS sink when w is http.ResponseWriter and a contains user input.", "role": "sink", "tracks": [1]},
-            "Sscanf": {"signature": "Sscanf(str string, format string, a ...any) (n int, err error)", "description": "Parses str. a arguments become tainted with str contents.", "role": "source"},
+            "Sprintf": {
+                "signature": "Sprintf(format string, a ...any) string",
+                "description": "Formats string. Propagates taint from arguments into the return value.",
+                "role": "neutral",
+            },
+            "Fprintf": {
+                "signature": "Fprintf(w io.Writer, format string, a ...any) (n int, err error)",
+                "description": "Writes to w. XSS sink when w is http.ResponseWriter and a contains user input.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Sscanf": {
+                "signature": "Sscanf(str string, format string, a ...any) (n int, err error)",
+                "description": "Parses str. a arguments become tainted with str contents.",
+                "role": "source",
+            },
         },
         "rules_using": [],
     },
-
     "GoTemplate": {
         "description": "Represents html/template.Template and text/template.Template. Execute() and ExecuteTemplate() are XSS sinks when data contains unsanitized user input passed to text/template (not html/template).",
         "category": "stdlib",
         "fqns": ["html/template.Template", "text/template.Template"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Execute": {"signature": "Execute(wr io.Writer, data any) error", "description": "Renders template with data. XSS sink for text/template when data is user-controlled.", "role": "sink", "tracks": [1]},
-            "ExecuteTemplate": {"signature": "ExecuteTemplate(wr io.Writer, name string, data any) error", "description": "Renders named template. Same XSS risk as Execute.", "role": "sink", "tracks": [2]},
-            "Parse": {"signature": "Parse(text string) (*Template, error)", "description": "Parses template text. Server-side template injection if text is user-controlled.", "role": "sink", "tracks": [0]},
+            "Execute": {
+                "signature": "Execute(wr io.Writer, data any) error",
+                "description": "Renders template with data. XSS sink for text/template when data is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "ExecuteTemplate": {
+                "signature": "ExecuteTemplate(wr io.Writer, name string, data any) error",
+                "description": "Renders named template. Same XSS risk as Execute.",
+                "role": "sink",
+                "tracks": [2],
+            },
+            "Parse": {
+                "signature": "Parse(text string) (*Template, error)",
+                "description": "Parses template text. Server-side template injection if text is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": ["GO-XSS-003"],
     },
-
     "GoCrypto": {
         "description": "Weak cryptographic algorithms: crypto/md5, crypto/sha1, crypto/des, crypto/rc4. All New() and Sum() calls are findings — these algorithms are cryptographically broken.",
         "category": "stdlib",
         "fqns": ["crypto/md5", "crypto/sha1", "crypto/des", "crypto/rc4"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "New": {"signature": "New() hash.Hash", "description": "Creates new hash instance using the weak algorithm. Always a finding.", "role": "sink"},
-            "Sum": {"signature": "Sum(data []byte) [N]byte", "description": "Computes weak hash. Always a finding.", "role": "sink"},
+            "New": {
+                "signature": "New() hash.Hash",
+                "description": "Creates new hash instance using the weak algorithm. Always a finding.",
+                "role": "sink",
+            },
+            "Sum": {
+                "signature": "Sum(data []byte) [N]byte",
+                "description": "Computes weak hash. Always a finding.",
+                "role": "sink",
+            },
         },
-        "rules_using": ["GO-CRYPTO-001", "GO-CRYPTO-002", "GO-CRYPTO-003", "GO-CRYPTO-004", "GO-CRYPTO-005"],
+        "rules_using": [
+            "GO-CRYPTO-001",
+            "GO-CRYPTO-002",
+            "GO-CRYPTO-003",
+            "GO-CRYPTO-004",
+            "GO-CRYPTO-005",
+        ],
     },
-
     "GoContext": {
         "description": "Represents context.Context. Value() can propagate tainted data stored by upstream handlers — treat returned values as taint sources in inter-procedural analysis.",
         "category": "stdlib",
         "fqns": ["context.Context"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Value": {"signature": "Value(key any) any", "description": "Returns value associated with key. Source of taint when key is a request-scoped user-data key.", "role": "source", "tracks": ["return"]},
-            "WithValue": {"signature": "WithValue(parent Context, key, val any) Context", "description": "Returns context carrying val. Propagates taint from val.", "role": "neutral"},
+            "Value": {
+                "signature": "Value(key any) any",
+                "description": "Returns value associated with key. Source of taint when key is a request-scoped user-data key.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "WithValue": {
+                "signature": "WithValue(parent Context, key, val any) Context",
+                "description": "Returns context carrying val. Propagates taint from val.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     # ── 40+ additional stdlib entries for UI scale testing ────────────────────
-
     "GoBufioReader": {
         "description": "bufio.Reader wraps an io.Reader with buffering. ReadString() and ReadLine() are sources when the underlying reader is an HTTP request body or stdin.",
         "category": "stdlib",
         "fqns": ["bufio.Reader"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "ReadString": {"signature": "ReadString(delim byte) (string, error)", "description": "Reads until delimiter. Source when wrapping user-controlled input.", "role": "source", "tracks": ["return"]},
-            "ReadLine": {"signature": "ReadLine() (line []byte, isPrefix bool, err error)", "description": "Reads one line. Source when wrapping HTTP body or stdin.", "role": "source", "tracks": ["return"]},
-            "ReadBytes": {"signature": "ReadBytes(delim byte) ([]byte, error)", "description": "Reads until delimiter. Source of tainted bytes.", "role": "source", "tracks": ["return"]},
+            "ReadString": {
+                "signature": "ReadString(delim byte) (string, error)",
+                "description": "Reads until delimiter. Source when wrapping user-controlled input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "ReadLine": {
+                "signature": "ReadLine() (line []byte, isPrefix bool, err error)",
+                "description": "Reads one line. Source when wrapping HTTP body or stdin.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "ReadBytes": {
+                "signature": "ReadBytes(delim byte) ([]byte, error)",
+                "description": "Reads until delimiter. Source of tainted bytes.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoBufioScanner": {
         "description": "bufio.Scanner reads tokens line-by-line. Text() and Bytes() are sources when the scanner wraps user-controlled input (stdin, HTTP body).",
         "category": "stdlib",
         "fqns": ["bufio.Scanner"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Text": {"signature": "Text() string", "description": "Returns current token as string. Source when scanning user input.", "role": "source", "tracks": ["return"]},
-            "Bytes": {"signature": "Bytes() []byte", "description": "Returns current token as bytes. Source when scanning user input.", "role": "source", "tracks": ["return"]},
+            "Text": {
+                "signature": "Text() string",
+                "description": "Returns current token as string. Source when scanning user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Bytes": {
+                "signature": "Bytes() []byte",
+                "description": "Returns current token as bytes. Source when scanning user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoIOReader": {
         "description": "io.Reader interface. ReadAll() from io package returns the full content of a reader — source of taint when the reader wraps HTTP request body.",
         "category": "stdlib",
         "fqns": ["io"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "ReadAll": {"signature": "ReadAll(r Reader) ([]byte, error)", "description": "Reads all bytes from r. Source when r is http.Request.Body.", "role": "source", "tracks": ["return"]},
-            "Copy": {"signature": "Copy(dst Writer, src Reader) (int64, error)", "description": "Copies src to dst. Propagates taint from src to dst.", "role": "neutral"},
-            "Pipe": {"signature": "Pipe() (*PipeReader, *PipeWriter)", "description": "Creates synchronized pipe. Propagates taint through the connection.", "role": "neutral"},
+            "ReadAll": {
+                "signature": "ReadAll(r Reader) ([]byte, error)",
+                "description": "Reads all bytes from r. Source when r is http.Request.Body.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Copy": {
+                "signature": "Copy(dst Writer, src Reader) (int64, error)",
+                "description": "Copies src to dst. Propagates taint from src to dst.",
+                "role": "neutral",
+            },
+            "Pipe": {
+                "signature": "Pipe() (*PipeReader, *PipeWriter)",
+                "description": "Creates synchronized pipe. Propagates taint through the connection.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoNetURL": {
         "description": "net/url package. Parse() returns a *url.URL from a string — source of taint when parsing user-supplied URLs. Used in SSRF detection for URL validation.",
         "category": "stdlib",
         "fqns": ["net/url"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Parse": {"signature": "Parse(rawURL string) (*URL, error)", "description": "Parses raw URL. Sanitizer when result host is validated against allowlist.", "role": "sanitizer"},
-            "QueryUnescape": {"signature": "QueryUnescape(s string) (string, error)", "description": "Decodes percent-encoded string. Returns decoded tainted data.", "role": "neutral"},
-            "PathEscape": {"signature": "PathEscape(s string) string", "description": "Escapes string for use in URL path segment. Sanitizes path injection.", "role": "sanitizer"},
-            "QueryEscape": {"signature": "QueryEscape(s string) string", "description": "Escapes string for use in URL query. Sanitizes injection via encoding.", "role": "sanitizer"},
+            "Parse": {
+                "signature": "Parse(rawURL string) (*URL, error)",
+                "description": "Parses raw URL. Sanitizer when result host is validated against allowlist.",
+                "role": "sanitizer",
+            },
+            "QueryUnescape": {
+                "signature": "QueryUnescape(s string) (string, error)",
+                "description": "Decodes percent-encoded string. Returns decoded tainted data.",
+                "role": "neutral",
+            },
+            "PathEscape": {
+                "signature": "PathEscape(s string) string",
+                "description": "Escapes string for use in URL path segment. Sanitizes path injection.",
+                "role": "sanitizer",
+            },
+            "QueryEscape": {
+                "signature": "QueryEscape(s string) string",
+                "description": "Escapes string for use in URL query. Sanitizes injection via encoding.",
+                "role": "sanitizer",
+            },
         },
         "rules_using": [],
     },
-
     "GoNetDial": {
         "description": "net.Dial and net.DialTCP create network connections. Dial() is an SSRF sink when the address is user-controlled.",
         "category": "stdlib",
         "fqns": ["net"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Dial": {"signature": "Dial(network, address string) (Conn, error)", "description": "Creates network connection to address. SSRF sink when address is user-controlled.", "role": "sink", "tracks": [1]},
-            "DialTCP": {"signature": "DialTCP(network string, laddr, raddr *TCPAddr) (*TCPConn, error)", "description": "Creates TCP connection. SSRF sink when raddr is user-controlled.", "role": "sink", "tracks": [2]},
-            "LookupHost": {"signature": "LookupHost(host string) ([]string, error)", "description": "DNS lookup. SSRF vector when host is user-controlled.", "role": "sink", "tracks": [0]},
+            "Dial": {
+                "signature": "Dial(network, address string) (Conn, error)",
+                "description": "Creates network connection to address. SSRF sink when address is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "DialTCP": {
+                "signature": "DialTCP(network string, laddr, raddr *TCPAddr) (*TCPConn, error)",
+                "description": "Creates TCP connection. SSRF sink when raddr is user-controlled.",
+                "role": "sink",
+                "tracks": [2],
+            },
+            "LookupHost": {
+                "signature": "LookupHost(host string) ([]string, error)",
+                "description": "DNS lookup. SSRF vector when host is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoNetTLS": {
         "description": "crypto/tls package. Config.InsecureSkipVerify = true disables certificate verification — a finding for all production code.",
         "category": "stdlib",
         "fqns": ["crypto/tls"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Dial": {"signature": "Dial(network, addr string, config *Config) (*Conn, error)", "description": "Creates TLS connection. Finding when config.InsecureSkipVerify is true.", "role": "sink", "tracks": [2]},
+            "Dial": {
+                "signature": "Dial(network, addr string, config *Config) (*Conn, error)",
+                "description": "Creates TLS connection. Finding when config.InsecureSkipVerify is true.",
+                "role": "sink",
+                "tracks": [2],
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingBase64": {
         "description": "encoding/base64 package. DecodeString() decodes user input — the result is still tainted and must be sanitized before use in sinks.",
         "category": "stdlib",
         "fqns": ["encoding/base64"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "DecodeString": {"signature": "DecodeString(s string) ([]byte, error)", "description": "Decodes base64. Output is tainted if input is tainted — not a sanitizer.", "role": "neutral"},
-            "EncodeToString": {"signature": "EncodeToString(src []byte) string", "description": "Encodes to base64. Does not sanitize — taint propagates.", "role": "neutral"},
+            "DecodeString": {
+                "signature": "DecodeString(s string) ([]byte, error)",
+                "description": "Decodes base64. Output is tainted if input is tainted — not a sanitizer.",
+                "role": "neutral",
+            },
+            "EncodeToString": {
+                "signature": "EncodeToString(src []byte) string",
+                "description": "Encodes to base64. Does not sanitize — taint propagates.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingHex": {
         "description": "encoding/hex package. DecodeString() converts hex to bytes — does not sanitize taint. EncodeToString() may be used as a sanitizer in specific contexts.",
         "category": "stdlib",
         "fqns": ["encoding/hex"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "DecodeString": {"signature": "DecodeString(s string) ([]byte, error)", "description": "Decodes hex string to bytes. Taint propagates through.", "role": "neutral"},
-            "EncodeToString": {"signature": "EncodeToString(src []byte) string", "description": "Encodes bytes to hex. Safe for SQL/command contexts — acts as sanitizer.", "role": "sanitizer"},
+            "DecodeString": {
+                "signature": "DecodeString(s string) ([]byte, error)",
+                "description": "Decodes hex string to bytes. Taint propagates through.",
+                "role": "neutral",
+            },
+            "EncodeToString": {
+                "signature": "EncodeToString(src []byte) string",
+                "description": "Encodes bytes to hex. Safe for SQL/command contexts — acts as sanitizer.",
+                "role": "sanitizer",
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingJSON": {
         "description": "encoding/json package. Unmarshal and Decoder.Decode() are sources of tainted data from JSON input. Marshal() propagates taint to output.",
         "category": "stdlib",
         "fqns": ["encoding/json"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Unmarshal": {"signature": "Unmarshal(data []byte, v any) error", "description": "Decodes JSON into v. v becomes tainted when data comes from user input.", "role": "source", "tracks": [1]},
-            "Marshal": {"signature": "Marshal(v any) ([]byte, error)", "description": "Encodes v to JSON. Propagates taint from v to output bytes.", "role": "neutral"},
+            "Unmarshal": {
+                "signature": "Unmarshal(data []byte, v any) error",
+                "description": "Decodes JSON into v. v becomes tainted when data comes from user input.",
+                "role": "source",
+                "tracks": [1],
+            },
+            "Marshal": {
+                "signature": "Marshal(v any) ([]byte, error)",
+                "description": "Encodes v to JSON. Propagates taint from v to output bytes.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingXML": {
         "description": "encoding/xml package. Unmarshal and Decoder.Decode() are sources. Can also be an XXE sink if xml.Decoder is used without disabling external entity processing.",
         "category": "stdlib",
         "fqns": ["encoding/xml"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Unmarshal": {"signature": "Unmarshal(data []byte, v any) error", "description": "Decodes XML into v. v becomes tainted. Potential XXE if data contains external entities.", "role": "source", "tracks": [1]},
-            "NewDecoder": {"signature": "NewDecoder(r io.Reader) *Decoder", "description": "Creates XML decoder. XXE risk when r is user-controlled and entity expansion not limited.", "role": "sink", "tracks": [0]},
+            "Unmarshal": {
+                "signature": "Unmarshal(data []byte, v any) error",
+                "description": "Decodes XML into v. v becomes tainted. Potential XXE if data contains external entities.",
+                "role": "source",
+                "tracks": [1],
+            },
+            "NewDecoder": {
+                "signature": "NewDecoder(r io.Reader) *Decoder",
+                "description": "Creates XML decoder. XXE risk when r is user-controlled and entity expansion not limited.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingCSV": {
         "description": "encoding/csv package. Reader.Read() and Reader.ReadAll() return user-controlled CSV data as string slices — treat as taint sources.",
         "category": "stdlib",
         "fqns": ["encoding/csv"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Read": {"signature": "Read() ([]string, error)", "description": "Reads one CSV record. Source of tainted strings when reading user-uploaded CSV.", "role": "source", "tracks": ["return"]},
-            "ReadAll": {"signature": "ReadAll() ([][]string, error)", "description": "Reads all CSV records. Source of tainted string slices.", "role": "source", "tracks": ["return"]},
+            "Read": {
+                "signature": "Read() ([]string, error)",
+                "description": "Reads one CSV record. Source of tainted strings when reading user-uploaded CSV.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "ReadAll": {
+                "signature": "ReadAll() ([][]string, error)",
+                "description": "Reads all CSV records. Source of tainted string slices.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingBinary": {
         "description": "encoding/binary package. Read() deserializes binary data from a reader — source of taint when the reader is network or user input.",
         "category": "stdlib",
         "fqns": ["encoding/binary"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Read": {"signature": "Read(r io.Reader, order ByteOrder, data any) error", "description": "Reads binary data into data. data becomes tainted when r is user-controlled.", "role": "source", "tracks": [2]},
+            "Read": {
+                "signature": "Read(r io.Reader, order ByteOrder, data any) error",
+                "description": "Reads binary data into data. data becomes tainted when r is user-controlled.",
+                "role": "source",
+                "tracks": [2],
+            },
         },
         "rules_using": [],
     },
-
     "GoEncodingGob": {
         "description": "encoding/gob package. Decoder.Decode() deserializes arbitrary Go types — unsafe deserialization sink when decoding untrusted data.",
         "category": "stdlib",
         "fqns": ["encoding/gob"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Decode": {"signature": "Decode(e any) error", "description": "Deserializes gob-encoded data. Unsafe deserialization sink when decoding user-controlled data.", "role": "sink", "tracks": [0]},
+            "Decode": {
+                "signature": "Decode(e any) error",
+                "description": "Deserializes gob-encoded data. Unsafe deserialization sink when decoding user-controlled data.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoMimeMultipart": {
         "description": "mime/multipart package. Reader.ReadForm() parses multipart form data including file uploads — source of user-controlled filenames and content.",
         "category": "stdlib",
         "fqns": ["mime/multipart"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "ReadForm": {"signature": "ReadForm(maxMemory int64) (*Form, error)", "description": "Parses entire multipart form including uploads. Source of user-controlled filenames.", "role": "source", "tracks": ["return"]},
-            "NextPart": {"signature": "NextPart() (*Part, error)", "description": "Returns next form part. FileName() on the result is user-controlled.", "role": "source", "tracks": ["return"]},
+            "ReadForm": {
+                "signature": "ReadForm(maxMemory int64) (*Form, error)",
+                "description": "Parses entire multipart form including uploads. Source of user-controlled filenames.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "NextPart": {
+                "signature": "NextPart() (*Part, error)",
+                "description": "Returns next form part. FileName() on the result is user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoHTTPMux": {
         "description": "net/http.ServeMux is the HTTP request multiplexer. Handle() and HandleFunc() register handlers — not typically a security sink but relevant for routing analysis.",
         "category": "stdlib",
         "fqns": ["net/http.ServeMux"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Handle": {"signature": "Handle(pattern string, handler Handler)", "description": "Registers handler for pattern. Not a security sink.", "role": "neutral"},
-            "HandleFunc": {"signature": "HandleFunc(pattern string, handler func(ResponseWriter, *Request))", "description": "Registers handler function. Not a security sink.", "role": "neutral"},
+            "Handle": {
+                "signature": "Handle(pattern string, handler Handler)",
+                "description": "Registers handler for pattern. Not a security sink.",
+                "role": "neutral",
+            },
+            "HandleFunc": {
+                "signature": "HandleFunc(pattern string, handler func(ResponseWriter, *Request))",
+                "description": "Registers handler function. Not a security sink.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoHTTPServer": {
         "description": "net/http.Server. ListenAndServe() without TLS is a finding in server configurations that should enforce HTTPS.",
         "category": "stdlib",
         "fqns": ["net/http.Server"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "ListenAndServe": {"signature": "ListenAndServe() error", "description": "Starts HTTP server without TLS. Finding when used in production without HTTPS redirect.", "role": "sink"},
-            "ListenAndServeTLS": {"signature": "ListenAndServeTLS(certFile, keyFile string) error", "description": "Starts HTTPS server. Safe — preferred over ListenAndServe.", "role": "neutral"},
+            "ListenAndServe": {
+                "signature": "ListenAndServe() error",
+                "description": "Starts HTTP server without TLS. Finding when used in production without HTTPS redirect.",
+                "role": "sink",
+            },
+            "ListenAndServeTLS": {
+                "signature": "ListenAndServeTLS(certFile, keyFile string) error",
+                "description": "Starts HTTPS server. Safe — preferred over ListenAndServe.",
+                "role": "neutral",
+            },
         },
         "rules_using": ["GO-NET-001"],
     },
-
     "GoHTTPCookie": {
         "description": "net/http.Cookie struct. Missing Secure, HttpOnly, or SameSite flags are security findings for session cookies.",
         "category": "stdlib",
         "fqns": ["net/http.Cookie"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "SetCookie": {"signature": "SetCookie(w ResponseWriter, cookie *Cookie)", "description": "Sets HTTP cookie. Finding when cookie.Secure or cookie.HttpOnly is false for session cookies.", "role": "sink", "tracks": [1]},
+            "SetCookie": {
+                "signature": "SetCookie(w ResponseWriter, cookie *Cookie)",
+                "description": "Sets HTTP cookie. Finding when cookie.Secure or cookie.HttpOnly is false for session cookies.",
+                "role": "sink",
+                "tracks": [1],
+            },
         },
         "rules_using": [],
     },
-
     "GoNetSMTP": {
         "description": "net/smtp package. SendMail() and SMTP.Mail() are email injection sinks when headers or body are built from user input without sanitization.",
         "category": "stdlib",
         "fqns": ["net/smtp"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "SendMail": {"signature": "SendMail(addr string, a Auth, from string, to []string, msg []byte) error", "description": "Sends email. Header injection sink when from/to/msg contain user input.", "role": "sink", "tracks": [2]},
+            "SendMail": {
+                "signature": "SendMail(addr string, a Auth, from string, to []string, msg []byte) error",
+                "description": "Sends email. Header injection sink when from/to/msg contain user input.",
+                "role": "sink",
+                "tracks": [2],
+            },
         },
         "rules_using": [],
     },
-
     "GoLog": {
         "description": "log standard library package. Printf, Println, and Fatal variants may log sensitive user input — a finding for privacy/compliance rules.",
         "category": "stdlib",
         "fqns": ["log"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Printf": {"signature": "Printf(format string, v ...any)", "description": "Logs formatted message. Log injection sink when v contains user input with newlines.", "role": "sink", "tracks": [0]},
-            "Println": {"signature": "Println(v ...any)", "description": "Logs values. Potential log injection.", "role": "sink", "tracks": [0]},
-            "Fatal": {"signature": "Fatal(v ...any)", "description": "Logs and calls os.Exit(1). Log injection sink.", "role": "sink", "tracks": [0]},
+            "Printf": {
+                "signature": "Printf(format string, v ...any)",
+                "description": "Logs formatted message. Log injection sink when v contains user input with newlines.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Println": {
+                "signature": "Println(v ...any)",
+                "description": "Logs values. Potential log injection.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Fatal": {
+                "signature": "Fatal(v ...any)",
+                "description": "Logs and calls os.Exit(1). Log injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoLogSlog": {
         "description": "log/slog package (Go 1.21+). Structured logging — Info, Warn, Error are log injection sinks when message or attributes contain unsanitized user input.",
         "category": "stdlib",
         "fqns": ["log/slog"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Info": {"signature": "Info(msg string, args ...any)", "description": "Logs at INFO level. Log injection sink when msg or args contain user input.", "role": "sink", "tracks": [0]},
-            "Warn": {"signature": "Warn(msg string, args ...any)", "description": "Logs at WARN level. Log injection sink.", "role": "sink", "tracks": [0]},
-            "Error": {"signature": "Error(msg string, args ...any)", "description": "Logs at ERROR level. Log injection sink.", "role": "sink", "tracks": [0]},
+            "Info": {
+                "signature": "Info(msg string, args ...any)",
+                "description": "Logs at INFO level. Log injection sink when msg or args contain user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Warn": {
+                "signature": "Warn(msg string, args ...any)",
+                "description": "Logs at WARN level. Log injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Error": {
+                "signature": "Error(msg string, args ...any)",
+                "description": "Logs at ERROR level. Log injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoStrings": {
         "description": "strings package. Contains(), HasPrefix(), ReplaceAll() are used as partial sanitizers. Builder is used to construct tainted strings.",
         "category": "stdlib",
         "fqns": ["strings"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Contains": {"signature": "Contains(s, substr string) bool", "description": "Checks if s contains substr. Used as a partial path containment sanitizer.", "role": "sanitizer"},
-            "HasPrefix": {"signature": "HasPrefix(s, prefix string) bool", "description": "Checks string prefix. Partial sanitizer for path traversal when checking allowed root.", "role": "sanitizer"},
-            "ReplaceAll": {"signature": "ReplaceAll(s, old, new string) string", "description": "Replaces all occurrences. Taint propagates — not a sanitizer by itself.", "role": "neutral"},
-            "TrimSpace": {"signature": "TrimSpace(s string) string", "description": "Trims whitespace. Taint propagates.", "role": "neutral"},
+            "Contains": {
+                "signature": "Contains(s, substr string) bool",
+                "description": "Checks if s contains substr. Used as a partial path containment sanitizer.",
+                "role": "sanitizer",
+            },
+            "HasPrefix": {
+                "signature": "HasPrefix(s, prefix string) bool",
+                "description": "Checks string prefix. Partial sanitizer for path traversal when checking allowed root.",
+                "role": "sanitizer",
+            },
+            "ReplaceAll": {
+                "signature": "ReplaceAll(s, old, new string) string",
+                "description": "Replaces all occurrences. Taint propagates — not a sanitizer by itself.",
+                "role": "neutral",
+            },
+            "TrimSpace": {
+                "signature": "TrimSpace(s string) string",
+                "description": "Trims whitespace. Taint propagates.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoRegexp": {
         "description": "regexp package. FindString() and FindAllString() return tainted matches. MustCompile() with user-controlled pattern is a ReDoS risk.",
         "category": "stdlib",
         "fqns": ["regexp"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Compile": {"signature": "Compile(expr string) (*Regexp, error)", "description": "Compiles regex. ReDoS risk when expr is user-controlled.", "role": "sink", "tracks": [0]},
-            "MustCompile": {"signature": "MustCompile(str string) *Regexp", "description": "Compiles regex, panics on error. ReDoS risk when str is user-controlled.", "role": "sink", "tracks": [0]},
-            "FindString": {"signature": "FindString(s string) string", "description": "Returns leftmost match. Source of tainted string from user input.", "role": "neutral"},
+            "Compile": {
+                "signature": "Compile(expr string) (*Regexp, error)",
+                "description": "Compiles regex. ReDoS risk when expr is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "MustCompile": {
+                "signature": "MustCompile(str string) *Regexp",
+                "description": "Compiles regex, panics on error. ReDoS risk when str is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "FindString": {
+                "signature": "FindString(s string) string",
+                "description": "Returns leftmost match. Source of tainted string from user input.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoMathRand": {
         "description": "math/rand package. Intn(), Float64() and related functions use a deterministic PRNG — a finding when used for cryptographic purposes (tokens, session IDs).",
         "category": "stdlib",
         "fqns": ["math/rand"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Intn": {"signature": "Intn(n int) int", "description": "Returns pseudo-random int. Finding when used to generate security tokens.", "role": "sink"},
-            "Read": {"signature": "Read(p []byte) (n int, err error)", "description": "Fills p with pseudo-random bytes. Finding when used as cryptographic randomness.", "role": "sink"},
+            "Intn": {
+                "signature": "Intn(n int) int",
+                "description": "Returns pseudo-random int. Finding when used to generate security tokens.",
+                "role": "sink",
+            },
+            "Read": {
+                "signature": "Read(p []byte) (n int, err error)",
+                "description": "Fills p with pseudo-random bytes. Finding when used as cryptographic randomness.",
+                "role": "sink",
+            },
         },
         "rules_using": [],
     },
-
     "GoCryptoRand": {
         "description": "crypto/rand package. The Reader is the cryptographically secure random source — use this instead of math/rand for tokens and session IDs.",
         "category": "stdlib",
         "fqns": ["crypto/rand"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Read": {"signature": "Read(b []byte) (n int, err error)", "description": "Fills b with cryptographically secure random bytes. Preferred over math/rand.Read.", "role": "neutral"},
-            "Int": {"signature": "Int(rand io.Reader, max *big.Int) (*big.Int, error)", "description": "Returns cryptographically secure random int. Safe for security purposes.", "role": "neutral"},
+            "Read": {
+                "signature": "Read(b []byte) (n int, err error)",
+                "description": "Fills b with cryptographically secure random bytes. Preferred over math/rand.Read.",
+                "role": "neutral",
+            },
+            "Int": {
+                "signature": "Int(rand io.Reader, max *big.Int) (*big.Int, error)",
+                "description": "Returns cryptographically secure random int. Safe for security purposes.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoSync": {
         "description": "sync package. Mutex, RWMutex, Once — not security sinks but relevant for race condition detection rules.",
         "category": "stdlib",
         "fqns": ["sync"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Lock": {"signature": "Lock()", "description": "Acquires mutex. Missing unlock is a resource leak finding.", "role": "neutral"},
-            "Unlock": {"signature": "Unlock()", "description": "Releases mutex. Must be called, typically via defer.", "role": "neutral"},
+            "Lock": {
+                "signature": "Lock()",
+                "description": "Acquires mutex. Missing unlock is a resource leak finding.",
+                "role": "neutral",
+            },
+            "Unlock": {
+                "signature": "Unlock()",
+                "description": "Releases mutex. Must be called, typically via defer.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoSyncMap": {
         "description": "sync.Map provides a concurrent map. Load() and Store() are relevant for data flow tracking in concurrent handlers where shared state is modified.",
         "category": "stdlib",
         "fqns": ["sync.Map"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Load": {"signature": "Load(key any) (value any, ok bool)", "description": "Loads value from map. Source of taint when map stores user-controlled data.", "role": "source", "tracks": ["return"]},
-            "Store": {"signature": "Store(key, value any)", "description": "Stores value in map. Propagates taint from value.", "role": "neutral"},
+            "Load": {
+                "signature": "Load(key any) (value any, ok bool)",
+                "description": "Loads value from map. Source of taint when map stores user-controlled data.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Store": {
+                "signature": "Store(key, value any)",
+                "description": "Stores value in map. Propagates taint from value.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoReflect": {
         "description": "reflect package. reflect.ValueOf() and reflect.New() with user-controlled type strings enable dynamic code execution — a finding for unsafe reflection rules.",
         "category": "stdlib",
         "fqns": ["reflect"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "ValueOf": {"signature": "ValueOf(i any) Value", "description": "Returns Value wrapping i. Taint propagates through reflect operations.", "role": "neutral"},
-            "New": {"signature": "New(typ Type) Value", "description": "Creates new zero value of type. Unsafe when type is derived from user input.", "role": "sink", "tracks": [0]},
+            "ValueOf": {
+                "signature": "ValueOf(i any) Value",
+                "description": "Returns Value wrapping i. Taint propagates through reflect operations.",
+                "role": "neutral",
+            },
+            "New": {
+                "signature": "New(typ Type) Value",
+                "description": "Creates new zero value of type. Unsafe when type is derived from user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoRuntime": {
         "description": "runtime package. SetFinalizer(), GOMAXPROCS() — not typical security sinks but relevant for resource exhaustion rules.",
         "category": "stdlib",
         "fqns": ["runtime"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "GOMAXPROCS": {"signature": "GOMAXPROCS(n int) int", "description": "Sets max OS threads. DoS risk when n is derived from user input without bounds check.", "role": "sink", "tracks": [0]},
-            "Stack": {"signature": "Stack(buf []byte, all bool) int", "description": "Writes goroutine stack trace. Information disclosure if written to user-visible output.", "role": "source"},
+            "GOMAXPROCS": {
+                "signature": "GOMAXPROCS(n int) int",
+                "description": "Sets max OS threads. DoS risk when n is derived from user input without bounds check.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Stack": {
+                "signature": "Stack(buf []byte, all bool) int",
+                "description": "Writes goroutine stack trace. Information disclosure if written to user-visible output.",
+                "role": "source",
+            },
         },
         "rules_using": [],
     },
-
     "GoOSUser": {
         "description": "os/user package. Lookup() and LookupId() resolve usernames — source of OS-level user data. Relevant for privilege escalation analysis.",
         "category": "stdlib",
         "fqns": ["os/user"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Lookup": {"signature": "Lookup(username string) (*User, error)", "description": "Looks up user by name. SSRF-like sink if username is user-controlled.", "role": "sink", "tracks": [0]},
-            "Current": {"signature": "Current() (*User, error)", "description": "Returns current OS user. Source of sensitive system information.", "role": "source", "tracks": ["return"]},
+            "Lookup": {
+                "signature": "Lookup(username string) (*User, error)",
+                "description": "Looks up user by name. SSRF-like sink if username is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Current": {
+                "signature": "Current() (*User, error)",
+                "description": "Returns current OS user. Source of sensitive system information.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoSyscall": {
         "description": "syscall package. Exec(), RawSyscall(), and socket operations are low-level command and network injection sinks.",
         "category": "stdlib",
         "fqns": ["syscall"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Exec": {"signature": "Exec(argv0 string, argv []string, envv []string) error", "description": "Executes program directly. Command injection sink when argv is user-controlled.", "role": "sink", "tracks": [0]},
-            "Getenv": {"signature": "Getenv(key string) (value string, found bool)", "description": "Gets environment variable. Source of external data.", "role": "source", "tracks": ["return"]},
+            "Exec": {
+                "signature": "Exec(argv0 string, argv []string, envv []string) error",
+                "description": "Executes program directly. Command injection sink when argv is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Getenv": {
+                "signature": "Getenv(key string) (value string, found bool)",
+                "description": "Gets environment variable. Source of external data.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoIOFS": {
         "description": "io/fs package (Go 1.16+). FS interface and ReadFile() operate on filesystem abstractions — path traversal sinks when path is user-controlled.",
         "category": "stdlib",
         "fqns": ["io/fs"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "ReadFile": {"signature": "ReadFile(fsys FS, name string) ([]byte, error)", "description": "Reads file from FS. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [1]},
-            "Stat": {"signature": "Stat(fsys FS, name string) (FileInfo, error)", "description": "Stats file. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [1]},
+            "ReadFile": {
+                "signature": "ReadFile(fsys FS, name string) ([]byte, error)",
+                "description": "Reads file from FS. Path traversal sink when name is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Stat": {
+                "signature": "Stat(fsys FS, name string) (FileInfo, error)",
+                "description": "Stats file. Path traversal sink when name is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
         },
         "rules_using": [],
     },
-
     "GoHTMLTemplate": {
         "description": "html/template package — the safe version of text/template. Auto-escapes context-appropriately. HTML(), JS(), URL() types are escape bypasses when used with user input.",
         "category": "stdlib",
         "fqns": ["html/template"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "HTML": {"signature": "HTML(string)", "description": "Marks string as safe HTML — bypasses auto-escaping. XSS sink when value is user-controlled.", "role": "sink", "tracks": [0]},
-            "JS": {"signature": "JS(string)", "description": "Marks string as safe JavaScript — bypasses auto-escaping. XSS sink.", "role": "sink", "tracks": [0]},
-            "URL": {"signature": "URL(string)", "description": "Marks string as safe URL — bypasses sanitization. Open redirect sink.", "role": "sink", "tracks": [0]},
+            "HTML": {
+                "signature": "HTML(string)",
+                "description": "Marks string as safe HTML — bypasses auto-escaping. XSS sink when value is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "JS": {
+                "signature": "JS(string)",
+                "description": "Marks string as safe JavaScript — bypasses auto-escaping. XSS sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "URL": {
+                "signature": "URL(string)",
+                "description": "Marks string as safe URL — bypasses sanitization. Open redirect sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": ["GO-XSS-002"],
     },
-
     "GoNetHTTP": {
         "description": "Package-level net/http functions: Get(), Post(), Head(). SSRF sinks when the URL argument is derived from user input.",
         "category": "stdlib",
         "fqns": ["net/http"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Get": {"signature": "Get(url string) (*Response, error)", "description": "Package-level HTTP GET. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
-            "Post": {"signature": "Post(url, contentType string, body io.Reader) (*Response, error)", "description": "Package-level HTTP POST. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
-            "Head": {"signature": "Head(url string) (*Response, error)", "description": "Package-level HTTP HEAD. SSRF sink.", "role": "sink", "tracks": [0]},
-            "Redirect": {"signature": "Redirect(w ResponseWriter, r *Request, url string, code int)", "description": "Sends redirect response. Open redirect sink when url is user-controlled.", "role": "sink", "tracks": [2]},
+            "Get": {
+                "signature": "Get(url string) (*Response, error)",
+                "description": "Package-level HTTP GET. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Post": {
+                "signature": "Post(url, contentType string, body io.Reader) (*Response, error)",
+                "description": "Package-level HTTP POST. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Head": {
+                "signature": "Head(url string) (*Response, error)",
+                "description": "Package-level HTTP HEAD. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Redirect": {
+                "signature": "Redirect(w ResponseWriter, r *Request, url string, code int)",
+                "description": "Sends redirect response. Open redirect sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [2],
+            },
         },
         "rules_using": ["GO-SSRF-002", "GO-REDIRECT-001"],
     },
-
     "GoArchiveTar": {
         "description": "archive/tar package. Reader.Next() returns headers with user-controlled filenames — Zip Slip path traversal sink when extracting to filesystem.",
         "category": "stdlib",
         "fqns": ["archive/tar"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Next": {"signature": "Next() (*Header, error)", "description": "Advances to next entry. Header.Name is user-controlled — Zip Slip path traversal sink.", "role": "source", "tracks": ["return"]},
+            "Next": {
+                "signature": "Next() (*Header, error)",
+                "description": "Advances to next entry. Header.Name is user-controlled — Zip Slip path traversal sink.",
+                "role": "source",
+                "tracks": ["return"],
+            },
         },
         "rules_using": [],
     },
-
     "GoArchiveZip": {
         "description": "archive/zip package. OpenReader() and File[].Name are sources of user-controlled filenames — Zip Slip path traversal when extracting.",
         "category": "stdlib",
         "fqns": ["archive/zip"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "OpenReader": {"signature": "OpenReader(name string) (*ReadCloser, error)", "description": "Opens zip file for reading. File.Name fields are user-controlled — Zip Slip source.", "role": "source"},
+            "OpenReader": {
+                "signature": "OpenReader(name string) (*ReadCloser, error)",
+                "description": "Opens zip file for reading. File.Name fields are user-controlled — Zip Slip source.",
+                "role": "source",
+            },
         },
         "rules_using": [],
     },
-
     "GoDatabaseSQL": {
         "description": "Alias reference: database/sql.Stmt. Prepared statement execution methods — safe when using ? placeholders, sink when mixing with string concatenation.",
         "category": "stdlib",
         "fqns": ["database/sql.Stmt"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Exec": {"signature": "Exec(args ...any) (Result, error)", "description": "Executes prepared statement. Safe with parameterized args.", "role": "neutral"},
-            "Query": {"signature": "Query(args ...any) (*Rows, error)", "description": "Executes parameterized query. Safe with ? placeholders.", "role": "neutral"},
-            "QueryRow": {"signature": "QueryRow(args ...any) *Row", "description": "Executes parameterized single-row query. Safe with ? placeholders.", "role": "neutral"},
+            "Exec": {
+                "signature": "Exec(args ...any) (Result, error)",
+                "description": "Executes prepared statement. Safe with parameterized args.",
+                "role": "neutral",
+            },
+            "Query": {
+                "signature": "Query(args ...any) (*Rows, error)",
+                "description": "Executes parameterized query. Safe with ? placeholders.",
+                "role": "neutral",
+            },
+            "QueryRow": {
+                "signature": "QueryRow(args ...any) *Row",
+                "description": "Executes parameterized single-row query. Safe with ? placeholders.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoTime": {
         "description": "time package. time.Parse() with user-controlled layout strings is a denial-of-service risk (algorithmic complexity). Not a typical injection sink.",
         "category": "stdlib",
         "fqns": ["time"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Parse": {"signature": "Parse(layout, value string) (Time, error)", "description": "Parses time string. Not an injection sink but DoS risk with user-controlled layout.", "role": "neutral"},
-            "After": {"signature": "After(d Duration) <-chan Time", "description": "Returns channel that fires after d. DoS risk when d is user-controlled without bounds.", "role": "neutral"},
+            "Parse": {
+                "signature": "Parse(layout, value string) (Time, error)",
+                "description": "Parses time string. Not an injection sink but DoS risk with user-controlled layout.",
+                "role": "neutral",
+            },
+            "After": {
+                "signature": "After(d Duration) <-chan Time",
+                "description": "Returns channel that fires after d. DoS risk when d is user-controlled without bounds.",
+                "role": "neutral",
+            },
         },
         "rules_using": [],
     },
-
     "GoPlugin": {
         "description": "plugin package. Open() loads a shared library — code execution sink when the plugin path is user-controlled.",
         "category": "stdlib",
         "fqns": ["plugin"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Open": {"signature": "Open(path string) (*Plugin, error)", "description": "Loads a shared object plugin. Code execution sink when path is user-controlled.", "role": "sink", "tracks": [0]},
+            "Open": {
+                "signature": "Open(path string) (*Plugin, error)",
+                "description": "Loads a shared object plugin. Code execution sink when path is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoCryptoHMAC": {
         "description": "crypto/hmac package. New() creates HMAC with a key. Equal() provides constant-time comparison. Using == instead of Equal() for MAC verification is a timing attack.",
         "category": "stdlib",
         "fqns": ["crypto/hmac"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "New": {"signature": "New(h func() hash.Hash, key []byte) hash.Hash", "description": "Creates new HMAC. Safe when using strong hash (sha256, sha512).", "role": "neutral"},
-            "Equal": {"signature": "Equal(mac1, mac2 []byte) bool", "description": "Constant-time comparison. Use this instead of bytes.Equal for MAC verification.", "role": "sanitizer"},
+            "New": {
+                "signature": "New(h func() hash.Hash, key []byte) hash.Hash",
+                "description": "Creates new HMAC. Safe when using strong hash (sha256, sha512).",
+                "role": "neutral",
+            },
+            "Equal": {
+                "signature": "Equal(mac1, mac2 []byte) bool",
+                "description": "Constant-time comparison. Use this instead of bytes.Equal for MAC verification.",
+                "role": "sanitizer",
+            },
         },
         "rules_using": [],
     },
-
     "GoCryptoAES": {
         "description": "crypto/aes package. NewCipher() with a weak mode (ECB, CBC without IV) is a cryptographic weakness finding.",
         "category": "stdlib",
         "fqns": ["crypto/aes"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "NewCipher": {"signature": "NewCipher(key []byte) (cipher.Block, error)", "description": "Creates AES block cipher. Finding when used in ECB mode (no IV).", "role": "sink", "tracks": [0]},
+            "NewCipher": {
+                "signature": "NewCipher(key []byte) (cipher.Block, error)",
+                "description": "Creates AES block cipher. Finding when used in ECB mode (no IV).",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     "GoCipherGCM": {
         "description": "cipher package. NewGCMWithNonceSize() and AEAD.Seal() — finding when nonce is reused or predictable.",
         "category": "stdlib",
         "fqns": ["crypto/cipher"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "NewGCM": {"signature": "NewGCM(cipher Block) (AEAD, error)", "description": "Creates GCM mode cipher. Finding when nonce is not cryptographically random.", "role": "neutral"},
-            "Seal": {"signature": "Seal(dst, nonce, plaintext, additionalData []byte) []byte", "description": "Encrypts and authenticates. Finding when nonce is reused.", "role": "sink", "tracks": [1]},
+            "NewGCM": {
+                "signature": "NewGCM(cipher Block) (AEAD, error)",
+                "description": "Creates GCM mode cipher. Finding when nonce is not cryptographically random.",
+                "role": "neutral",
+            },
+            "Seal": {
+                "signature": "Seal(dst, nonce, plaintext, additionalData []byte) []byte",
+                "description": "Encrypts and authenticates. Finding when nonce is reused.",
+                "role": "sink",
+                "tracks": [1],
+            },
         },
         "rules_using": [],
     },
-
     "GoX509": {
         "description": "crypto/x509 package. Certificate.Verify() is the TLS chain validation entry point. Skipping verification or using empty VerifyOptions is a finding.",
         "category": "stdlib",
         "fqns": ["crypto/x509"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Verify": {"signature": "Verify(opts VerifyOptions) ([][]*Certificate, error)", "description": "Verifies certificate chain. Finding when opts is empty (no root CA check).", "role": "sink", "tracks": [0]},
-            "ParseCertificate": {"signature": "ParseCertificate(asn1Data []byte) (*Certificate, error)", "description": "Parses DER-encoded certificate. Source of cert data from network input.", "role": "source"},
+            "Verify": {
+                "signature": "Verify(opts VerifyOptions) ([][]*Certificate, error)",
+                "description": "Verifies certificate chain. Finding when opts is empty (no root CA check).",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "ParseCertificate": {
+                "signature": "ParseCertificate(asn1Data []byte) (*Certificate, error)",
+                "description": "Parses DER-encoded certificate. Source of cert data from network input.",
+                "role": "source",
+            },
         },
         "rules_using": [],
     },
-
     "GoGobDecoder": {
         "description": "encoding/gob.Decoder. Decode() deserializes arbitrary Go values — unsafe deserialization when decoding user-supplied bytes.",
         "category": "stdlib",
         "fqns": ["encoding/gob.Decoder"],
         "go_mod": "// standard library — no go.mod entry required",
         "methods": {
-            "Decode": {"signature": "Decode(e any) error", "description": "Deserializes next gob value into e. Unsafe deserialization sink.", "role": "sink", "tracks": [0]},
-            "DecodeValue": {"signature": "DecodeValue(v reflect.Value) error", "description": "Decodes into reflect.Value. Unsafe deserialization sink.", "role": "sink", "tracks": [0]},
+            "Decode": {
+                "signature": "Decode(e any) error",
+                "description": "Deserializes next gob value into e. Unsafe deserialization sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "DecodeValue": {
+                "signature": "DecodeValue(v reflect.Value) error",
+                "description": "Decodes into reflect.Value. Unsafe deserialization sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Web frameworks — third-party routers
     # =====================================================================
-
     "GoChiRouter": {
         "description": (
             "Chi HTTP router (chi.Router and chi.Mux). Path parameters extracted via URLParam "
@@ -1160,7 +1636,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-GORM-SQLI-001"],
     },
-
     "GoGorillaMuxRouter": {
         "description": (
             "Gorilla mux HTTP router (mux.Router). Path variables extracted via mux.Vars(r) are "
@@ -1202,11 +1677,9 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Databases — third-party drivers
     # =====================================================================
-
     "GoPgxConn": {
         "description": (
             "pgx PostgreSQL driver. Connection and Pool types expose Query/Exec/QueryRow that "
@@ -1267,7 +1740,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": ["GO-SQLI-002"],
     },
-
     "GoMongoCollection": {
         "description": (
             "MongoDB Go driver Collection and Client. Queries built from user input via "
@@ -1328,7 +1800,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     "GoRedisClient": {
         "description": (
             "go-redis Client for Redis operations. Most Redis commands are typed and safe, but "
@@ -1377,11 +1848,9 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Serialization & config — third-party
     # =====================================================================
-
     "GoYAMLDecoder": {
         "description": (
             "gopkg.in/yaml.v3 Decoder for YAML deserialization. Decode() hydrates arbitrary Go "
@@ -1406,7 +1875,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     "GoViperConfig": {
         "description": (
             "github.com/spf13/viper is the de-facto Go configuration library. Values returned from "
@@ -1461,11 +1929,9 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # gRPC
     # =====================================================================
-
     "GoGRPCServerTransportStream": {
         "description": (
             "google.golang.org/grpc.ServerTransportStream exposes transport-layer metadata for "
@@ -1503,11 +1969,9 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # stdlib (late additions)
     # =====================================================================
-
     "GoIO": {
         "description": (
             "The io standard library package. ReadAll and Copy move data from readers — sources when "
@@ -1556,7 +2020,6 @@ def detect_gorm_sqli_concat():
         },
         "rules_using": [],
     },
-
     "GoJSON": {
         "description": (
             "encoding/json for JSON encode/decode. Unmarshal and Decoder.Decode deserialize JSON into "

--- a/python-sdk/codepathfinder/go_rule_meta.py
+++ b/python-sdk/codepathfinder/go_rule_meta.py
@@ -1,0 +1,1608 @@
+# go_rule_meta.py — Companion metadata for go_rule.py SDK classes.
+# Read by scripts/generate_sdk_manifest.py to produce sdk-manifest.json.
+# Keep in sync with go_rule.py: if you add a class there, add metadata here.
+
+SDK_META: dict = {
+    "GoGinContext": {
+        "description": (
+            "Represents gin.Context, the primary request/response carrier in the Gin HTTP framework. "
+            "All user-input accessors (Query, Param, PostForm, etc.) are taint sources. "
+            "Output methods (JSON, String, Redirect) are sinks for XSS and open-redirect rules."
+        ),
+        "category": "web-frameworks",
+        "go_mod": "require github.com/gin-gonic/gin v1.9.1",
+        "methods": {
+            "Query": {
+                "signature": "Query(key string) string",
+                "description": "Returns URL query parameter value for the given key. Empty string if missing.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "DefaultQuery": {
+                "signature": "DefaultQuery(key, defaultValue string) string",
+                "description": "Returns URL query parameter value, or defaultValue if the key is absent.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Param": {
+                "signature": "Param(key string) string",
+                "description": "Returns URL path parameter (e.g. /user/:id). Always non-empty if route matched.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "PostForm": {
+                "signature": "PostForm(key string) string",
+                "description": "Returns POST form value for the given key from application/x-www-form-urlencoded body.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "GetHeader": {
+                "signature": "GetHeader(key string) string",
+                "description": "Returns HTTP request header value. User-controlled for headers like X-Forwarded-For.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "ShouldBindJSON": {
+                "signature": "ShouldBindJSON(obj any) error",
+                "description": "Deserializes JSON request body into obj. obj becomes tainted after binding.",
+                "role": "source",
+                "tracks": [0],
+            },
+            "Cookie": {
+                "signature": "Cookie(name string) (string, error)",
+                "description": "Returns the named cookie value. Cookies are user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "JSON": {
+                "signature": "JSON(code int, obj any)",
+                "description": "Serializes obj to JSON and writes to response. Sink for reflected XSS if obj contains raw HTML.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Redirect": {
+                "signature": "Redirect(code int, location string)",
+                "description": "Redirects to location. Sink for open-redirect if location comes from user input.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "example_rule": """\
+from codepathfinder.go_rule import GoGinContext, GoGormDB, GoStrconv
+from codepathfinder import flows
+from codepathfinder.presets import PropagationPresets
+from codepathfinder.go_decorators import go_rule
+
+@go_rule(
+    id="GO-GORM-SQLI-001",
+    severity="CRITICAL",
+    cwe="CWE-89",
+    owasp="A03:2021",
+    message="User input flows into GORM Raw()/Exec(). Use parameterized queries.",
+)
+def detect_gorm_sqli():
+    return flows(
+        from_sources=[
+            GoGinContext.method("Query", "Param", "PostForm", "ShouldBindJSON"),
+        ],
+        to_sinks=[
+            GoGormDB.method("Raw", "Exec"),
+        ],
+        sanitized_by=[
+            GoStrconv.method("Atoi", "ParseInt", "ParseFloat"),
+        ],
+        propagates_through=PropagationPresets.standard(),
+        scope="global",
+    )
+""",
+        "rules_using": ["GO-GORM-SQLI-001", "GO-GORM-SQLI-002", "GO-SEC-001", "GO-SQLI-003",
+                        "GO-SSRF-001", "GO-SEC-002", "GO-XSS-001", "GO-PATH-001", "GO-REDIRECT-001"],
+    },
+
+    "GoEchoContext": {
+        "description": (
+            "Represents echo.Context in the Echo HTTP framework (v4). "
+            "Provides typed accessors for all parts of the HTTP request. "
+            "All input methods are taint sources."
+        ),
+        "category": "web-frameworks",
+        "go_mod": "require github.com/labstack/echo/v4 v4.11.4",
+        "methods": {
+            "QueryParam": {
+                "signature": "QueryParam(name string) string",
+                "description": "Returns URL query parameter value by name.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "FormValue": {
+                "signature": "FormValue(name string) string",
+                "description": "Returns POST form value. Reads application/x-www-form-urlencoded or multipart/form-data.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Param": {
+                "signature": "Param(name string) string",
+                "description": "Returns URL path parameter value.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Bind": {
+                "signature": "Bind(i any) error",
+                "description": "Deserializes request body into i based on Content-Type. i becomes tainted.",
+                "role": "source",
+                "tracks": [0],
+            },
+            "Redirect": {
+                "signature": "Redirect(code int, url string) error",
+                "description": "Redirects to url. Sink for open-redirect.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": ["GO-SEC-001", "GO-SEC-002", "GO-SSRF-001"],
+    },
+
+    "GoFiberCtx": {
+        "description": (
+            "Represents fiber.Ctx in the Fiber HTTP framework (v2), inspired by Express.js. "
+            "Zero-allocation design. All input methods are taint sources."
+        ),
+        "category": "web-frameworks",
+        "go_mod": "require github.com/gofiber/fiber/v2 v2.52.0",
+        "methods": {
+            "Params": {
+                "signature": "Params(key string, defaultValue ...string) string",
+                "description": "Returns URL path parameter value.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Query": {
+                "signature": "Query(key string, defaultValue ...string) string",
+                "description": "Returns URL query parameter value.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "FormValue": {
+                "signature": "FormValue(key string, defaultValue ...string) string",
+                "description": "Returns POST form value.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "BodyParser": {
+                "signature": "BodyParser(out any) error",
+                "description": "Parses request body into out. out becomes tainted.",
+                "role": "source",
+                "tracks": [0],
+            },
+            "Redirect": {
+                "signature": "Redirect(location string, status ...int) error",
+                "description": "Redirects to location. Sink for open-redirect.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": ["GO-SEC-001", "GO-SEC-002"],
+    },
+
+    "GoGormDB": {
+        "description": (
+            "Represents gorm.DB, the primary database handle in GORM v2. "
+            "Raw(), Exec(), and Where() with string arguments are SQL injection sinks "
+            "when called with unsanitized user input."
+        ),
+        "category": "databases",
+        "go_mod": "require gorm.io/gorm v1.25.5",
+        "methods": {
+            "Raw": {
+                "signature": "Raw(sql string, values ...any) *DB",
+                "description": "Executes raw SQL. The sql string is an injection sink when built with user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Exec": {
+                "signature": "Exec(sql string, values ...any) *DB",
+                "description": "Executes raw SQL DML. Same risk as Raw().",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Where": {
+                "signature": "Where(query any, args ...any) *DB",
+                "description": "Adds WHERE clause. Sink when query is a string with user input concatenated.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Find": {
+                "signature": "Find(dest any, conds ...any) *DB",
+                "description": "Executes SELECT with optional conditions. Safe when using struct conditions.",
+                "role": "neutral",
+            },
+            "Create": {
+                "signature": "Create(value any) *DB",
+                "description": "Inserts record. Safe when using struct with parameterized fields.",
+                "role": "neutral",
+            },
+        },
+        "example_rule": """\
+from codepathfinder.go_rule import GoGinContext, GoGormDB, GoStrconv
+from codepathfinder import flows
+from codepathfinder.presets import PropagationPresets
+from codepathfinder.go_decorators import go_rule
+
+@go_rule(
+    id="GO-GORM-SQLI-002",
+    severity="HIGH",
+    cwe="CWE-89",
+    owasp="A03:2021",
+    message="String concatenation in GORM query builder. Use ? placeholders.",
+)
+def detect_gorm_sqli_concat():
+    return flows(
+        from_sources=[
+            GoGinContext.method("Query", "Param", "PostForm"),
+        ],
+        to_sinks=[
+            GoGormDB.method("Where", "Having", "Order"),
+        ],
+        propagates_through=PropagationPresets.standard(),
+        scope="global",
+    )
+""",
+        "rules_using": ["GO-GORM-SQLI-001", "GO-GORM-SQLI-002"],
+    },
+
+    "GoSqlxDB": {
+        "description": (
+            "Represents sqlx.DB and sqlx.Tx from the sqlx library, which extends database/sql "
+            "with struct scanning. Unsafe query methods (QueryUnsafe, GetUnsafe) and raw "
+            "string methods are injection sinks."
+        ),
+        "category": "databases",
+        "go_mod": "require github.com/jmoiron/sqlx v1.3.5",
+        "methods": {
+            "Query": {
+                "signature": "Query(query string, args ...any) (*sql.Rows, error)",
+                "description": "Executes raw SQL query. Sink when query string contains user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Exec": {
+                "signature": "Exec(query string, args ...any) (sql.Result, error)",
+                "description": "Executes raw SQL DML. Sink when query string contains user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Queryx": {
+                "signature": "Queryx(query string, args ...any) (*sqlx.Rows, error)",
+                "description": "Like Query but returns sqlx.Rows. Same injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Get": {
+                "signature": "Get(dest any, query string, args ...any) error",
+                "description": "Executes query and scans result into dest. query is an injection sink.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": ["GO-SQLI-003"],
+    },
+
+    "GoSQLDB": {
+        "description": (
+            "Represents database/sql.DB and database/sql.Tx from the Go standard library. "
+            "Query(), Exec(), and Prepare() are SQL injection sinks when the query "
+            "string is built from user input instead of using ? placeholders."
+        ),
+        "category": "stdlib",
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Query": {
+                "signature": "Query(query string, args ...any) (*Rows, error)",
+                "description": "Executes parameterized SELECT. Sink when query is built via string concatenation.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "QueryRow": {
+                "signature": "QueryRow(query string, args ...any) *Row",
+                "description": "Executes parameterized SELECT returning one row. Same injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Exec": {
+                "signature": "Exec(query string, args ...any) (Result, error)",
+                "description": "Executes parameterized DML. Sink when query contains user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Prepare": {
+                "signature": "Prepare(query string) (*Stmt, error)",
+                "description": "Creates prepared statement. Sink when query string is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": ["GO-SEC-001"],
+    },
+
+    "GoStrconv": {
+        "description": (
+            "The strconv standard library package. Atoi, ParseInt, ParseFloat, and related "
+            "functions serve as sanitizers in SQL injection and path traversal rules — "
+            "converting a string to a numeric type eliminates injection risk."
+        ),
+        "category": "stdlib",
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Atoi": {
+                "signature": "Atoi(s string) (int, error)",
+                "description": "Converts string to int. Use as sanitizer: parsed ints cannot inject SQL.",
+                "role": "sanitizer",
+            },
+            "ParseInt": {
+                "signature": "ParseInt(s string, base int, bitSize int) (int64, error)",
+                "description": "Parses string as integer with given base and bit size. Sanitizes SQL/path injection.",
+                "role": "sanitizer",
+            },
+            "ParseFloat": {
+                "signature": "ParseFloat(s string, bitSize int) (float64, error)",
+                "description": "Parses string as float. Sanitizes injection via numeric validation.",
+                "role": "sanitizer",
+            },
+            "ParseBool": {
+                "signature": "ParseBool(str string) (bool, error)",
+                "description": "Parses \"true\"/\"false\" string to bool. Sanitizes by constraining to boolean domain.",
+                "role": "sanitizer",
+            },
+        },
+        "rules_using": ["GO-GORM-SQLI-001", "GO-SEC-001"],
+    },
+
+    "GoOSExec": {
+        "description": (
+            "The os/exec standard library package. exec.Command and exec.CommandContext "
+            "are command injection sinks when any argument comes from user-controlled input. "
+            "Most dangerous with shell=true-equivalent patterns."
+        ),
+        "category": "stdlib",
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Command": {
+                "signature": "Command(name string, arg ...string) *Cmd",
+                "description": "Creates Cmd to run name with args. name and any arg are injection sinks.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "CommandContext": {
+                "signature": "CommandContext(ctx context.Context, name string, arg ...string) *Cmd",
+                "description": "Like Command but with context for cancellation. Same injection risk.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": ["GO-SEC-002"],
+    },
+
+    "GoHTTPRequest": {
+        "description": (
+            "Represents *http.Request from the net/http standard library. "
+            "Used in standard http.HandlerFunc handlers. FormValue, URL.Query(), "
+            "Header.Get(), and Body are all taint sources."
+        ),
+        "category": "stdlib",
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "FormValue": {
+                "signature": "FormValue(key string) string",
+                "description": "Returns the first value for the named POST or query-string field.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "PostFormValue": {
+                "signature": "PostFormValue(key string) string",
+                "description": "Returns the first value for the named POST body field only.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Header": {
+                "signature": "Header.Get(key string) string",
+                "description": "Returns the HTTP header value. User-controlled headers like X-Forwarded-For.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "URL": {
+                "signature": "URL.Query().Get(key string) string",
+                "description": "URL query string accessor. Equivalent to FormValue for GET params.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": ["GO-SEC-001", "GO-SEC-002", "GO-XSS-001", "GO-SSRF-002"],
+    },
+
+    "GoRestyClient": {
+        "description": (
+            "Represents resty.Client and resty.Request from go-resty/resty v2. "
+            "SetURL, Execute, Get, Post etc. are SSRF sinks when the URL comes "
+            "from user-controlled input."
+        ),
+        "category": "http-clients",
+        "go_mod": "require github.com/go-resty/resty/v2 v2.11.0",
+        "methods": {
+            "SetURL": {
+                "signature": "SetURL(url string) *Request",
+                "description": "Sets the request URL. Sink for SSRF when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Get": {
+                "signature": "Get(url string) (*Response, error)",
+                "description": "Makes GET request to url. Sink for SSRF.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Post": {
+                "signature": "Post(url string) (*Response, error)",
+                "description": "Makes POST request to url. Sink for SSRF.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Execute": {
+                "signature": "Execute(method, url string) (*Response, error)",
+                "description": "Makes HTTP request with given method and url. Sink for SSRF.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": ["GO-SSRF-001"],
+    },
+
+    "GoJWTToken": {
+        "description": (
+            "Represents jwt.Token from github.com/golang-jwt/jwt v5. "
+            "The Valid field and Parse function are critical — rules detect patterns "
+            "where signature verification is skipped."
+        ),
+        "category": "auth-config",
+        "go_mod": "require github.com/golang-jwt/jwt/v5 v5.2.0",
+        "methods": {
+            "ParseWithClaims": {
+                "signature": "ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc, options ...ParserOption) (*Token, error)",
+                "description": "Parses and validates JWT. keyFunc returning nil skips signature verification.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Valid": {
+                "signature": "Valid bool (field)",
+                "description": "True if the token was validated. Accessing claims without checking Valid is a finding.",
+                "role": "neutral",
+            },
+        },
+        "rules_using": ["GO-JWT-002"],
+    },
+
+    # ── stdlib already in go_rule.py but not yet in meta ──────────────────────
+
+    "GoHTTPResponseWriter": {
+        "description": "Represents net/http.ResponseWriter. Write() and WriteString() are XSS sinks when writing unsanitized user input into the HTTP response body.",
+        "category": "stdlib",
+        "fqns": ["net/http.ResponseWriter"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Write": {"signature": "Write(b []byte) (int, error)", "description": "Writes raw bytes to response. XSS sink when b contains user input.", "role": "sink", "tracks": [0]},
+            "WriteHeader": {"signature": "WriteHeader(statusCode int)", "description": "Sets HTTP status code. Not a taint sink.", "role": "neutral"},
+        },
+        "rules_using": ["GO-XSS-001"],
+    },
+
+    "GoHTTPClient": {
+        "description": "Represents net/http.Client. Do(), Get(), Post() are SSRF sinks when the URL comes from user input.",
+        "category": "stdlib",
+        "fqns": ["net/http.Client"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Get": {"signature": "Get(url string) (*Response, error)", "description": "Makes GET request. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
+            "Post": {"signature": "Post(url, contentType string, body io.Reader) (*Response, error)", "description": "Makes POST request. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
+            "Do": {"signature": "Do(req *Request) (*Response, error)", "description": "Executes arbitrary HTTP request. SSRF sink.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": ["GO-SSRF-002"],
+    },
+
+    "GoOS": {
+        "description": "The os standard library package. Getenv() is a source of environment variable data. Open(), Create(), Remove() are file operation sinks for path traversal.",
+        "category": "stdlib",
+        "fqns": ["os"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Getenv": {"signature": "Getenv(key string) string", "description": "Returns environment variable value. Source of external data.", "role": "source", "tracks": ["return"]},
+            "Open": {"signature": "Open(name string) (*File, error)", "description": "Opens file for reading. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [0]},
+            "Create": {"signature": "Create(name string) (*File, error)", "description": "Creates file. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [0]},
+            "Remove": {"signature": "Remove(name string) error", "description": "Removes file. Dangerous sink when name is user-controlled.", "role": "sink", "tracks": [0]},
+            "ReadFile": {"signature": "ReadFile(name string) ([]byte, error)", "description": "Reads entire file. Path traversal sink.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": ["GO-PATH-001"],
+    },
+
+    "GoFilepath": {
+        "description": "The path/filepath standard library package. Join(), Abs(), Clean() are used as sanitizers in path traversal rules when combined with containment checks.",
+        "category": "stdlib",
+        "fqns": ["path/filepath"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Join": {"signature": "Join(elem ...string) string", "description": "Joins path elements. Sanitizer when followed by a prefix containment check.", "role": "sanitizer"},
+            "Abs": {"signature": "Abs(path string) (string, error)", "description": "Returns absolute path. Sanitizer when result is checked against allowed root.", "role": "sanitizer"},
+            "Clean": {"signature": "Clean(path string) string", "description": "Lexically cleans path. Partial sanitizer — still needs containment check.", "role": "sanitizer"},
+            "Base": {"signature": "Base(path string) string", "description": "Returns last element of path. Strips directory traversal sequences.", "role": "sanitizer"},
+        },
+        "rules_using": ["GO-PATH-001"],
+    },
+
+    "GoFmt": {
+        "description": "The fmt standard library package. Sprintf, Fprintf, Sscanf are sources of formatted string data. Fprintf to http.ResponseWriter is an XSS sink.",
+        "category": "stdlib",
+        "fqns": ["fmt"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Sprintf": {"signature": "Sprintf(format string, a ...any) string", "description": "Formats string. Propagates taint from arguments into the return value.", "role": "neutral"},
+            "Fprintf": {"signature": "Fprintf(w io.Writer, format string, a ...any) (n int, err error)", "description": "Writes to w. XSS sink when w is http.ResponseWriter and a contains user input.", "role": "sink", "tracks": [1]},
+            "Sscanf": {"signature": "Sscanf(str string, format string, a ...any) (n int, err error)", "description": "Parses str. a arguments become tainted with str contents.", "role": "source"},
+        },
+        "rules_using": [],
+    },
+
+    "GoTemplate": {
+        "description": "Represents html/template.Template and text/template.Template. Execute() and ExecuteTemplate() are XSS sinks when data contains unsanitized user input passed to text/template (not html/template).",
+        "category": "stdlib",
+        "fqns": ["html/template.Template", "text/template.Template"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Execute": {"signature": "Execute(wr io.Writer, data any) error", "description": "Renders template with data. XSS sink for text/template when data is user-controlled.", "role": "sink", "tracks": [1]},
+            "ExecuteTemplate": {"signature": "ExecuteTemplate(wr io.Writer, name string, data any) error", "description": "Renders named template. Same XSS risk as Execute.", "role": "sink", "tracks": [2]},
+            "Parse": {"signature": "Parse(text string) (*Template, error)", "description": "Parses template text. Server-side template injection if text is user-controlled.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": ["GO-XSS-003"],
+    },
+
+    "GoCrypto": {
+        "description": "Weak cryptographic algorithms: crypto/md5, crypto/sha1, crypto/des, crypto/rc4. All New() and Sum() calls are findings — these algorithms are cryptographically broken.",
+        "category": "stdlib",
+        "fqns": ["crypto/md5", "crypto/sha1", "crypto/des", "crypto/rc4"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "New": {"signature": "New() hash.Hash", "description": "Creates new hash instance using the weak algorithm. Always a finding.", "role": "sink"},
+            "Sum": {"signature": "Sum(data []byte) [N]byte", "description": "Computes weak hash. Always a finding.", "role": "sink"},
+        },
+        "rules_using": ["GO-CRYPTO-001", "GO-CRYPTO-002", "GO-CRYPTO-003", "GO-CRYPTO-004", "GO-CRYPTO-005"],
+    },
+
+    "GoContext": {
+        "description": "Represents context.Context. Value() can propagate tainted data stored by upstream handlers — treat returned values as taint sources in inter-procedural analysis.",
+        "category": "stdlib",
+        "fqns": ["context.Context"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Value": {"signature": "Value(key any) any", "description": "Returns value associated with key. Source of taint when key is a request-scoped user-data key.", "role": "source", "tracks": ["return"]},
+            "WithValue": {"signature": "WithValue(parent Context, key, val any) Context", "description": "Returns context carrying val. Propagates taint from val.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    # ── 40+ additional stdlib entries for UI scale testing ────────────────────
+
+    "GoBufioReader": {
+        "description": "bufio.Reader wraps an io.Reader with buffering. ReadString() and ReadLine() are sources when the underlying reader is an HTTP request body or stdin.",
+        "category": "stdlib",
+        "fqns": ["bufio.Reader"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ReadString": {"signature": "ReadString(delim byte) (string, error)", "description": "Reads until delimiter. Source when wrapping user-controlled input.", "role": "source", "tracks": ["return"]},
+            "ReadLine": {"signature": "ReadLine() (line []byte, isPrefix bool, err error)", "description": "Reads one line. Source when wrapping HTTP body or stdin.", "role": "source", "tracks": ["return"]},
+            "ReadBytes": {"signature": "ReadBytes(delim byte) ([]byte, error)", "description": "Reads until delimiter. Source of tainted bytes.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoBufioScanner": {
+        "description": "bufio.Scanner reads tokens line-by-line. Text() and Bytes() are sources when the scanner wraps user-controlled input (stdin, HTTP body).",
+        "category": "stdlib",
+        "fqns": ["bufio.Scanner"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Text": {"signature": "Text() string", "description": "Returns current token as string. Source when scanning user input.", "role": "source", "tracks": ["return"]},
+            "Bytes": {"signature": "Bytes() []byte", "description": "Returns current token as bytes. Source when scanning user input.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoIOReader": {
+        "description": "io.Reader interface. ReadAll() from io package returns the full content of a reader — source of taint when the reader wraps HTTP request body.",
+        "category": "stdlib",
+        "fqns": ["io"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ReadAll": {"signature": "ReadAll(r Reader) ([]byte, error)", "description": "Reads all bytes from r. Source when r is http.Request.Body.", "role": "source", "tracks": ["return"]},
+            "Copy": {"signature": "Copy(dst Writer, src Reader) (int64, error)", "description": "Copies src to dst. Propagates taint from src to dst.", "role": "neutral"},
+            "Pipe": {"signature": "Pipe() (*PipeReader, *PipeWriter)", "description": "Creates synchronized pipe. Propagates taint through the connection.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoNetURL": {
+        "description": "net/url package. Parse() returns a *url.URL from a string — source of taint when parsing user-supplied URLs. Used in SSRF detection for URL validation.",
+        "category": "stdlib",
+        "fqns": ["net/url"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Parse": {"signature": "Parse(rawURL string) (*URL, error)", "description": "Parses raw URL. Sanitizer when result host is validated against allowlist.", "role": "sanitizer"},
+            "QueryUnescape": {"signature": "QueryUnescape(s string) (string, error)", "description": "Decodes percent-encoded string. Returns decoded tainted data.", "role": "neutral"},
+            "PathEscape": {"signature": "PathEscape(s string) string", "description": "Escapes string for use in URL path segment. Sanitizes path injection.", "role": "sanitizer"},
+            "QueryEscape": {"signature": "QueryEscape(s string) string", "description": "Escapes string for use in URL query. Sanitizes injection via encoding.", "role": "sanitizer"},
+        },
+        "rules_using": [],
+    },
+
+    "GoNetDial": {
+        "description": "net.Dial and net.DialTCP create network connections. Dial() is an SSRF sink when the address is user-controlled.",
+        "category": "stdlib",
+        "fqns": ["net"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Dial": {"signature": "Dial(network, address string) (Conn, error)", "description": "Creates network connection to address. SSRF sink when address is user-controlled.", "role": "sink", "tracks": [1]},
+            "DialTCP": {"signature": "DialTCP(network string, laddr, raddr *TCPAddr) (*TCPConn, error)", "description": "Creates TCP connection. SSRF sink when raddr is user-controlled.", "role": "sink", "tracks": [2]},
+            "LookupHost": {"signature": "LookupHost(host string) ([]string, error)", "description": "DNS lookup. SSRF vector when host is user-controlled.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoNetTLS": {
+        "description": "crypto/tls package. Config.InsecureSkipVerify = true disables certificate verification — a finding for all production code.",
+        "category": "stdlib",
+        "fqns": ["crypto/tls"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Dial": {"signature": "Dial(network, addr string, config *Config) (*Conn, error)", "description": "Creates TLS connection. Finding when config.InsecureSkipVerify is true.", "role": "sink", "tracks": [2]},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingBase64": {
+        "description": "encoding/base64 package. DecodeString() decodes user input — the result is still tainted and must be sanitized before use in sinks.",
+        "category": "stdlib",
+        "fqns": ["encoding/base64"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "DecodeString": {"signature": "DecodeString(s string) ([]byte, error)", "description": "Decodes base64. Output is tainted if input is tainted — not a sanitizer.", "role": "neutral"},
+            "EncodeToString": {"signature": "EncodeToString(src []byte) string", "description": "Encodes to base64. Does not sanitize — taint propagates.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingHex": {
+        "description": "encoding/hex package. DecodeString() converts hex to bytes — does not sanitize taint. EncodeToString() may be used as a sanitizer in specific contexts.",
+        "category": "stdlib",
+        "fqns": ["encoding/hex"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "DecodeString": {"signature": "DecodeString(s string) ([]byte, error)", "description": "Decodes hex string to bytes. Taint propagates through.", "role": "neutral"},
+            "EncodeToString": {"signature": "EncodeToString(src []byte) string", "description": "Encodes bytes to hex. Safe for SQL/command contexts — acts as sanitizer.", "role": "sanitizer"},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingJSON": {
+        "description": "encoding/json package. Unmarshal and Decoder.Decode() are sources of tainted data from JSON input. Marshal() propagates taint to output.",
+        "category": "stdlib",
+        "fqns": ["encoding/json"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Unmarshal": {"signature": "Unmarshal(data []byte, v any) error", "description": "Decodes JSON into v. v becomes tainted when data comes from user input.", "role": "source", "tracks": [1]},
+            "Marshal": {"signature": "Marshal(v any) ([]byte, error)", "description": "Encodes v to JSON. Propagates taint from v to output bytes.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingXML": {
+        "description": "encoding/xml package. Unmarshal and Decoder.Decode() are sources. Can also be an XXE sink if xml.Decoder is used without disabling external entity processing.",
+        "category": "stdlib",
+        "fqns": ["encoding/xml"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Unmarshal": {"signature": "Unmarshal(data []byte, v any) error", "description": "Decodes XML into v. v becomes tainted. Potential XXE if data contains external entities.", "role": "source", "tracks": [1]},
+            "NewDecoder": {"signature": "NewDecoder(r io.Reader) *Decoder", "description": "Creates XML decoder. XXE risk when r is user-controlled and entity expansion not limited.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingCSV": {
+        "description": "encoding/csv package. Reader.Read() and Reader.ReadAll() return user-controlled CSV data as string slices — treat as taint sources.",
+        "category": "stdlib",
+        "fqns": ["encoding/csv"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Read": {"signature": "Read() ([]string, error)", "description": "Reads one CSV record. Source of tainted strings when reading user-uploaded CSV.", "role": "source", "tracks": ["return"]},
+            "ReadAll": {"signature": "ReadAll() ([][]string, error)", "description": "Reads all CSV records. Source of tainted string slices.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingBinary": {
+        "description": "encoding/binary package. Read() deserializes binary data from a reader — source of taint when the reader is network or user input.",
+        "category": "stdlib",
+        "fqns": ["encoding/binary"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Read": {"signature": "Read(r io.Reader, order ByteOrder, data any) error", "description": "Reads binary data into data. data becomes tainted when r is user-controlled.", "role": "source", "tracks": [2]},
+        },
+        "rules_using": [],
+    },
+
+    "GoEncodingGob": {
+        "description": "encoding/gob package. Decoder.Decode() deserializes arbitrary Go types — unsafe deserialization sink when decoding untrusted data.",
+        "category": "stdlib",
+        "fqns": ["encoding/gob"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Decode": {"signature": "Decode(e any) error", "description": "Deserializes gob-encoded data. Unsafe deserialization sink when decoding user-controlled data.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoMimeMultipart": {
+        "description": "mime/multipart package. Reader.ReadForm() parses multipart form data including file uploads — source of user-controlled filenames and content.",
+        "category": "stdlib",
+        "fqns": ["mime/multipart"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ReadForm": {"signature": "ReadForm(maxMemory int64) (*Form, error)", "description": "Parses entire multipart form including uploads. Source of user-controlled filenames.", "role": "source", "tracks": ["return"]},
+            "NextPart": {"signature": "NextPart() (*Part, error)", "description": "Returns next form part. FileName() on the result is user-controlled.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoHTTPMux": {
+        "description": "net/http.ServeMux is the HTTP request multiplexer. Handle() and HandleFunc() register handlers — not typically a security sink but relevant for routing analysis.",
+        "category": "stdlib",
+        "fqns": ["net/http.ServeMux"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Handle": {"signature": "Handle(pattern string, handler Handler)", "description": "Registers handler for pattern. Not a security sink.", "role": "neutral"},
+            "HandleFunc": {"signature": "HandleFunc(pattern string, handler func(ResponseWriter, *Request))", "description": "Registers handler function. Not a security sink.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoHTTPServer": {
+        "description": "net/http.Server. ListenAndServe() without TLS is a finding in server configurations that should enforce HTTPS.",
+        "category": "stdlib",
+        "fqns": ["net/http.Server"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ListenAndServe": {"signature": "ListenAndServe() error", "description": "Starts HTTP server without TLS. Finding when used in production without HTTPS redirect.", "role": "sink"},
+            "ListenAndServeTLS": {"signature": "ListenAndServeTLS(certFile, keyFile string) error", "description": "Starts HTTPS server. Safe — preferred over ListenAndServe.", "role": "neutral"},
+        },
+        "rules_using": ["GO-NET-001"],
+    },
+
+    "GoHTTPCookie": {
+        "description": "net/http.Cookie struct. Missing Secure, HttpOnly, or SameSite flags are security findings for session cookies.",
+        "category": "stdlib",
+        "fqns": ["net/http.Cookie"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "SetCookie": {"signature": "SetCookie(w ResponseWriter, cookie *Cookie)", "description": "Sets HTTP cookie. Finding when cookie.Secure or cookie.HttpOnly is false for session cookies.", "role": "sink", "tracks": [1]},
+        },
+        "rules_using": [],
+    },
+
+    "GoNetSMTP": {
+        "description": "net/smtp package. SendMail() and SMTP.Mail() are email injection sinks when headers or body are built from user input without sanitization.",
+        "category": "stdlib",
+        "fqns": ["net/smtp"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "SendMail": {"signature": "SendMail(addr string, a Auth, from string, to []string, msg []byte) error", "description": "Sends email. Header injection sink when from/to/msg contain user input.", "role": "sink", "tracks": [2]},
+        },
+        "rules_using": [],
+    },
+
+    "GoLog": {
+        "description": "log standard library package. Printf, Println, and Fatal variants may log sensitive user input — a finding for privacy/compliance rules.",
+        "category": "stdlib",
+        "fqns": ["log"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Printf": {"signature": "Printf(format string, v ...any)", "description": "Logs formatted message. Log injection sink when v contains user input with newlines.", "role": "sink", "tracks": [0]},
+            "Println": {"signature": "Println(v ...any)", "description": "Logs values. Potential log injection.", "role": "sink", "tracks": [0]},
+            "Fatal": {"signature": "Fatal(v ...any)", "description": "Logs and calls os.Exit(1). Log injection sink.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoLogSlog": {
+        "description": "log/slog package (Go 1.21+). Structured logging — Info, Warn, Error are log injection sinks when message or attributes contain unsanitized user input.",
+        "category": "stdlib",
+        "fqns": ["log/slog"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Info": {"signature": "Info(msg string, args ...any)", "description": "Logs at INFO level. Log injection sink when msg or args contain user input.", "role": "sink", "tracks": [0]},
+            "Warn": {"signature": "Warn(msg string, args ...any)", "description": "Logs at WARN level. Log injection sink.", "role": "sink", "tracks": [0]},
+            "Error": {"signature": "Error(msg string, args ...any)", "description": "Logs at ERROR level. Log injection sink.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoStrings": {
+        "description": "strings package. Contains(), HasPrefix(), ReplaceAll() are used as partial sanitizers. Builder is used to construct tainted strings.",
+        "category": "stdlib",
+        "fqns": ["strings"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Contains": {"signature": "Contains(s, substr string) bool", "description": "Checks if s contains substr. Used as a partial path containment sanitizer.", "role": "sanitizer"},
+            "HasPrefix": {"signature": "HasPrefix(s, prefix string) bool", "description": "Checks string prefix. Partial sanitizer for path traversal when checking allowed root.", "role": "sanitizer"},
+            "ReplaceAll": {"signature": "ReplaceAll(s, old, new string) string", "description": "Replaces all occurrences. Taint propagates — not a sanitizer by itself.", "role": "neutral"},
+            "TrimSpace": {"signature": "TrimSpace(s string) string", "description": "Trims whitespace. Taint propagates.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoRegexp": {
+        "description": "regexp package. FindString() and FindAllString() return tainted matches. MustCompile() with user-controlled pattern is a ReDoS risk.",
+        "category": "stdlib",
+        "fqns": ["regexp"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Compile": {"signature": "Compile(expr string) (*Regexp, error)", "description": "Compiles regex. ReDoS risk when expr is user-controlled.", "role": "sink", "tracks": [0]},
+            "MustCompile": {"signature": "MustCompile(str string) *Regexp", "description": "Compiles regex, panics on error. ReDoS risk when str is user-controlled.", "role": "sink", "tracks": [0]},
+            "FindString": {"signature": "FindString(s string) string", "description": "Returns leftmost match. Source of tainted string from user input.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoMathRand": {
+        "description": "math/rand package. Intn(), Float64() and related functions use a deterministic PRNG — a finding when used for cryptographic purposes (tokens, session IDs).",
+        "category": "stdlib",
+        "fqns": ["math/rand"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Intn": {"signature": "Intn(n int) int", "description": "Returns pseudo-random int. Finding when used to generate security tokens.", "role": "sink"},
+            "Read": {"signature": "Read(p []byte) (n int, err error)", "description": "Fills p with pseudo-random bytes. Finding when used as cryptographic randomness.", "role": "sink"},
+        },
+        "rules_using": [],
+    },
+
+    "GoCryptoRand": {
+        "description": "crypto/rand package. The Reader is the cryptographically secure random source — use this instead of math/rand for tokens and session IDs.",
+        "category": "stdlib",
+        "fqns": ["crypto/rand"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Read": {"signature": "Read(b []byte) (n int, err error)", "description": "Fills b with cryptographically secure random bytes. Preferred over math/rand.Read.", "role": "neutral"},
+            "Int": {"signature": "Int(rand io.Reader, max *big.Int) (*big.Int, error)", "description": "Returns cryptographically secure random int. Safe for security purposes.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoSync": {
+        "description": "sync package. Mutex, RWMutex, Once — not security sinks but relevant for race condition detection rules.",
+        "category": "stdlib",
+        "fqns": ["sync"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Lock": {"signature": "Lock()", "description": "Acquires mutex. Missing unlock is a resource leak finding.", "role": "neutral"},
+            "Unlock": {"signature": "Unlock()", "description": "Releases mutex. Must be called, typically via defer.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoSyncMap": {
+        "description": "sync.Map provides a concurrent map. Load() and Store() are relevant for data flow tracking in concurrent handlers where shared state is modified.",
+        "category": "stdlib",
+        "fqns": ["sync.Map"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Load": {"signature": "Load(key any) (value any, ok bool)", "description": "Loads value from map. Source of taint when map stores user-controlled data.", "role": "source", "tracks": ["return"]},
+            "Store": {"signature": "Store(key, value any)", "description": "Stores value in map. Propagates taint from value.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoReflect": {
+        "description": "reflect package. reflect.ValueOf() and reflect.New() with user-controlled type strings enable dynamic code execution — a finding for unsafe reflection rules.",
+        "category": "stdlib",
+        "fqns": ["reflect"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ValueOf": {"signature": "ValueOf(i any) Value", "description": "Returns Value wrapping i. Taint propagates through reflect operations.", "role": "neutral"},
+            "New": {"signature": "New(typ Type) Value", "description": "Creates new zero value of type. Unsafe when type is derived from user input.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoRuntime": {
+        "description": "runtime package. SetFinalizer(), GOMAXPROCS() — not typical security sinks but relevant for resource exhaustion rules.",
+        "category": "stdlib",
+        "fqns": ["runtime"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "GOMAXPROCS": {"signature": "GOMAXPROCS(n int) int", "description": "Sets max OS threads. DoS risk when n is derived from user input without bounds check.", "role": "sink", "tracks": [0]},
+            "Stack": {"signature": "Stack(buf []byte, all bool) int", "description": "Writes goroutine stack trace. Information disclosure if written to user-visible output.", "role": "source"},
+        },
+        "rules_using": [],
+    },
+
+    "GoOSUser": {
+        "description": "os/user package. Lookup() and LookupId() resolve usernames — source of OS-level user data. Relevant for privilege escalation analysis.",
+        "category": "stdlib",
+        "fqns": ["os/user"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Lookup": {"signature": "Lookup(username string) (*User, error)", "description": "Looks up user by name. SSRF-like sink if username is user-controlled.", "role": "sink", "tracks": [0]},
+            "Current": {"signature": "Current() (*User, error)", "description": "Returns current OS user. Source of sensitive system information.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoSyscall": {
+        "description": "syscall package. Exec(), RawSyscall(), and socket operations are low-level command and network injection sinks.",
+        "category": "stdlib",
+        "fqns": ["syscall"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Exec": {"signature": "Exec(argv0 string, argv []string, envv []string) error", "description": "Executes program directly. Command injection sink when argv is user-controlled.", "role": "sink", "tracks": [0]},
+            "Getenv": {"signature": "Getenv(key string) (value string, found bool)", "description": "Gets environment variable. Source of external data.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoIOFS": {
+        "description": "io/fs package (Go 1.16+). FS interface and ReadFile() operate on filesystem abstractions — path traversal sinks when path is user-controlled.",
+        "category": "stdlib",
+        "fqns": ["io/fs"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ReadFile": {"signature": "ReadFile(fsys FS, name string) ([]byte, error)", "description": "Reads file from FS. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [1]},
+            "Stat": {"signature": "Stat(fsys FS, name string) (FileInfo, error)", "description": "Stats file. Path traversal sink when name is user-controlled.", "role": "sink", "tracks": [1]},
+        },
+        "rules_using": [],
+    },
+
+    "GoHTMLTemplate": {
+        "description": "html/template package — the safe version of text/template. Auto-escapes context-appropriately. HTML(), JS(), URL() types are escape bypasses when used with user input.",
+        "category": "stdlib",
+        "fqns": ["html/template"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "HTML": {"signature": "HTML(string)", "description": "Marks string as safe HTML — bypasses auto-escaping. XSS sink when value is user-controlled.", "role": "sink", "tracks": [0]},
+            "JS": {"signature": "JS(string)", "description": "Marks string as safe JavaScript — bypasses auto-escaping. XSS sink.", "role": "sink", "tracks": [0]},
+            "URL": {"signature": "URL(string)", "description": "Marks string as safe URL — bypasses sanitization. Open redirect sink.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": ["GO-XSS-002"],
+    },
+
+    "GoNetHTTP": {
+        "description": "Package-level net/http functions: Get(), Post(), Head(). SSRF sinks when the URL argument is derived from user input.",
+        "category": "stdlib",
+        "fqns": ["net/http"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Get": {"signature": "Get(url string) (*Response, error)", "description": "Package-level HTTP GET. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
+            "Post": {"signature": "Post(url, contentType string, body io.Reader) (*Response, error)", "description": "Package-level HTTP POST. SSRF sink when url is user-controlled.", "role": "sink", "tracks": [0]},
+            "Head": {"signature": "Head(url string) (*Response, error)", "description": "Package-level HTTP HEAD. SSRF sink.", "role": "sink", "tracks": [0]},
+            "Redirect": {"signature": "Redirect(w ResponseWriter, r *Request, url string, code int)", "description": "Sends redirect response. Open redirect sink when url is user-controlled.", "role": "sink", "tracks": [2]},
+        },
+        "rules_using": ["GO-SSRF-002", "GO-REDIRECT-001"],
+    },
+
+    "GoArchiveTar": {
+        "description": "archive/tar package. Reader.Next() returns headers with user-controlled filenames — Zip Slip path traversal sink when extracting to filesystem.",
+        "category": "stdlib",
+        "fqns": ["archive/tar"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Next": {"signature": "Next() (*Header, error)", "description": "Advances to next entry. Header.Name is user-controlled — Zip Slip path traversal sink.", "role": "source", "tracks": ["return"]},
+        },
+        "rules_using": [],
+    },
+
+    "GoArchiveZip": {
+        "description": "archive/zip package. OpenReader() and File[].Name are sources of user-controlled filenames — Zip Slip path traversal when extracting.",
+        "category": "stdlib",
+        "fqns": ["archive/zip"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "OpenReader": {"signature": "OpenReader(name string) (*ReadCloser, error)", "description": "Opens zip file for reading. File.Name fields are user-controlled — Zip Slip source.", "role": "source"},
+        },
+        "rules_using": [],
+    },
+
+    "GoDatabaseSQL": {
+        "description": "Alias reference: database/sql.Stmt. Prepared statement execution methods — safe when using ? placeholders, sink when mixing with string concatenation.",
+        "category": "stdlib",
+        "fqns": ["database/sql.Stmt"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Exec": {"signature": "Exec(args ...any) (Result, error)", "description": "Executes prepared statement. Safe with parameterized args.", "role": "neutral"},
+            "Query": {"signature": "Query(args ...any) (*Rows, error)", "description": "Executes parameterized query. Safe with ? placeholders.", "role": "neutral"},
+            "QueryRow": {"signature": "QueryRow(args ...any) *Row", "description": "Executes parameterized single-row query. Safe with ? placeholders.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoTime": {
+        "description": "time package. time.Parse() with user-controlled layout strings is a denial-of-service risk (algorithmic complexity). Not a typical injection sink.",
+        "category": "stdlib",
+        "fqns": ["time"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Parse": {"signature": "Parse(layout, value string) (Time, error)", "description": "Parses time string. Not an injection sink but DoS risk with user-controlled layout.", "role": "neutral"},
+            "After": {"signature": "After(d Duration) <-chan Time", "description": "Returns channel that fires after d. DoS risk when d is user-controlled without bounds.", "role": "neutral"},
+        },
+        "rules_using": [],
+    },
+
+    "GoPlugin": {
+        "description": "plugin package. Open() loads a shared library — code execution sink when the plugin path is user-controlled.",
+        "category": "stdlib",
+        "fqns": ["plugin"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Open": {"signature": "Open(path string) (*Plugin, error)", "description": "Loads a shared object plugin. Code execution sink when path is user-controlled.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoCryptoHMAC": {
+        "description": "crypto/hmac package. New() creates HMAC with a key. Equal() provides constant-time comparison. Using == instead of Equal() for MAC verification is a timing attack.",
+        "category": "stdlib",
+        "fqns": ["crypto/hmac"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "New": {"signature": "New(h func() hash.Hash, key []byte) hash.Hash", "description": "Creates new HMAC. Safe when using strong hash (sha256, sha512).", "role": "neutral"},
+            "Equal": {"signature": "Equal(mac1, mac2 []byte) bool", "description": "Constant-time comparison. Use this instead of bytes.Equal for MAC verification.", "role": "sanitizer"},
+        },
+        "rules_using": [],
+    },
+
+    "GoCryptoAES": {
+        "description": "crypto/aes package. NewCipher() with a weak mode (ECB, CBC without IV) is a cryptographic weakness finding.",
+        "category": "stdlib",
+        "fqns": ["crypto/aes"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "NewCipher": {"signature": "NewCipher(key []byte) (cipher.Block, error)", "description": "Creates AES block cipher. Finding when used in ECB mode (no IV).", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    "GoCipherGCM": {
+        "description": "cipher package. NewGCMWithNonceSize() and AEAD.Seal() — finding when nonce is reused or predictable.",
+        "category": "stdlib",
+        "fqns": ["crypto/cipher"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "NewGCM": {"signature": "NewGCM(cipher Block) (AEAD, error)", "description": "Creates GCM mode cipher. Finding when nonce is not cryptographically random.", "role": "neutral"},
+            "Seal": {"signature": "Seal(dst, nonce, plaintext, additionalData []byte) []byte", "description": "Encrypts and authenticates. Finding when nonce is reused.", "role": "sink", "tracks": [1]},
+        },
+        "rules_using": [],
+    },
+
+    "GoX509": {
+        "description": "crypto/x509 package. Certificate.Verify() is the TLS chain validation entry point. Skipping verification or using empty VerifyOptions is a finding.",
+        "category": "stdlib",
+        "fqns": ["crypto/x509"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Verify": {"signature": "Verify(opts VerifyOptions) ([][]*Certificate, error)", "description": "Verifies certificate chain. Finding when opts is empty (no root CA check).", "role": "sink", "tracks": [0]},
+            "ParseCertificate": {"signature": "ParseCertificate(asn1Data []byte) (*Certificate, error)", "description": "Parses DER-encoded certificate. Source of cert data from network input.", "role": "source"},
+        },
+        "rules_using": [],
+    },
+
+    "GoGobDecoder": {
+        "description": "encoding/gob.Decoder. Decode() deserializes arbitrary Go values — unsafe deserialization when decoding user-supplied bytes.",
+        "category": "stdlib",
+        "fqns": ["encoding/gob.Decoder"],
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Decode": {"signature": "Decode(e any) error", "description": "Deserializes next gob value into e. Unsafe deserialization sink.", "role": "sink", "tracks": [0]},
+            "DecodeValue": {"signature": "DecodeValue(v reflect.Value) error", "description": "Decodes into reflect.Value. Unsafe deserialization sink.", "role": "sink", "tracks": [0]},
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Web frameworks — third-party routers
+    # =====================================================================
+
+    "GoChiRouter": {
+        "description": (
+            "Chi HTTP router (chi.Router and chi.Mux). Path parameters extracted via URLParam "
+            "are taint sources. Chi is one of the most popular lightweight routers in the Go ecosystem."
+        ),
+        "category": "web-frameworks",
+        "go_mod": "require github.com/go-chi/chi/v5 v5.0.12",
+        "methods": {
+            "URLParam": {
+                "signature": "URLParam(r *http.Request, key string) string",
+                "description": "Returns URL path parameter for the given key (e.g. /users/{id}). User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "URLParamFromCtx": {
+                "signature": "URLParamFromCtx(ctx context.Context, key string) string",
+                "description": "Returns URL path parameter from the request context. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Handle": {
+                "signature": "Handle(pattern string, h http.Handler)",
+                "description": "Registers an http.Handler for a URL pattern. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "HandleFunc": {
+                "signature": "HandleFunc(pattern string, h http.HandlerFunc)",
+                "description": "Registers a handler function for a pattern. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Get": {
+                "signature": "Get(pattern string, h http.HandlerFunc)",
+                "description": "Registers a GET handler for a pattern. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Post": {
+                "signature": "Post(pattern string, h http.HandlerFunc)",
+                "description": "Registers a POST handler. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": ["GO-GORM-SQLI-001"],
+    },
+
+    "GoGorillaMuxRouter": {
+        "description": (
+            "Gorilla mux HTTP router (mux.Router). Path variables extracted via mux.Vars(r) are "
+            "taint sources. Gorilla mux is the canonical router for larger Go web applications."
+        ),
+        "category": "web-frameworks",
+        "go_mod": "require github.com/gorilla/mux v1.8.1",
+        "methods": {
+            "Vars": {
+                "signature": "Vars(r *http.Request) map[string]string",
+                "description": "Returns the route variables for the current request. All map values are user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "CurrentRoute": {
+                "signature": "CurrentRoute(r *http.Request) *Route",
+                "description": "Returns the matched route for the request. Metadata accessor (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "HandleFunc": {
+                "signature": "HandleFunc(path string, f func(http.ResponseWriter, *http.Request)) *Route",
+                "description": "Registers a handler function for a path. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Handle": {
+                "signature": "Handle(path string, handler http.Handler) *Route",
+                "description": "Registers an http.Handler for a path. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "PathPrefix": {
+                "signature": "PathPrefix(tpl string) *Route",
+                "description": "Registers a sub-router under a path prefix. Routing primitive (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Databases — third-party drivers
+    # =====================================================================
+
+    "GoPgxConn": {
+        "description": (
+            "pgx PostgreSQL driver. Connection and Pool types expose Query/Exec/QueryRow that "
+            "accept raw SQL strings — injection sinks when the SQL is built from user input. "
+            "pgx is the recommended Postgres driver for new Go projects."
+        ),
+        "category": "databases",
+        "go_mod": "require github.com/jackc/pgx/v5 v5.5.5",
+        "methods": {
+            "Exec": {
+                "signature": "Exec(ctx context.Context, sql string, args ...any) (CommandTag, error)",
+                "description": "Executes SQL that doesn't return rows. Sink when sql is built from user input.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Query": {
+                "signature": "Query(ctx context.Context, sql string, args ...any) (Rows, error)",
+                "description": "Executes a query returning rows. SQL injection sink.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "QueryRow": {
+                "signature": "QueryRow(ctx context.Context, sql string, args ...any) Row",
+                "description": "Executes a query returning a single row. SQL injection sink.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "ExecEx": {
+                "signature": "ExecEx(ctx context.Context, sql string, options *QueryExOptions, args ...any) (CommandTag, error)",
+                "description": "pgx v4 compatibility shim for Exec. Same injection risk.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "QueryEx": {
+                "signature": "QueryEx(ctx context.Context, sql string, options *QueryExOptions, args ...any) (*Rows, error)",
+                "description": "pgx v4 compatibility shim for Query. Same injection risk.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "QueryRowEx": {
+                "signature": "QueryRowEx(ctx context.Context, sql string, options *QueryExOptions, args ...any) *Row",
+                "description": "pgx v4 compatibility shim for QueryRow. Same injection risk.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "SendBatch": {
+                "signature": "SendBatch(ctx context.Context, b *Batch) BatchResults",
+                "description": "Sends a batch of queries. Each query in the batch can be an injection sink.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Prepare": {
+                "signature": "Prepare(ctx context.Context, name, sql string) (*StatementDescription, error)",
+                "description": "Creates a prepared statement. Sink when sql is user-controlled.",
+                "role": "sink",
+                "tracks": [2],
+            },
+        },
+        "rules_using": ["GO-SQLI-002"],
+    },
+
+    "GoMongoCollection": {
+        "description": (
+            "MongoDB Go driver Collection and Client. Queries built from user input via "
+            "bson.D or bson.M with string interpolation are NoSQL injection sinks. The filter "
+            "argument on Find/Update/Delete operations is where tainted input lands."
+        ),
+        "category": "databases",
+        "go_mod": "require go.mongodb.org/mongo-driver v1.14.0",
+        "methods": {
+            "Find": {
+                "signature": "Find(ctx context.Context, filter any, opts ...*options.FindOptions) (*Cursor, error)",
+                "description": "Queries documents matching filter. NoSQL injection sink if filter is built from user input.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "FindOne": {
+                "signature": "FindOne(ctx context.Context, filter any, opts ...*options.FindOneOptions) *SingleResult",
+                "description": "Returns one document matching filter. Same NoSQL injection risk.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "UpdateOne": {
+                "signature": "UpdateOne(ctx context.Context, filter, update any, opts ...*options.UpdateOptions) (*UpdateResult, error)",
+                "description": "Updates one document matching filter. Both filter and update are injection sinks.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "UpdateMany": {
+                "signature": "UpdateMany(ctx context.Context, filter, update any, opts ...*options.UpdateOptions) (*UpdateResult, error)",
+                "description": "Updates all matching documents. Injection sink on filter and update arguments.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "DeleteOne": {
+                "signature": "DeleteOne(ctx context.Context, filter any, opts ...*options.DeleteOptions) (*DeleteResult, error)",
+                "description": "Deletes first document matching filter. NoSQL injection sink.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "DeleteMany": {
+                "signature": "DeleteMany(ctx context.Context, filter any, opts ...*options.DeleteOptions) (*DeleteResult, error)",
+                "description": "Deletes all matching documents. NoSQL injection sink.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Aggregate": {
+                "signature": "Aggregate(ctx context.Context, pipeline any, opts ...*options.AggregateOptions) (*Cursor, error)",
+                "description": "Runs an aggregation pipeline. Each stage can be an injection sink if built from user input.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "InsertOne": {
+                "signature": "InsertOne(ctx context.Context, document any, opts ...*options.InsertOneOptions) (*InsertOneResult, error)",
+                "description": "Inserts a document. Generally safe because fields are typed, but tainted document fields reach storage.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "GoRedisClient": {
+        "description": (
+            "go-redis Client for Redis operations. Most Redis commands are typed and safe, but "
+            "Eval() and EvalSha() accept Lua scripts that can be injection sinks when the script "
+            "body is user-controlled. ACL commands can also be sinks."
+        ),
+        "category": "databases",
+        "go_mod": "require github.com/redis/go-redis/v9 v9.5.1",
+        "methods": {
+            "Eval": {
+                "signature": "Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd",
+                "description": "Executes a Lua script on the Redis server. Injection sink if script is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "EvalSha": {
+                "signature": "EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd",
+                "description": "Executes a cached Lua script by SHA. Less risky than Eval but tainted SHA can still trigger unintended scripts.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "ScriptLoad": {
+                "signature": "ScriptLoad(ctx context.Context, script string) *StringCmd",
+                "description": "Registers a Lua script for later EvalSha. Sink when script is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Do": {
+                "signature": "Do(ctx context.Context, args ...any) *Cmd",
+                "description": "Sends an arbitrary command. Command-injection sink when the command name is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Get": {
+                "signature": "Get(ctx context.Context, key string) *StringCmd",
+                "description": "Fetches a string value. Source when cached data originated from user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Set": {
+                "signature": "Set(ctx context.Context, key string, value any, expiration time.Duration) *StatusCmd",
+                "description": "Stores a value. Typed and generally safe.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Serialization & config — third-party
+    # =====================================================================
+
+    "GoYAMLDecoder": {
+        "description": (
+            "gopkg.in/yaml.v3 Decoder for YAML deserialization. Decode() hydrates arbitrary Go "
+            "types from YAML input — a deserialization sink when the YAML source is user-controlled. "
+            "Package-level yaml.Unmarshal has the same properties."
+        ),
+        "category": "auth-config",
+        "go_mod": "require gopkg.in/yaml.v3 v3.0.1",
+        "methods": {
+            "Decode": {
+                "signature": "Decode(v any) error",
+                "description": "Deserializes the next YAML document into v. Sink when the underlying reader is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "KnownFields": {
+                "signature": "KnownFields(enable bool)",
+                "description": "Configures the decoder to error on unknown fields. Hardening control (neutral).",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "GoViperConfig": {
+        "description": (
+            "github.com/spf13/viper is the de-facto Go configuration library. Values returned from "
+            "Get* methods are sources when the config file itself contains untrusted fields "
+            "(environment, remote KV stores). Write methods that persist config back are typically neutral."
+        ),
+        "category": "auth-config",
+        "go_mod": "require github.com/spf13/viper v1.18.2",
+        "methods": {
+            "Get": {
+                "signature": "Get(key string) any",
+                "description": "Returns the raw value for key. Source when the backing config contains user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "GetString": {
+                "signature": "GetString(key string) string",
+                "description": "Returns the config value coerced to string. Source for user-supplied config.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "GetInt": {
+                "signature": "GetInt(key string) int",
+                "description": "Returns the config value coerced to int. Numeric coercion acts as a sanitizer for SQL / path injection.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "GetBool": {
+                "signature": "GetBool(key string) bool",
+                "description": "Returns the config value coerced to bool. Sanitizer via type coercion.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "GetStringSlice": {
+                "signature": "GetStringSlice(key string) []string",
+                "description": "Returns the config value as a string slice. Elements are sources.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "ReadConfig": {
+                "signature": "ReadConfig(in io.Reader) error",
+                "description": "Reads config from a reader. Subsequent Get* values become sources if the reader is user-controlled.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Unmarshal": {
+                "signature": "Unmarshal(rawVal any, opts ...DecoderConfigOption) error",
+                "description": "Hydrates a Go struct from the config. rawVal becomes tainted if the config contains user input.",
+                "role": "source",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # gRPC
+    # =====================================================================
+
+    "GoGRPCServerTransportStream": {
+        "description": (
+            "google.golang.org/grpc.ServerTransportStream exposes transport-layer metadata for "
+            "in-flight gRPC calls. Method() returns the fully-qualified gRPC method name — path-like "
+            "and frequently user-influenced via client-supplied routing. Header/Trailer methods ship "
+            "metadata back to the client."
+        ),
+        "category": "auth-config",
+        "go_mod": "require google.golang.org/grpc v1.62.1",
+        "methods": {
+            "Method": {
+                "signature": "Method() string",
+                "description": "Returns the fully-qualified gRPC method name. Source when the method path is used for authorization decisions.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "SetHeader": {
+                "signature": "SetHeader(md metadata.MD) error",
+                "description": "Sets response headers. Neutral for outbound metadata, but secret leakage possible if md contains sensitive fields.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "SendHeader": {
+                "signature": "SendHeader(md metadata.MD) error",
+                "description": "Sends response headers immediately. Same considerations as SetHeader.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "SetTrailer": {
+                "signature": "SetTrailer(md metadata.MD)",
+                "description": "Sets response trailers. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # stdlib (late additions)
+    # =====================================================================
+
+    "GoIO": {
+        "description": (
+            "The io standard library package. ReadAll and Copy move data from readers — sources when "
+            "the underlying reader is user-controlled (e.g. an http.Request.Body). WriteString writes "
+            "to a writer and is a sink when the writer is an HTTP response."
+        ),
+        "category": "stdlib",
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "ReadAll": {
+                "signature": "ReadAll(r Reader) ([]byte, error)",
+                "description": "Reads from r until EOF and returns the result. Source when r wraps user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Copy": {
+                "signature": "Copy(dst Writer, src Reader) (written int64, err error)",
+                "description": "Copies from src to dst. Neutral data-transfer primitive; taint transits src → dst.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "CopyN": {
+                "signature": "CopyN(dst Writer, src Reader, n int64) (written int64, err error)",
+                "description": "Copies exactly n bytes from src to dst. Same as Copy.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "WriteString": {
+                "signature": "WriteString(w Writer, s string) (n int, err error)",
+                "description": "Writes s to w. Sink when w is a response writer and s is user-controlled (XSS).",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "ReadFull": {
+                "signature": "ReadFull(r Reader, buf []byte) (n int, err error)",
+                "description": "Reads exactly len(buf) bytes from r. Buffer becomes tainted if r is user-controlled.",
+                "role": "source",
+                "tracks": [1],
+            },
+            "NopCloser": {
+                "signature": "NopCloser(r Reader) ReadCloser",
+                "description": "Wraps r in a no-op ReadCloser. Neutral transformation.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "GoJSON": {
+        "description": (
+            "encoding/json for JSON encode/decode. Unmarshal and Decoder.Decode deserialize JSON into "
+            "Go values — the destination struct becomes tainted if the input bytes are user-controlled. "
+            "Encoder.Encode writes JSON to a writer, a sink when the writer is an HTTP response."
+        ),
+        "category": "stdlib",
+        "go_mod": "// standard library — no go.mod entry required",
+        "methods": {
+            "Marshal": {
+                "signature": "Marshal(v any) ([]byte, error)",
+                "description": "Serializes v to JSON bytes. Generally neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Unmarshal": {
+                "signature": "Unmarshal(data []byte, v any) error",
+                "description": "Parses JSON bytes into v. v becomes tainted if data comes from user input.",
+                "role": "source",
+                "tracks": [1],
+            },
+            "NewDecoder": {
+                "signature": "NewDecoder(r io.Reader) *Decoder",
+                "description": "Creates a streaming decoder bound to r. Decoder.Decode is the actual source.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "NewEncoder": {
+                "signature": "NewEncoder(w io.Writer) *Encoder",
+                "description": "Creates a streaming encoder bound to w. Encoder.Encode is the actual sink.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Decode": {
+                "signature": "Decode(v any) error",
+                "description": "Reads the next JSON-encoded value from the stream into v. Source when stream is user input.",
+                "role": "source",
+                "tracks": [0],
+            },
+            "Encode": {
+                "signature": "Encode(v any) error",
+                "description": "Writes v as JSON to the underlying writer. Sink when writer is a response and v contains raw HTML.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+}

--- a/python-sdk/codepathfinder/python_rule_meta.py
+++ b/python-sdk/codepathfinder/python_rule_meta.py
@@ -1,0 +1,3389 @@
+# python_rule_meta.py — Companion metadata for Python rule writing.
+# Read by scripts/generate_sdk_manifest.py to produce sdk-manifest.json.
+#
+# Unlike Go, Python rules don't use QueryType classes — they use calls(),
+# variable(), and attribute() with pattern-based matching. This file documents
+# the most security-relevant stdlib and third-party modules that rule authors
+# typically target.
+#
+# Method signatures use Python syntax (def-style). The `fqns` field is the
+# canonical import path used with calls(). For classes with instance methods,
+# the FQN is the dotted path (e.g., "sqlite3.Cursor", "psycopg2.extensions.cursor").
+
+SDK_META: dict = {
+
+    # =====================================================================
+    # Command execution
+    # =====================================================================
+
+    "PySubprocess": {
+        "description": (
+            "The subprocess standard library module for spawning child processes. "
+            "Most call APIs accept either a list[str] (safe) or a string with shell=True "
+            "(command-injection sink when the string contains user input)."
+        ),
+        "category": "command-execution",
+        "fqns": ["subprocess"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "run": {
+                "signature": "subprocess.run(args, *, shell=False, capture_output=False, ...) -> CompletedProcess",
+                "description": "Runs a command and waits for completion. Sink when args is a string with shell=True.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "call": {
+                "signature": "subprocess.call(args, *, shell=False, ...) -> int",
+                "description": "Runs a command and returns its exit code. Sink under shell=True.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "check_call": {
+                "signature": "subprocess.check_call(args, *, shell=False, ...) -> int",
+                "description": "Like call() but raises on non-zero exit. Same injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "check_output": {
+                "signature": "subprocess.check_output(args, *, shell=False, ...) -> bytes",
+                "description": "Runs a command and returns stdout. Sink under shell=True.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Popen": {
+                "signature": "subprocess.Popen(args, *, shell=False, ...) -> Popen",
+                "description": "Low-level process constructor. Sink when args is a string with shell=True.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "example_rule": """\
+from codepathfinder.python_decorators import python_rule
+from codepathfinder import calls, flows
+from codepathfinder.presets import PropagationPresets
+
+
+@python_rule(
+    id="PYTHON-CMDI-001",
+    name="Command injection via subprocess with shell=True",
+    severity="CRITICAL",
+    category="command-execution",
+    cwe="CWE-78",
+    owasp="A03:2021",
+    message="User input flows into subprocess with shell=True. Pass args as a list and avoid shell=True.",
+)
+def detect_subprocess_shell_injection():
+    return flows(
+        from_sources=[
+            calls("request.args.get", "request.form.get", "request.get_json"),
+            calls("input"),
+        ],
+        to_sinks=[
+            calls("subprocess.run", match_name={"shell": True}).tracks(0),
+            calls("subprocess.Popen", match_name={"shell": True}).tracks(0),
+            calls("subprocess.call", match_name={"shell": True}).tracks(0),
+            calls("subprocess.check_output", match_name={"shell": True}).tracks(0),
+        ],
+        sanitized_by=[calls("shlex.quote"), calls("shlex.split")],
+        propagates_through=PropagationPresets.standard(),
+        scope="global",
+    )
+""",
+        "rules_using": [],
+    },
+
+    "PyOS": {
+        "description": (
+            "The os standard library module. os.system() and os.popen() always invoke a shell "
+            "and are injection sinks. os.exec* variants avoid the shell but are still sinks "
+            "for the program path. Environment accessors (os.environ, os.getenv) are sources."
+        ),
+        "category": "command-execution",
+        "fqns": ["os"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "system": {
+                "signature": "os.system(command: str) -> int",
+                "description": "Executes command via the shell. Command-injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "popen": {
+                "signature": "os.popen(command: str, mode: str = 'r') -> IO",
+                "description": "Opens a pipe to a shell command. Injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "execv": {
+                "signature": "os.execv(path: str, args: list) -> None",
+                "description": "Replaces the current process. Sink for user-controlled program path.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+            "execvp": {
+                "signature": "os.execvp(file: str, args: list) -> None",
+                "description": "Like execv but searches PATH. Same injection risk.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+            "spawnv": {
+                "signature": "os.spawnv(mode: int, path: str, args: list) -> int",
+                "description": "Spawns a new process. Sink for user-controlled program path.",
+                "role": "sink",
+                "tracks": [1, 2],
+            },
+            "getenv": {
+                "signature": "os.getenv(key: str, default: str | None = None) -> str | None",
+                "description": "Reads environment variable. Source when attacker controls env (container / CI).",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "environ": {
+                "signature": "os.environ: dict[str, str]",
+                "description": "Process environment map. Reading from it is a source.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Deserialization
+    # =====================================================================
+
+    "PyPickle": {
+        "description": (
+            "The pickle module for Python object serialization. pickle.load() and pickle.loads() "
+            "execute arbitrary code during deserialization via __reduce__ — always unsafe with "
+            "untrusted input. Use json or signed payloads instead."
+        ),
+        "category": "deserialization",
+        "fqns": ["pickle"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "load": {
+                "signature": "pickle.load(file: IO) -> Any",
+                "description": "Reads a pickled object from a file. Arbitrary-code-execution sink on untrusted data.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "loads": {
+                "signature": "pickle.loads(data: bytes) -> Any",
+                "description": "Deserializes a pickle byte string. RCE sink on untrusted data.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Unpickler": {
+                "signature": "pickle.Unpickler(file: IO) -> Unpickler",
+                "description": "Stateful unpickler. The load() method is the sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "example_rule": """\
+from codepathfinder.python_decorators import python_rule
+from codepathfinder import calls, flows
+from codepathfinder.presets import PropagationPresets
+
+
+@python_rule(
+    id="PYTHON-DESER-001",
+    name="Unsafe Pickle Deserialization",
+    severity="CRITICAL",
+    category="deserialization",
+    cwe="CWE-502",
+    owasp="A08:2021",
+    message="Untrusted data flows to pickle.loads(). Use json.loads() or signed payloads.",
+)
+def detect_pickle_deserialization():
+    return flows(
+        from_sources=[
+            calls("request.data"),
+            calls("request.get_data"),
+            calls("*.read"),
+            calls("*.recv"),
+        ],
+        to_sinks=[calls("pickle.loads"), calls("pickle.load")],
+        sanitized_by=[calls("hmac.compare_digest"), calls("*.verify_signature")],
+        propagates_through=PropagationPresets.standard(),
+        scope="local",
+    )
+""",
+        "rules_using": ["PYTHON-DESER-001"],
+    },
+
+    "PyMarshal": {
+        "description": (
+            "The marshal module for Python internal object serialization. Like pickle, "
+            "marshal.load() / marshal.loads() execute code paths determined by the input bytes — "
+            "unsafe on untrusted data. The module is undocumented for general use."
+        ),
+        "category": "deserialization",
+        "fqns": ["marshal"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "load": {
+                "signature": "marshal.load(file: IO) -> Any",
+                "description": "Reads a marshalled object. Unsafe deserialization sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "loads": {
+                "signature": "marshal.loads(bytes) -> Any",
+                "description": "Deserializes marshal bytes. Unsafe on untrusted input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Databases — stdlib
+    # =====================================================================
+
+    "PySqlite3": {
+        "description": (
+            "The sqlite3 module wraps the SQLite C library. cursor.execute() and executemany() "
+            "accept raw SQL strings and are injection sinks when the SQL is built from user input. "
+            "Use the ? placeholder form for safe parameter binding."
+        ),
+        "category": "databases",
+        "fqns": ["sqlite3", "sqlite3.Cursor", "sqlite3.Connection"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "connect": {
+                "signature": "sqlite3.connect(database: str, ...) -> Connection",
+                "description": "Opens a database connection. Neutral; the Cursor is where injection happens.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "execute": {
+                "signature": "Cursor.execute(sql: str, parameters: Sequence = ()) -> Cursor",
+                "description": "Executes SQL. Sink for injection when sql is built from user input without placeholders.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "executemany": {
+                "signature": "Cursor.executemany(sql: str, parameters: Iterable) -> Cursor",
+                "description": "Executes SQL repeatedly. Same injection risk as execute().",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "executescript": {
+                "signature": "Cursor.executescript(sql_script: str) -> Cursor",
+                "description": "Runs a multi-statement SQL script. No parameter binding available — always injection-sensitive.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Databases — third party
+    # =====================================================================
+
+    "PyPsycopg2": {
+        "description": (
+            "psycopg2 is the canonical PostgreSQL driver for Python. Cursor.execute() and "
+            "executemany() are SQL injection sinks when the query is built by string concatenation "
+            "or f-strings. Use %s placeholders for safe binding."
+        ),
+        "category": "databases",
+        "fqns": ["psycopg2", "psycopg2.extensions.cursor"],
+        "pip_snippet": "pip install psycopg2-binary",
+        "methods": {
+            "connect": {
+                "signature": "psycopg2.connect(dsn=None, ...) -> Connection",
+                "description": "Opens a PostgreSQL connection.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "execute": {
+                "signature": "cursor.execute(query: str, vars: Sequence | Mapping = None) -> None",
+                "description": "Executes a query. SQL injection sink when query is built from user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "executemany": {
+                "signature": "cursor.executemany(query: str, vars_list: Iterable) -> None",
+                "description": "Executes a query for each element in vars_list. Same injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "mogrify": {
+                "signature": "cursor.mogrify(query: str, vars=None) -> bytes",
+                "description": "Returns the query after parameter substitution. Does not execute, but the resulting bytes can flow to a later execute().",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPyMongo": {
+        "description": (
+            "PyMongo is the official MongoDB driver for Python. Collection methods accept filter "
+            "dicts; NoSQL injection occurs when filter dicts are built from user-supplied JSON "
+            "that lets attackers inject $where, $regex, or operator keys."
+        ),
+        "category": "databases",
+        "fqns": ["pymongo", "pymongo.collection.Collection", "pymongo.MongoClient"],
+        "pip_snippet": "pip install pymongo",
+        "methods": {
+            "find": {
+                "signature": "Collection.find(filter: Mapping = None, projection: Mapping = None, ...) -> Cursor",
+                "description": "Queries documents. NoSQL injection sink if filter is built from user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "find_one": {
+                "signature": "Collection.find_one(filter: Mapping = None, ...) -> dict | None",
+                "description": "Returns first matching document. Same NoSQL injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "update_one": {
+                "signature": "Collection.update_one(filter: Mapping, update: Mapping, ...) -> UpdateResult",
+                "description": "Updates a single document. Injection sink on filter and update args.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+            "delete_one": {
+                "signature": "Collection.delete_one(filter: Mapping, ...) -> DeleteResult",
+                "description": "Deletes a single document. NoSQL injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "aggregate": {
+                "signature": "Collection.aggregate(pipeline: Sequence[Mapping], ...) -> CommandCursor",
+                "description": "Runs an aggregation pipeline. Each stage can be injection-sensitive.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyRedis": {
+        "description": (
+            "redis-py is the de-facto Redis client for Python. Most commands are typed and safe. "
+            "The main sinks are eval() and evalsha() which run Lua scripts — injection-sensitive "
+            "when the script body is user-controlled."
+        ),
+        "category": "databases",
+        "fqns": ["redis", "redis.Redis", "redis.StrictRedis"],
+        "pip_snippet": "pip install redis",
+        "methods": {
+            "eval": {
+                "signature": "Redis.eval(script: str, numkeys: int, *keys_and_args) -> Any",
+                "description": "Executes a Lua script on the server. Injection sink when script is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "evalsha": {
+                "signature": "Redis.evalsha(sha: str, numkeys: int, *keys_and_args) -> Any",
+                "description": "Executes a cached Lua script by SHA. Tainted sha reaches pre-registered scripts.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "execute_command": {
+                "signature": "Redis.execute_command(*args) -> Any",
+                "description": "Sends an arbitrary Redis command. Injection sink for command name.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "get": {
+                "signature": "Redis.get(name: str) -> bytes | None",
+                "description": "Reads a key. Source when cached data originated from user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "set": {
+                "signature": "Redis.set(name: str, value, ex=None, ...) -> bool",
+                "description": "Sets a key. Typed arguments, generally safe.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Web frameworks
+    # =====================================================================
+
+    "PyFlask": {
+        "description": (
+            "Flask is a popular Python web microframework. The flask.request global exposes all "
+            "HTTP input (args, form, json, files, headers, cookies) as taint sources. Response helpers "
+            "like render_template (SSTI if template is user-controlled) and redirect (open-redirect) are sinks."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["flask", "flask.Request"],
+        "pip_snippet": "pip install flask",
+        "methods": {
+            "request.args": {
+                "signature": "request.args: MultiDict",
+                "description": "URL query string. All values are user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "request.form": {
+                "signature": "request.form: MultiDict",
+                "description": "POST form data (application/x-www-form-urlencoded, multipart/form-data).",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "request.get_json": {
+                "signature": "request.get_json(force=False, silent=False, cache=True) -> Any",
+                "description": "Parsed JSON request body. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "request.cookies": {
+                "signature": "request.cookies: ImmutableMultiDict",
+                "description": "Request cookies. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "request.headers": {
+                "signature": "request.headers: EnvironHeaders",
+                "description": "Request headers. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "render_template_string": {
+                "signature": "flask.render_template_string(source: str, **context) -> str",
+                "description": "Renders a template from a raw string. SSTI sink when source contains user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "redirect": {
+                "signature": "flask.redirect(location: str, code: int = 302) -> Response",
+                "description": "Returns a redirect response. Open-redirect sink when location is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "send_file": {
+                "signature": "flask.send_file(path_or_file, ...) -> Response",
+                "description": "Serves a file. Path-traversal sink when path is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyDjango": {
+        "description": (
+            "Django is a full-featured Python web framework. HttpRequest exposes request data; "
+            "the ORM Manager.raw() and Cursor.execute() are SQL injection sinks when the SQL is built "
+            "from user input. Template rendering via mark_safe bypasses auto-escaping (XSS sink)."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["django", "django.http.HttpRequest", "django.db.models.Manager"],
+        "pip_snippet": "pip install django",
+        "methods": {
+            "HttpRequest.GET": {
+                "signature": "request.GET: QueryDict",
+                "description": "URL query parameters. All values user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "HttpRequest.POST": {
+                "signature": "request.POST: QueryDict",
+                "description": "POST form data. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "HttpRequest.COOKIES": {
+                "signature": "request.COOKIES: dict[str, str]",
+                "description": "Request cookies. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "HttpRequest.body": {
+                "signature": "request.body: bytes",
+                "description": "Raw HTTP request body. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Manager.raw": {
+                "signature": "Manager.raw(raw_query: str, params: Sequence = None, ...) -> RawQuerySet",
+                "description": "Executes a raw SQL query against the ORM. SQL injection sink when raw_query is built from user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "mark_safe": {
+                "signature": "django.utils.safestring.mark_safe(s: str) -> SafeString",
+                "description": "Declares a string as safe, bypassing template auto-escaping. XSS sink on user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyFastAPI": {
+        "description": (
+            "FastAPI is a modern Python web framework built on Starlette and Pydantic. Path / query / "
+            "body parameters declared on endpoints are sources. Response helpers inherited from "
+            "Starlette include HTMLResponse and RedirectResponse (XSS and open-redirect sinks)."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["fastapi", "fastapi.Request", "starlette.requests.Request"],
+        "pip_snippet": "pip install fastapi",
+        "methods": {
+            "Request.query_params": {
+                "signature": "request.query_params: QueryParams",
+                "description": "URL query parameters. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.cookies": {
+                "signature": "request.cookies: dict[str, str]",
+                "description": "Request cookies. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.headers": {
+                "signature": "request.headers: Headers",
+                "description": "Request headers. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.json": {
+                "signature": "async Request.json() -> Any",
+                "description": "Parsed JSON request body. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "HTMLResponse": {
+                "signature": "HTMLResponse(content: str, status_code: int = 200, ...) -> Response",
+                "description": "Returns raw HTML. XSS sink when content contains unescaped user input.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "RedirectResponse": {
+                "signature": "RedirectResponse(url: str, status_code: int = 307, ...) -> Response",
+                "description": "Returns a redirect. Open-redirect sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Templating
+    # =====================================================================
+
+    "PyJinja2": {
+        "description": (
+            "Jinja2 is the template engine behind Flask and many Python frameworks. "
+            "Template(source).render() and Environment.from_string() evaluate template syntax — "
+            "SSTI sink when the template source comes from user input. Autoescape only protects "
+            "rendered output, not the template source itself."
+        ),
+        "category": "templating",
+        "fqns": ["jinja2", "jinja2.Template", "jinja2.Environment"],
+        "pip_snippet": "pip install jinja2",
+        "methods": {
+            "Template": {
+                "signature": "jinja2.Template(source: str, ...) -> Template",
+                "description": "Compiles a template from source. SSTI sink when source is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Environment.from_string": {
+                "signature": "Environment.from_string(source: str, ...) -> Template",
+                "description": "Compiles a template from source using this environment. Same SSTI risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "render": {
+                "signature": "Template.render(**context) -> str",
+                "description": "Renders a compiled template. Safe with autoescape=True on trusted templates; dangerous if the Template source itself was user-controlled.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # HTTP clients
+    # =====================================================================
+
+    "PyRequests": {
+        "description": (
+            "requests is the most popular HTTP client for Python. All top-level methods and "
+            "Session methods accept a URL as the first argument — SSRF sink when the URL is "
+            "user-controlled. verify=False disables TLS verification (separate rule)."
+        ),
+        "category": "http-clients",
+        "fqns": ["requests", "requests.Session"],
+        "pip_snippet": "pip install requests",
+        "methods": {
+            "get": {
+                "signature": "requests.get(url: str, params=None, **kwargs) -> Response",
+                "description": "Sends a GET request. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "post": {
+                "signature": "requests.post(url: str, data=None, json=None, **kwargs) -> Response",
+                "description": "Sends a POST request. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "put": {
+                "signature": "requests.put(url: str, data=None, **kwargs) -> Response",
+                "description": "Sends a PUT request. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "delete": {
+                "signature": "requests.delete(url: str, **kwargs) -> Response",
+                "description": "Sends a DELETE request. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "request": {
+                "signature": "requests.request(method: str, url: str, **kwargs) -> Response",
+                "description": "Sends a request with arbitrary method. SSRF sink on url.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyUrllib": {
+        "description": (
+            "urllib.request (stdlib) is the lowest-level HTTP client in Python. urlopen() accepts "
+            "both a URL string and a Request object — SSRF sink when the URL is user-controlled. "
+            "Unlike requests, urlopen defaults to no TLS verification on some platforms."
+        ),
+        "category": "http-clients",
+        "fqns": ["urllib.request"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "urlopen": {
+                "signature": "urllib.request.urlopen(url, data=None, timeout=None, ...) -> HTTPResponse",
+                "description": "Opens an HTTP(S) URL. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Request": {
+                "signature": "urllib.request.Request(url: str, data=None, headers={}, ...) -> Request",
+                "description": "Builds an HTTP request object. SSRF sink when url is user-controlled (passed later to urlopen).",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Deserialization — third party
+    # =====================================================================
+
+    "PyYaml": {
+        "description": (
+            "PyYAML is the standard YAML library. yaml.load() with the default Loader (or "
+            "UnsafeLoader / Loader) instantiates arbitrary Python classes — RCE sink on untrusted "
+            "input. Use yaml.safe_load() or Loader=yaml.SafeLoader instead."
+        ),
+        "category": "deserialization",
+        "fqns": ["yaml"],
+        "pip_snippet": "pip install pyyaml",
+        "methods": {
+            "load": {
+                "signature": "yaml.load(stream, Loader) -> Any",
+                "description": "Deserializes a YAML document. RCE sink under Loader / UnsafeLoader.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "load_all": {
+                "signature": "yaml.load_all(stream, Loader) -> Iterator[Any]",
+                "description": "Deserializes multiple YAML documents. Same RCE risk as load().",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "full_load": {
+                "signature": "yaml.full_load(stream) -> Any",
+                "description": "Uses FullLoader — safer than Loader but still resolves some Python tags. Prefer safe_load.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "safe_load": {
+                "signature": "yaml.safe_load(stream) -> Any",
+                "description": "Deserializes YAML using SafeLoader. Only built-in types. Use this.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "safe_load_all": {
+                "signature": "yaml.safe_load_all(stream) -> Iterator[Any]",
+                "description": "Safe multi-document load. Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # File system
+    # =====================================================================
+
+    "PyOSPath": {
+        "description": (
+            "The os.path module for path manipulation. join() concatenates path components but "
+            "does not resolve traversal sequences — path-traversal bug when joining a trusted "
+            "base with a user-controlled path. Use os.path.commonpath + realpath containment "
+            "checks to sanitize."
+        ),
+        "category": "file-system",
+        "fqns": ["os.path"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "join": {
+                "signature": "os.path.join(*paths: str) -> str",
+                "description": "Joins path components. Does NOT defend against ../ traversal — neutral, but the output often reaches file sinks.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "abspath": {
+                "signature": "os.path.abspath(path: str) -> str",
+                "description": "Returns the absolute path. Does not resolve symlinks.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "realpath": {
+                "signature": "os.path.realpath(path: str) -> str",
+                "description": "Resolves all symlinks and . / .. components. Combine with commonpath for traversal defense.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "commonpath": {
+                "signature": "os.path.commonpath(paths: Sequence[str]) -> str",
+                "description": "Returns the longest common path. Use to assert a user path stays inside a trusted base.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyTempfile": {
+        "description": (
+            "The tempfile module. mktemp() is deprecated and insecure (race condition between "
+            "filename generation and open). Use NamedTemporaryFile, mkstemp, or TemporaryDirectory "
+            "which atomically create the file."
+        ),
+        "category": "file-system",
+        "fqns": ["tempfile"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "mktemp": {
+                "signature": "tempfile.mktemp(suffix='', prefix='tmp', dir=None) -> str",
+                "description": "Returns a candidate temp file path without creating it. Insecure (TOCTOU) — finding whenever used.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "mkstemp": {
+                "signature": "tempfile.mkstemp(suffix=None, prefix=None, dir=None, text=False) -> (fd, path)",
+                "description": "Atomically creates a temp file and returns an open fd. Safe replacement for mktemp.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "NamedTemporaryFile": {
+                "signature": "tempfile.NamedTemporaryFile(mode='w+b', ...) -> _TemporaryFileWrapper",
+                "description": "Context-managed temp file. Atomic creation. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Archives
+    # =====================================================================
+
+    "PyTarfile": {
+        "description": (
+            "The tarfile module. extractall() and extract() follow archive entry paths as-is — "
+            "path-traversal sink (zip slip) when the archive is user-supplied and extractall's "
+            "filter= argument is not set to a safe filter. Python 3.12 changed the default to 'data'."
+        ),
+        "category": "archives",
+        "fqns": ["tarfile", "tarfile.TarFile"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "extractall": {
+                "signature": "TarFile.extractall(path='.', members=None, *, numeric_owner=False, filter=None) -> None",
+                "description": "Extracts all entries. Zip-slip sink when members comes from a hostile archive and filter is unset.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "extract": {
+                "signature": "TarFile.extract(member, path='', *, set_attrs=True, numeric_owner=False, filter=None) -> None",
+                "description": "Extracts a single entry. Same path-traversal risk as extractall.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "open": {
+                "signature": "tarfile.open(name=None, mode='r', fileobj=None, ...) -> TarFile",
+                "description": "Opens a tar archive. Neutral; extract() is where traversal happens.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyZipfile": {
+        "description": (
+            "The zipfile module. ZipFile.extractall() and extract() are zip-slip sinks when the "
+            "archive is untrusted. Python's extractall resolves .. segments in archive members "
+            "to paths outside the target directory."
+        ),
+        "category": "archives",
+        "fqns": ["zipfile", "zipfile.ZipFile"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "extractall": {
+                "signature": "ZipFile.extractall(path=None, members=None, pwd=None) -> None",
+                "description": "Extracts all members. Zip-slip sink on untrusted archives.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "extract": {
+                "signature": "ZipFile.extract(member, path=None, pwd=None) -> str",
+                "description": "Extracts a single member. Same zip-slip risk.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Cryptography
+    # =====================================================================
+
+    "PyHashlib": {
+        "description": (
+            "The hashlib module provides cryptographic hash functions. md5 and sha1 are "
+            "cryptographically broken — findings for password hashing / signature use. For "
+            "password hashing use hashlib.scrypt, pbkdf2_hmac, or the passlib / argon2-cffi packages."
+        ),
+        "category": "crypto",
+        "fqns": ["hashlib"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "md5": {
+                "signature": "hashlib.md5(data: bytes = b'', *, usedforsecurity=True) -> Hash",
+                "description": "MD5 hash. Broken for cryptographic use — finding for password hashing or digital signatures.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "sha1": {
+                "signature": "hashlib.sha1(data: bytes = b'', *, usedforsecurity=True) -> Hash",
+                "description": "SHA-1 hash. Broken for cryptographic use — finding for signature contexts.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "sha256": {
+                "signature": "hashlib.sha256(data: bytes = b'') -> Hash",
+                "description": "SHA-256 hash. Acceptable for digests; use scrypt / pbkdf2 for passwords.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "pbkdf2_hmac": {
+                "signature": "hashlib.pbkdf2_hmac(hash_name, password, salt, iterations, dklen=None) -> bytes",
+                "description": "Password-based key derivation. Safe with iterations ≥ 100_000.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "scrypt": {
+                "signature": "hashlib.scrypt(password, *, salt, n, r, p, maxmem=0, dklen=64) -> bytes",
+                "description": "Memory-hard password hash. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyHmac": {
+        "description": (
+            "The hmac module for keyed message authentication. compare_digest is the only "
+            "constant-time comparison helper — using ordinary == for MAC comparison is a timing-attack sink."
+        ),
+        "category": "crypto",
+        "fqns": ["hmac"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "new": {
+                "signature": "hmac.new(key: bytes, msg: bytes = None, digestmod='') -> HMAC",
+                "description": "Creates an HMAC instance. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "compare_digest": {
+                "signature": "hmac.compare_digest(a, b) -> bool",
+                "description": "Constant-time comparison. Sanitizer for signature verification flows.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PySecrets": {
+        "description": (
+            "The secrets module provides cryptographically strong random values suitable for "
+            "managing authentication tokens. Use secrets instead of the random module for "
+            "session IDs, tokens, and CSRF nonces."
+        ),
+        "category": "crypto",
+        "fqns": ["secrets"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "token_bytes": {
+                "signature": "secrets.token_bytes(nbytes: int | None = None) -> bytes",
+                "description": "Cryptographically secure random bytes. Safe source for tokens.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "token_hex": {
+                "signature": "secrets.token_hex(nbytes: int | None = None) -> str",
+                "description": "Hex-encoded secure random token. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "token_urlsafe": {
+                "signature": "secrets.token_urlsafe(nbytes: int | None = None) -> str",
+                "description": "URL-safe base64 secure random token. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "compare_digest": {
+                "signature": "secrets.compare_digest(a, b) -> bool",
+                "description": "Constant-time comparison. Sanitizer for secret comparison.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "choice": {
+                "signature": "secrets.choice(seq)",
+                "description": "Cryptographically secure random choice from a non-empty sequence.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyRandom": {
+        "description": (
+            "The random module uses a Mersenne Twister PRNG — NOT suitable for cryptography. "
+            "random.random, random.choice, random.randint, and SystemRandom(..) should be flagged "
+            "for security contexts. Use the secrets module for tokens, passwords, and keys."
+        ),
+        "category": "crypto",
+        "fqns": ["random"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "random": {
+                "signature": "random.random() -> float",
+                "description": "Non-crypto float in [0.0, 1.0). Sink for security-relevant randomness.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "randint": {
+                "signature": "random.randint(a: int, b: int) -> int",
+                "description": "Non-crypto integer in [a, b]. Sink for security-relevant randomness.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "choice": {
+                "signature": "random.choice(seq)",
+                "description": "Non-crypto random choice. Sink for tokens / passwords / keys.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "randbytes": {
+                "signature": "random.randbytes(n: int) -> bytes",
+                "description": "Non-crypto random bytes. Sink for cryptographic use.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "seed": {
+                "signature": "random.seed(a=None, version=2) -> None",
+                "description": "Seeds the PRNG. Findings when seeded with predictable value for security-sensitive randomness.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PySsl": {
+        "description": (
+            "The ssl module for TLS / SSL. SSLContext with verify_mode=CERT_NONE disables "
+            "certificate validation (MITM risk). _create_unverified_context() is an explicit "
+            "bypass — finding for any production code. Use create_default_context() for sane defaults."
+        ),
+        "category": "crypto",
+        "fqns": ["ssl"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "create_default_context": {
+                "signature": "ssl.create_default_context(purpose=Purpose.SERVER_AUTH, ...) -> SSLContext",
+                "description": "Creates a context with safe defaults (verify, hostname check). Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "_create_unverified_context": {
+                "signature": "ssl._create_unverified_context() -> SSLContext",
+                "description": "Returns a context that skips verification. Always a finding in production code.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "wrap_socket": {
+                "signature": "ssl.wrap_socket(sock, ssl_version=..., cert_reqs=CERT_NONE, ...) -> SSLSocket",
+                "description": "Legacy socket wrapping. Finding when cert_reqs=CERT_NONE.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "SSLContext": {
+                "signature": "ssl.SSLContext(protocol=PROTOCOL_TLS) -> SSLContext",
+                "description": "TLS context. Finding when .check_hostname is False or .verify_mode is CERT_NONE.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — parsers & eval
+    # =====================================================================
+
+    "PyAst": {
+        "description": (
+            "The ast module exposes Python's abstract syntax tree. ast.literal_eval is a safe "
+            "evaluator for literals only. The builtins eval() and exec() execute arbitrary Python "
+            "code — RCE sinks on user input. compile() produces code objects that reach exec()."
+        ),
+        "category": "deserialization",
+        "fqns": ["ast", "builtins"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "literal_eval": {
+                "signature": "ast.literal_eval(node_or_string) -> Any",
+                "description": "Safely evaluates Python literals (str, int, list, dict, tuple, bool, None). Sanitizer replacement for eval().",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "parse": {
+                "signature": "ast.parse(source, filename='<unknown>', mode='exec', ...) -> Module",
+                "description": "Parses source into an AST. Neutral on its own.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "eval": {
+                "signature": "eval(expression, globals=None, locals=None) -> Any",
+                "description": "Evaluates a Python expression. RCE sink when expression is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "exec": {
+                "signature": "exec(object, globals=None, locals=None) -> None",
+                "description": "Executes Python code. RCE sink on user-controlled source.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "compile": {
+                "signature": "compile(source, filename, mode, flags=0, dont_inherit=False, optimize=-1)",
+                "description": "Compiles source to a code object. Reaches exec / eval. Sink on user-controlled source.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyJson": {
+        "description": (
+            "The json module for JSON encode / decode. Unlike pickle, json is safe by default — "
+            "only parses primitives, lists, dicts. Still worth documenting because json.loads is a "
+            "common source entry point and json.dumps on response values is where reflected XSS originates."
+        ),
+        "category": "deserialization",
+        "fqns": ["json"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "loads": {
+                "signature": "json.loads(s: str | bytes, ...) -> Any",
+                "description": "Parses a JSON string. Safe by default. Source for user-controlled JSON input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "load": {
+                "signature": "json.load(fp, ...) -> Any",
+                "description": "Parses JSON from a file. Safe. Source when fp is user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "dumps": {
+                "signature": "json.dumps(obj, *, ensure_ascii=True, ...) -> str",
+                "description": "Serializes obj to JSON. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "dump": {
+                "signature": "json.dump(obj, fp, ...) -> None",
+                "description": "Writes JSON to a file. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — HTTP / networking
+    # =====================================================================
+
+    "PyHttpClient": {
+        "description": (
+            "The http.client module provides low-level HTTP primitives. HTTPConnection / "
+            "HTTPSConnection.request() is an SSRF sink when the host or path comes from user input. "
+            "HTTPSConnection with context=None falls back to system default TLS settings."
+        ),
+        "category": "http-clients",
+        "fqns": ["http.client", "http.client.HTTPConnection", "http.client.HTTPSConnection"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "HTTPConnection": {
+                "signature": "http.client.HTTPConnection(host, port=None, ...) -> HTTPConnection",
+                "description": "Opens an HTTP connection. SSRF sink when host is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "HTTPSConnection": {
+                "signature": "http.client.HTTPSConnection(host, port=None, *, context=None, ...) -> HTTPSConnection",
+                "description": "Opens an HTTPS connection. SSRF sink on host. context=None uses defaults.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "request": {
+                "signature": "HTTPConnection.request(method: str, url: str, body=None, headers={}) -> None",
+                "description": "Sends an HTTP request. SSRF sink when url is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PySocket": {
+        "description": (
+            "The socket module for low-level network operations. socket.connect() is an SSRF "
+            "primitive when the host / port comes from user input. socket.bind() on 0.0.0.0 is "
+            "a finding for services that should be localhost-only."
+        ),
+        "category": "http-clients",
+        "fqns": ["socket"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "socket": {
+                "signature": "socket.socket(family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None) -> socket",
+                "description": "Creates a socket. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "connect": {
+                "signature": "socket.connect(address: tuple | str) -> None",
+                "description": "Connects to a remote address. SSRF sink when address is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "bind": {
+                "signature": "socket.bind(address: tuple | str) -> None",
+                "description": "Binds to a local address. Finding when bound to 0.0.0.0 or '' on internal services.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "create_connection": {
+                "signature": "socket.create_connection(address, timeout=..., source_address=None) -> socket",
+                "description": "High-level connection helper. SSRF sink on address.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyUrllibParse": {
+        "description": (
+            "The urllib.parse module for URL parsing and building. urljoin is commonly used to "
+            "build request URLs — when the base is user-controlled, attackers can redirect to "
+            "arbitrary hosts. urlparse can be used as a sanitizer for SSRF if the netloc is validated."
+        ),
+        "category": "http-clients",
+        "fqns": ["urllib.parse"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "urlparse": {
+                "signature": "urllib.parse.urlparse(urlstring: str, scheme='', allow_fragments=True) -> ParseResult",
+                "description": "Parses a URL into components. Building block for SSRF sanitization (check netloc).",
+                "role": "neutral",
+                "tracks": ["return"],
+            },
+            "urljoin": {
+                "signature": "urllib.parse.urljoin(base: str, url: str, allow_fragments=True) -> str",
+                "description": "Joins a base URL and a relative URL. Neutral; output often reaches HTTP sinks.",
+                "role": "neutral",
+                "tracks": ["return"],
+            },
+            "quote": {
+                "signature": "urllib.parse.quote(string, safe='/', ...) -> str",
+                "description": "Percent-encodes a URL component. Sanitizer when used on user input before URL concat.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "quote_plus": {
+                "signature": "urllib.parse.quote_plus(string, safe='', ...) -> str",
+                "description": "Like quote but encodes spaces as +. Sanitizer for query strings.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyFtplib": {
+        "description": (
+            "The ftplib module for FTP (insecure plaintext protocol). FTP() connects unencrypted; "
+            "FTP_TLS is the secure variant. Any use of the plain FTP class is a finding for sensitive "
+            "data flows."
+        ),
+        "category": "http-clients",
+        "fqns": ["ftplib"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "FTP": {
+                "signature": "ftplib.FTP(host='', user='', passwd='', acct='', timeout=...) -> FTP",
+                "description": "Opens a plaintext FTP session. Finding — credentials transmitted unencrypted.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "FTP_TLS": {
+                "signature": "ftplib.FTP_TLS(host='', user='', passwd='', ...) -> FTP_TLS",
+                "description": "Opens an FTPS session. Secure replacement.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyTelnetlib": {
+        "description": (
+            "The telnetlib module for Telnet (insecure plaintext protocol). Any use of Telnet is "
+            "a finding; use paramiko / SSH instead. Deprecated since 3.11, removed in 3.13."
+        ),
+        "category": "http-clients",
+        "fqns": ["telnetlib"],
+        "pip_snippet": "# stdlib — no install required (removed in Python 3.13)",
+        "methods": {
+            "Telnet": {
+                "signature": "telnetlib.Telnet(host=None, port=0, timeout=...) -> Telnet",
+                "description": "Opens a plaintext Telnet session. Finding — deprecated and insecure.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PySmtplib": {
+        "description": (
+            "The smtplib module for SMTP. SMTP() uses plaintext unless starttls() is called. "
+            "SMTP_SSL is the always-encrypted variant. Rule writers also target email header / "
+            "recipient construction for header-injection sinks."
+        ),
+        "category": "http-clients",
+        "fqns": ["smtplib"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "SMTP": {
+                "signature": "smtplib.SMTP(host='', port=0, local_hostname=None, ...) -> SMTP",
+                "description": "Opens a plaintext SMTP session. Finding if starttls is not called later.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "SMTP_SSL": {
+                "signature": "smtplib.SMTP_SSL(host='', port=0, ..., context=None) -> SMTP_SSL",
+                "description": "Opens an SMTP session over TLS. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "sendmail": {
+                "signature": "SMTP.sendmail(from_addr, to_addrs, msg, mail_options=(), rcpt_options=())",
+                "description": "Sends an email. Header-injection sink when msg / to_addrs is user-controlled without sanitization.",
+                "role": "sink",
+                "tracks": [1, 2],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — file system
+    # =====================================================================
+
+    "PyPathlib": {
+        "description": (
+            "The pathlib module is the modern OO path API. Path.resolve() expands symlinks "
+            "(sanitizer when combined with containment check). Path.open / read_text / write_text "
+            "are file I/O sinks when the path is user-controlled."
+        ),
+        "category": "file-system",
+        "fqns": ["pathlib", "pathlib.Path"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "Path": {
+                "signature": "pathlib.Path(*pathsegments) -> Path",
+                "description": "Constructs a path. Neutral; does not defend against traversal.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "resolve": {
+                "signature": "Path.resolve(strict=False) -> Path",
+                "description": "Resolves symlinks and relative segments. Use with relative_to() for traversal defense.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "open": {
+                "signature": "Path.open(mode='r', buffering=-1, ...) -> IO",
+                "description": "Opens the file at this path. Path-traversal sink when path is user-controlled.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "read_text": {
+                "signature": "Path.read_text(encoding=None, errors=None) -> str",
+                "description": "Reads the whole file as text. Path-traversal sink.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "write_text": {
+                "signature": "Path.write_text(data, encoding=None, errors=None, newline=None) -> int",
+                "description": "Writes text. Path-traversal sink when path is user-controlled.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyShutil": {
+        "description": (
+            "The shutil module for high-level file operations. unpack_archive automatically "
+            "extracts tar / zip / gztar / bztar / xztar archives — same zip-slip risks as "
+            "tarfile.extractall. copytree can also be used for path-traversal."
+        ),
+        "category": "file-system",
+        "fqns": ["shutil"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "unpack_archive": {
+                "signature": "shutil.unpack_archive(filename, extract_dir=None, format=None) -> None",
+                "description": "Unpacks an archive. Zip-slip sink on untrusted archives — uses tarfile / zipfile under the hood.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "copyfile": {
+                "signature": "shutil.copyfile(src, dst, *, follow_symlinks=True) -> str",
+                "description": "Copies a file. Path-traversal sink when src / dst is user-controlled.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+            "copytree": {
+                "signature": "shutil.copytree(src, dst, symlinks=False, ...) -> str",
+                "description": "Recursively copies a directory. Path-traversal sink on untrusted paths.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+            "rmtree": {
+                "signature": "shutil.rmtree(path, ignore_errors=False, onerror=None) -> None",
+                "description": "Recursively deletes a directory tree. Finding on user-controlled path (arbitrary-file-delete).",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "which": {
+                "signature": "shutil.which(cmd, mode=os.F_OK | os.X_OK, path=None) -> str | None",
+                "description": "Locates an executable on PATH. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyShlex": {
+        "description": (
+            "The shlex module provides shell-compatible tokenization and quoting. shlex.quote "
+            "is the canonical sanitizer for shell=True command construction. shlex.split is safer "
+            "than splitting yourself, but quote is what protects against shell-metacharacter injection."
+        ),
+        "category": "command-execution",
+        "fqns": ["shlex"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "quote": {
+                "signature": "shlex.quote(s: str) -> str",
+                "description": "Returns a shell-escaped version of s. Sanitizer for shell=True sinks.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "split": {
+                "signature": "shlex.split(s, comments=False, posix=True) -> list[str]",
+                "description": "Splits a string using shell-like syntax. Sanitizer when producing list[str] for subprocess (implies shell=False).",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "join": {
+                "signature": "shlex.join(split_command: Iterable[str]) -> str",
+                "description": "Joins tokens with proper shell quoting.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — XML
+    # =====================================================================
+
+    "PyXmlEtree": {
+        "description": (
+            "xml.etree.ElementTree is the stdlib XML parser. The C-accelerated parser has some "
+            "built-in protections but still processes external entities in some configurations — "
+            "XXE sink. Prefer defusedxml for untrusted XML."
+        ),
+        "category": "deserialization",
+        "fqns": ["xml.etree.ElementTree"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "parse": {
+                "signature": "xml.etree.ElementTree.parse(source, parser=None) -> ElementTree",
+                "description": "Parses an XML file. XXE sink under certain Python versions / custom parsers.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "fromstring": {
+                "signature": "xml.etree.ElementTree.fromstring(text, parser=None) -> Element",
+                "description": "Parses XML from a string. Same XXE considerations as parse().",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "XMLParser": {
+                "signature": "xml.etree.ElementTree.XMLParser(*, target=None, encoding=None) -> XMLParser",
+                "description": "Custom parser. Pair with untrusted input to produce XXE.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyXmlSax": {
+        "description": (
+            "xml.sax is the stdlib SAX parser. By default it resolves external entities — XXE "
+            "sink on untrusted XML. Disable with parser.setFeature(feature_external_ges, False) "
+            "or use defusedxml.sax."
+        ),
+        "category": "deserialization",
+        "fqns": ["xml.sax"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "parse": {
+                "signature": "xml.sax.parse(source, handler, error_handler=...) -> None",
+                "description": "Parses XML with a SAX handler. XXE sink by default.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "parseString": {
+                "signature": "xml.sax.parseString(string, handler, error_handler=...) -> None",
+                "description": "Parses XML from a string. XXE sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "make_parser": {
+                "signature": "xml.sax.make_parser(parser_list=()) -> XMLReader",
+                "description": "Creates a SAX parser. XXE-prone unless external entities are disabled.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyXmlDom": {
+        "description": (
+            "xml.dom.minidom for DOM-style XML parsing. Built on pyexpat which by default does "
+            "not resolve external entities, but custom resolvers can reintroduce XXE. "
+            "defusedxml.minidom is the hardened replacement."
+        ),
+        "category": "deserialization",
+        "fqns": ["xml.dom", "xml.dom.minidom"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "parse": {
+                "signature": "xml.dom.minidom.parse(file, parser=None, bufsize=None) -> Document",
+                "description": "Parses XML file via minidom. XXE sink on custom parsers that resolve externals.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "parseString": {
+                "signature": "xml.dom.minidom.parseString(string, parser=None) -> Document",
+                "description": "Parses XML string. Same XXE considerations.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyXmlrpc": {
+        "description": (
+            "xmlrpc.client and xmlrpc.server. ServerProxy RPCs execute arbitrary methods — "
+            "dispatch on untrusted method names is a sink. ServerProxy + HTTP (not HTTPS) transmits "
+            "credentials in plaintext."
+        ),
+        "category": "deserialization",
+        "fqns": ["xmlrpc.client", "xmlrpc.server"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "ServerProxy": {
+                "signature": "xmlrpc.client.ServerProxy(uri, transport=None, encoding=None, verbose=False, ...) -> ServerProxy",
+                "description": "Opens an XML-RPC connection. Finding on http:// URIs (credentials in plaintext).",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "loads": {
+                "signature": "xmlrpc.client.loads(data, use_datetime=False, use_builtin_types=False) -> (params, methodname)",
+                "description": "Parses an XML-RPC response. Inherits XXE surface from the XML parser.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — misc
+    # =====================================================================
+
+    "PyZlib": {
+        "description": (
+            "The zlib module for compression. decompress() on untrusted input can consume "
+            "unbounded memory (zip bomb / decompression amplification). Set max_length to cap output."
+        ),
+        "category": "archives",
+        "fqns": ["zlib"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "decompress": {
+                "signature": "zlib.decompress(data: bytes, wbits=MAX_WBITS, bufsize=DEF_BUF_SIZE) -> bytes",
+                "description": "Decompresses zlib / deflate data. Decompression-bomb sink on untrusted input without length cap.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "decompressobj": {
+                "signature": "zlib.decompressobj(wbits=MAX_WBITS, zdict=b'') -> Decompress",
+                "description": "Returns a streaming decompressor. Use with .decompress(data, max_length) to cap output.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyShelve": {
+        "description": (
+            "The shelve module persists arbitrary Python objects — backed by pickle under the "
+            "hood. shelve.open() on untrusted files is a deserialization sink (RCE via pickle's "
+            "__reduce__)."
+        ),
+        "category": "deserialization",
+        "fqns": ["shelve"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "open": {
+                "signature": "shelve.open(filename, flag='c', protocol=None, writeback=False) -> Shelf",
+                "description": "Opens a shelf (pickle-backed dict). Deserialization sink on untrusted files.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyLogging": {
+        "description": (
+            "The logging module. Most uses are neutral. Log-injection findings arise when "
+            "user-controlled data is logged without sanitization — attackers can break log "
+            "line boundaries with \\n or forge subsequent log entries."
+        ),
+        "category": "file-system",
+        "fqns": ["logging"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "info": {
+                "signature": "logging.info(msg, *args, **kwargs) -> None",
+                "description": "Writes an info log. Log-injection sink when msg is tainted and contains newlines.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "error": {
+                "signature": "logging.error(msg, *args, **kwargs) -> None",
+                "description": "Writes an error log. Log-injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "warning": {
+                "signature": "logging.warning(msg, *args, **kwargs) -> None",
+                "description": "Writes a warning log. Log-injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "debug": {
+                "signature": "logging.debug(msg, *args, **kwargs) -> None",
+                "description": "Writes a debug log. Log-injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — databases
+    # =====================================================================
+
+    "PySqlalchemy": {
+        "description": (
+            "SQLAlchemy is the most-used Python ORM. The text() wrapper and raw execute() are "
+            "SQL injection sinks when the SQL is built from user input. Core and ORM query APIs "
+            "with bound parameters are safe."
+        ),
+        "category": "databases",
+        "fqns": ["sqlalchemy", "sqlalchemy.engine.Engine", "sqlalchemy.orm.Session"],
+        "pip_snippet": "pip install sqlalchemy",
+        "methods": {
+            "text": {
+                "signature": "sqlalchemy.text(text: str) -> TextClause",
+                "description": "Wraps a raw SQL string. SQL injection sink when text is built from user input without :bindparams.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Engine.execute": {
+                "signature": "Engine.execute(statement, *multiparams, **params) -> CursorResult",
+                "description": "Executes a statement. Injection sink when statement is a raw string.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Connection.execute": {
+                "signature": "Connection.execute(statement, parameters=None, ...) -> CursorResult",
+                "description": "Executes a statement. Injection sink when statement is a raw string without text() + bindparams.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "Session.execute": {
+                "signature": "Session.execute(statement, params=None, ...) -> Result",
+                "description": "Executes a statement. Injection sink on raw strings.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPymysql": {
+        "description": (
+            "PyMySQL is a pure-Python MySQL driver. Cursor.execute() accepts a raw query and "
+            "parameter tuple — injection sink when the query is built from user input without "
+            "the %s placeholder."
+        ),
+        "category": "databases",
+        "fqns": ["pymysql", "pymysql.cursors.Cursor"],
+        "pip_snippet": "pip install pymysql",
+        "methods": {
+            "connect": {
+                "signature": "pymysql.connect(host='localhost', user=None, password='', ...) -> Connection",
+                "description": "Opens a MySQL connection.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "execute": {
+                "signature": "Cursor.execute(query: str, args=None) -> int",
+                "description": "Executes a query. SQL injection sink when query is built from user input without %s.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "executemany": {
+                "signature": "Cursor.executemany(query: str, args: Sequence) -> int",
+                "description": "Executes a query many times. Same injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyMysqlDb": {
+        "description": (
+            "MySQLdb (mysqlclient) is a C-extension MySQL driver. Cursor.execute() is an SQL "
+            "injection sink when the query is built without %s placeholders."
+        ),
+        "category": "databases",
+        "fqns": ["MySQLdb", "MySQLdb.cursors.Cursor"],
+        "pip_snippet": "pip install mysqlclient",
+        "methods": {
+            "connect": {
+                "signature": "MySQLdb.connect(host='localhost', user=None, passwd='', ...) -> Connection",
+                "description": "Opens a MySQL connection.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "execute": {
+                "signature": "Cursor.execute(query: str, args=None) -> int",
+                "description": "Executes a query. SQL injection sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "executemany": {
+                "signature": "Cursor.executemany(query: str, args: Sequence) -> int",
+                "description": "Batched query execution. Same injection risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — HTTP
+    # =====================================================================
+
+    "PyHttpx": {
+        "description": (
+            "httpx is a modern async-capable HTTP client. Identical SSRF surface to requests — "
+            "the URL argument on get/post/etc is a sink when user-controlled. verify=False "
+            "disables TLS verification (separate rule)."
+        ),
+        "category": "http-clients",
+        "fqns": ["httpx", "httpx.Client", "httpx.AsyncClient"],
+        "pip_snippet": "pip install httpx",
+        "methods": {
+            "get": {
+                "signature": "httpx.get(url, *, params=None, headers=None, ...) -> Response",
+                "description": "Sends a GET request. SSRF sink on url.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "post": {
+                "signature": "httpx.post(url, *, content=None, data=None, json=None, ...) -> Response",
+                "description": "Sends a POST request. SSRF sink on url.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "put": {
+                "signature": "httpx.put(url, *, content=None, data=None, ...) -> Response",
+                "description": "Sends a PUT request. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "delete": {
+                "signature": "httpx.delete(url, ...) -> Response",
+                "description": "Sends a DELETE request. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "stream": {
+                "signature": "httpx.stream(method, url, ...) -> ContextManager[Response]",
+                "description": "Streams a response. SSRF sink on url.",
+                "role": "sink",
+                "tracks": [1],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyHttplib2": {
+        "description": (
+            "httplib2 is an HTTP client with advanced caching features. Http.request() is an "
+            "SSRF sink when the URI is user-controlled."
+        ),
+        "category": "http-clients",
+        "fqns": ["httplib2", "httplib2.Http"],
+        "pip_snippet": "pip install httplib2",
+        "methods": {
+            "Http": {
+                "signature": "httplib2.Http(cache=None, timeout=None, proxy_info=..., ca_certs=None, disable_ssl_certificate_validation=False) -> Http",
+                "description": "Creates an HTTP client. Finding when disable_ssl_certificate_validation=True.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "request": {
+                "signature": "Http.request(uri, method='GET', body=None, headers=None, ...) -> (Response, bytes)",
+                "description": "Sends an HTTP request. SSRF sink on uri.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — XML / parsing
+    # =====================================================================
+
+    "PyLxml": {
+        "description": (
+            "lxml is the C-backed XML / HTML parser. etree.parse / fromstring with a custom "
+            "XMLParser(resolve_entities=True) is an XXE sink. Default behavior in recent lxml is "
+            "safer but the API still allows unsafe configurations."
+        ),
+        "category": "deserialization",
+        "fqns": ["lxml", "lxml.etree"],
+        "pip_snippet": "pip install lxml",
+        "methods": {
+            "parse": {
+                "signature": "lxml.etree.parse(source, parser=None, base_url=None) -> ElementTree",
+                "description": "Parses XML. XXE sink when parser has resolve_entities=True.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "fromstring": {
+                "signature": "lxml.etree.fromstring(text, parser=None, base_url=None) -> Element",
+                "description": "Parses XML from string. XXE sink under unsafe parser config.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "XMLParser": {
+                "signature": "lxml.etree.XMLParser(resolve_entities=False, no_network=True, ...) -> XMLParser",
+                "description": "Creates an XML parser. Finding when resolve_entities=True or no_network=False.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "HTMLParser": {
+                "signature": "lxml.etree.HTMLParser(recover=True, ...) -> HTMLParser",
+                "description": "HTML parser variant. Less XXE risk than XML but still processes entities.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyDefusedXml": {
+        "description": (
+            "defusedxml is the hardened XML parser suite. It wraps xml.etree, xml.sax, xml.dom, "
+            "lxml etc. with external-entity resolution disabled. Using defusedxml counterparts "
+            "is the recommended sanitizer for XML sources."
+        ),
+        "category": "deserialization",
+        "fqns": ["defusedxml"],
+        "pip_snippet": "pip install defusedxml",
+        "methods": {
+            "parse": {
+                "signature": "defusedxml.ElementTree.parse(source, parser=None) -> ElementTree",
+                "description": "Safe XML parse. XXE-free. Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "fromstring": {
+                "signature": "defusedxml.ElementTree.fromstring(text, parser=None) -> Element",
+                "description": "Safe XML parse from string. Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — auth / crypto
+    # =====================================================================
+
+    "PyJose": {
+        "description": (
+            "python-jose implements JWT / JWS / JWE. jwt.decode() is the canonical validation "
+            "entry point. Finding when algorithms=['none'] is passed (unsigned token acceptance) or "
+            "verify_signature=False."
+        ),
+        "category": "crypto",
+        "fqns": ["jose", "jose.jwt"],
+        "pip_snippet": "pip install python-jose",
+        "methods": {
+            "encode": {
+                "signature": "jose.jwt.encode(claims, key, algorithm='HS256', ...) -> str",
+                "description": "Signs a JWT. Safe with a proper algorithm.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "decode": {
+                "signature": "jose.jwt.decode(token, key, algorithms=None, options=None, ...) -> dict",
+                "description": "Verifies and decodes a JWT. Finding when algorithms contains 'none' or options disable verification.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "get_unverified_header": {
+                "signature": "jose.jwt.get_unverified_header(token) -> dict",
+                "description": "Reads the JWT header without verifying the signature. Finding when return value drives auth decisions.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "get_unverified_claims": {
+                "signature": "jose.jwt.get_unverified_claims(token) -> dict",
+                "description": "Reads claims without verifying. Finding for authz code.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyAuthlib": {
+        "description": (
+            "Authlib is a comprehensive OAuth / OpenID / JWT library. JsonWebToken.decode() and "
+            "the OAuth client Client.parse_request_body_response track access-token flows."
+        ),
+        "category": "crypto",
+        "fqns": ["authlib", "authlib.jose"],
+        "pip_snippet": "pip install authlib",
+        "methods": {
+            "jwt.encode": {
+                "signature": "authlib.jose.jwt.encode(header, payload, key, check=True) -> bytes",
+                "description": "Signs a JWT. Neutral with safe algorithm.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "jwt.decode": {
+                "signature": "authlib.jose.jwt.decode(s, key, claims_cls=..., claims_options=..., ...) -> JWTClaims",
+                "description": "Verifies and decodes a JWT. Finding under permissive claims_options.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyParamiko": {
+        "description": (
+            "paramiko is the SSH / SFTP client for Python. SSHClient.set_missing_host_key_policy "
+            "with AutoAddPolicy() silently trusts unknown hosts — MITM risk. exec_command() is a "
+            "command-execution sink when the command is user-controlled."
+        ),
+        "category": "crypto",
+        "fqns": ["paramiko", "paramiko.SSHClient"],
+        "pip_snippet": "pip install paramiko",
+        "methods": {
+            "SSHClient": {
+                "signature": "paramiko.SSHClient() -> SSHClient",
+                "description": "Creates an SSH client.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "set_missing_host_key_policy": {
+                "signature": "SSHClient.set_missing_host_key_policy(policy: MissingHostKeyPolicy)",
+                "description": "Sets host-key policy. Finding when policy is AutoAddPolicy() or WarningPolicy() (MITM).",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "connect": {
+                "signature": "SSHClient.connect(hostname, port=22, username=None, password=None, ...) -> None",
+                "description": "Connects to an SSH server. SSRF-like sink when hostname is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "exec_command": {
+                "signature": "SSHClient.exec_command(command: str, bufsize=-1, ...) -> (stdin, stdout, stderr)",
+                "description": "Runs a command on the remote host. Command-injection sink on user-controlled command.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyLdap3": {
+        "description": (
+            "ldap3 is a pure-Python LDAP client. Connection.search() accepts a search_filter — "
+            "LDAP injection sink when the filter is built from user input without escaping. "
+            "Use ldap3.utils.conv.escape_filter_chars() for safe construction."
+        ),
+        "category": "databases",
+        "fqns": ["ldap3", "ldap3.Connection"],
+        "pip_snippet": "pip install ldap3",
+        "methods": {
+            "Connection": {
+                "signature": "ldap3.Connection(server, user=None, password=None, ...) -> Connection",
+                "description": "Creates an LDAP connection.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "search": {
+                "signature": "Connection.search(search_base, search_filter, search_scope=SUBTREE, ...) -> bool",
+                "description": "Runs an LDAP search. Injection sink when search_filter is built from user input.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "bind": {
+                "signature": "Connection.bind() -> bool",
+                "description": "Binds / authenticates. Neutral.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — misc
+    # =====================================================================
+
+    "PyBleach": {
+        "description": (
+            "bleach is an HTML sanitizer library. bleach.clean() strips dangerous tags and "
+            "attributes — sanitizer for XSS flows. bleach.linkify() is also safe."
+        ),
+        "category": "templating",
+        "fqns": ["bleach"],
+        "pip_snippet": "pip install bleach",
+        "methods": {
+            "clean": {
+                "signature": "bleach.clean(text, tags=..., attributes=..., styles=..., ...) -> str",
+                "description": "Strips dangerous HTML from text. XSS sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "linkify": {
+                "signature": "bleach.linkify(text, callbacks=..., skip_tags=None, parse_email=False) -> str",
+                "description": "Converts URLs to safe <a> tags. Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyWerkzeug": {
+        "description": (
+            "Werkzeug is the WSGI toolkit Flask is built on. safe_join() is the canonical "
+            "path-traversal sanitizer for serving files. utils.redirect is where Flask's open-redirect "
+            "surface originates."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["werkzeug"],
+        "pip_snippet": "pip install werkzeug",
+        "methods": {
+            "safe_join": {
+                "signature": "werkzeug.utils.safe_join(directory: str, *pathnames) -> str | None",
+                "description": "Safely joins a base directory with user-supplied components. Path-traversal sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "redirect": {
+                "signature": "werkzeug.utils.redirect(location: str, code: int = 302, Response=None) -> Response",
+                "description": "Returns a redirect response. Open-redirect sink on user-controlled location.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "send_file": {
+                "signature": "werkzeug.utils.send_file(path_or_file, environ, mimetype=None, ...) -> Response",
+                "description": "Serves a file. Path-traversal sink on user-controlled path.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyJsonschema": {
+        "description": (
+            "jsonschema validates JSON documents against a schema. validate() is a sanitizer for "
+            "shape-checking untrusted JSON before passing fields to other sinks."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["jsonschema"],
+        "pip_snippet": "pip install jsonschema",
+        "methods": {
+            "validate": {
+                "signature": "jsonschema.validate(instance, schema, cls=None, ...) -> None",
+                "description": "Raises ValidationError on mismatch. Sanitizer when it passes.",
+                "role": "sanitizer",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPydantic": {
+        "description": (
+            "Pydantic provides strict type-validated models. BaseModel parses / coerces input and "
+            "raises on mismatch — the parsed model is a sanitizer for the raw input. Still, string "
+            "fields on the model can remain tainted (not magically escaped)."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["pydantic", "pydantic.BaseModel"],
+        "pip_snippet": "pip install pydantic",
+        "methods": {
+            "BaseModel": {
+                "signature": "pydantic.BaseModel(**data: Any)",
+                "description": "Constructs a validated model. Sanitizer for type / shape. String fields remain tainted.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "parse_obj": {
+                "signature": "BaseModel.parse_obj(obj: Any) -> BaseModel",
+                "description": "Parses a dict into a model. Sanitizer for shape.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "parse_raw": {
+                "signature": "BaseModel.parse_raw(b: str | bytes, ...) -> BaseModel",
+                "description": "Parses JSON / bytes into a model. Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyBoto3": {
+        "description": (
+            "boto3 is the AWS SDK for Python. client('s3').get_object(...) and similar operations "
+            "commonly ingest user input into bucket / key names — SSRF-like vectors through S3 URLs "
+            "and IAM misconfiguration. Covering for rule writers that check AWS-specific patterns."
+        ),
+        "category": "http-clients",
+        "fqns": ["boto3"],
+        "pip_snippet": "pip install boto3",
+        "methods": {
+            "client": {
+                "signature": "boto3.client(service_name, region_name=None, ...) -> BaseClient",
+                "description": "Creates a service client.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "resource": {
+                "signature": "boto3.resource(service_name, region_name=None, ...) -> ServiceResource",
+                "description": "Creates a higher-level resource client.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyAiofiles": {
+        "description": (
+            "aiofiles provides async file I/O. aiofiles.open() is a path-traversal sink when "
+            "the path is user-controlled (same as built-in open)."
+        ),
+        "category": "file-system",
+        "fqns": ["aiofiles"],
+        "pip_snippet": "pip install aiofiles",
+        "methods": {
+            "open": {
+                "signature": "aiofiles.open(file, mode='r', buffering=-1, encoding=None, ...) -> AsyncTextIOWrapper",
+                "description": "Async file open. Path-traversal sink on user-controlled file path.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — HTML / escaping / templating
+    # =====================================================================
+
+    "PyHtml": {
+        "description": (
+            "The html module. html.escape() is the canonical XSS sanitizer for writing user "
+            "input into HTML text content. html.unescape() does the inverse and should NOT be "
+            "used on output paths."
+        ),
+        "category": "templating",
+        "fqns": ["html", "html.parser"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "escape": {
+                "signature": "html.escape(s: str, quote: bool = True) -> str",
+                "description": "Escapes &, <, > and optionally \" and ' for HTML text. XSS sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "unescape": {
+                "signature": "html.unescape(s: str) -> str",
+                "description": "Converts HTML entities back to chars. Inverse of escape(). Not a sanitizer.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyStringTemplate": {
+        "description": (
+            "string.Template and string.Formatter. Template($var) substitution is safe when "
+            "placeholders are explicit. Formatter.format() with user-controlled format_spec is "
+            "a format-string injection vector."
+        ),
+        "category": "templating",
+        "fqns": ["string"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "Template": {
+                "signature": "string.Template(template: str) -> Template",
+                "description": "Creates a $-substitution template. Neutral; substitute() is the rendering step.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Formatter": {
+                "signature": "string.Formatter() -> Formatter",
+                "description": "Advanced str.format interface. Format-string injection sink when format string is user-controlled.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — regex / validation
+    # =====================================================================
+
+    "PyRe": {
+        "description": (
+            "The re module. Catastrophic backtracking in regex patterns (ReDoS) — finding when a "
+            "user-controlled pattern flows into re.compile / re.search / re.match. Also, re.findall "
+            "on untrusted HTML is a common anti-pattern that misses cases."
+        ),
+        "category": "file-system",
+        "fqns": ["re"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "compile": {
+                "signature": "re.compile(pattern, flags=0) -> Pattern",
+                "description": "Compiles a regex. ReDoS sink when pattern is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "match": {
+                "signature": "re.match(pattern, string, flags=0) -> Match | None",
+                "description": "Matches at start of string. ReDoS sink on user-controlled pattern.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "search": {
+                "signature": "re.search(pattern, string, flags=0) -> Match | None",
+                "description": "Searches for pattern. ReDoS sink on user-controlled pattern.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "sub": {
+                "signature": "re.sub(pattern, repl, string, count=0, flags=0) -> str",
+                "description": "Regex-based substitution. ReDoS sink on user-controlled pattern.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyIpaddress": {
+        "description": (
+            "The ipaddress module for IP address parsing and classification. IPv4Address / "
+            "IPv6Address constructors raise on invalid input — sanitizer for IP flows. "
+            "is_private / is_loopback / is_reserved are building blocks for SSRF defense."
+        ),
+        "category": "http-clients",
+        "fqns": ["ipaddress"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "ip_address": {
+                "signature": "ipaddress.ip_address(address) -> IPv4Address | IPv6Address",
+                "description": "Parses an IP address. Sanitizer (raises on invalid input).",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "ip_network": {
+                "signature": "ipaddress.ip_network(address, strict=True) -> IPv4Network | IPv6Network",
+                "description": "Parses an IP network. Sanitizer.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — CSV / email / config
+    # =====================================================================
+
+    "PyCsv": {
+        "description": (
+            "The csv module. csv.writer + writerow on user-controlled cells produces CSV-formula "
+            "injection when the receiver opens the CSV in Excel (cells starting with =, +, -, @ are "
+            "interpreted as formulas). No stdlib sanitizer — prefix with a tab or apostrophe."
+        ),
+        "category": "deserialization",
+        "fqns": ["csv"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "writer": {
+                "signature": "csv.writer(csvfile, dialect='excel', **fmtparams) -> _writer",
+                "description": "Creates a CSV writer. writerow() with user-controlled cells is a formula-injection sink.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "reader": {
+                "signature": "csv.reader(csvfile, dialect='excel', **fmtparams) -> _reader",
+                "description": "Creates a CSV reader. Rows are sources when the file is user-supplied.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "DictReader": {
+                "signature": "csv.DictReader(f, fieldnames=None, ...) -> DictReader",
+                "description": "CSV reader that maps rows to dicts. Source on untrusted CSV files.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "DictWriter": {
+                "signature": "csv.DictWriter(f, fieldnames, ...) -> DictWriter",
+                "description": "Dict-based CSV writer. Formula-injection sink on user cells.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyEmail": {
+        "description": (
+            "The email package. email.message.EmailMessage assembly with user-controlled Subject, "
+            "To, From, or body is an email-header-injection sink (CRLF in header values can inject "
+            "extra headers). email.parser handles incoming messages — sources of user content."
+        ),
+        "category": "http-clients",
+        "fqns": ["email", "email.message", "email.parser", "email.mime"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "EmailMessage": {
+                "signature": "email.message.EmailMessage(policy=default) -> EmailMessage",
+                "description": "Creates a message. Setting headers from user input is a CRLF-injection sink.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "message_from_string": {
+                "signature": "email.message_from_string(s, _class=EmailMessage, *, policy=compat32) -> EmailMessage",
+                "description": "Parses a message from a string. Source for incoming email content.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "message_from_bytes": {
+                "signature": "email.message_from_bytes(s, _class=EmailMessage, *, policy=compat32) -> EmailMessage",
+                "description": "Parses a message from bytes. Source.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyConfigparser": {
+        "description": (
+            "The configparser module reads INI-style config files. Values read via get() are "
+            "sources when the config file is user-supplied. The module itself has no injection "
+            "sinks of its own."
+        ),
+        "category": "file-system",
+        "fqns": ["configparser"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "ConfigParser": {
+                "signature": "configparser.ConfigParser(defaults=None, ...) -> ConfigParser",
+                "description": "Creates a parser.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "read": {
+                "signature": "ConfigParser.read(filenames, encoding=None) -> list[str]",
+                "description": "Reads config files. Subsequent get() values become sources.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "get": {
+                "signature": "ConfigParser.get(section: str, option: str, *, raw=False, vars=None, fallback=...) -> str",
+                "description": "Returns a config value. Source when the config file is user-supplied.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — HTTP server / cookies / IMAP / POP3 / CGI / WSGI
+    # =====================================================================
+
+    "PyHttpServer": {
+        "description": (
+            "The http.server module. SimpleHTTPRequestHandler serves files from the current "
+            "working directory — path-traversal sink on directory containing secrets. Intended "
+            "for development only, finding on any production use."
+        ),
+        "category": "http-clients",
+        "fqns": ["http.server"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "HTTPServer": {
+                "signature": "http.server.HTTPServer(server_address, RequestHandlerClass, bind_and_activate=True) -> HTTPServer",
+                "description": "HTTP server. Finding when bound to 0.0.0.0 without access control.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "SimpleHTTPRequestHandler": {
+                "signature": "http.server.SimpleHTTPRequestHandler(*args, **kwargs) -> SimpleHTTPRequestHandler",
+                "description": "Serves files from CWD. Path-traversal sink for sensitive directories.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyHttpCookies": {
+        "description": (
+            "The http.cookies module for cookie parsing. SimpleCookie accepts raw Cookie headers "
+            "— the parsed morsels carry user input. Setting a cookie without Secure / HttpOnly / "
+            "SameSite is a common hardening finding."
+        ),
+        "category": "http-clients",
+        "fqns": ["http.cookies"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "SimpleCookie": {
+                "signature": "http.cookies.SimpleCookie(input=None) -> SimpleCookie",
+                "description": "Parses a Cookie header. Parsed morsels are sources.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Morsel": {
+                "signature": "http.cookies.Morsel() -> Morsel",
+                "description": "Represents one cookie. Finding when secure/httponly/samesite flags are not set.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyImaplib": {
+        "description": (
+            "The imaplib module. IMAP4() uses plaintext; IMAP4_SSL is the encrypted variant. "
+            "Any use of plain IMAP is a credential-over-plaintext finding."
+        ),
+        "category": "http-clients",
+        "fqns": ["imaplib"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "IMAP4": {
+                "signature": "imaplib.IMAP4(host='', port=143, timeout=None) -> IMAP4",
+                "description": "Plaintext IMAP. Credentials transmitted unencrypted. Finding.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "IMAP4_SSL": {
+                "signature": "imaplib.IMAP4_SSL(host='', port=993, *, ssl_context=None, timeout=None) -> IMAP4_SSL",
+                "description": "IMAP over TLS. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPoplib": {
+        "description": (
+            "The poplib module. POP3() is plaintext; POP3_SSL encrypts. Plaintext POP3 is a "
+            "credential-over-plaintext finding."
+        ),
+        "category": "http-clients",
+        "fqns": ["poplib"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "POP3": {
+                "signature": "poplib.POP3(host, port=110, timeout=...) -> POP3",
+                "description": "Plaintext POP3. Finding.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "POP3_SSL": {
+                "signature": "poplib.POP3_SSL(host, port=995, keyfile=None, certfile=None, timeout=..., context=None) -> POP3_SSL",
+                "description": "POP3 over TLS. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyCgi": {
+        "description": (
+            "The cgi module (deprecated in 3.11, removed in 3.13). cgi.FieldStorage collects form "
+            "data for CGI scripts — each field value is a source. Any new code should not use cgi."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["cgi"],
+        "pip_snippet": "# stdlib — deprecated in Python 3.11, removed in 3.13",
+        "methods": {
+            "FieldStorage": {
+                "signature": "cgi.FieldStorage(fp=None, headers=None, outerboundary=b'', environ=os.environ, ...) -> FieldStorage",
+                "description": "Parses form data. Each field is user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "parse": {
+                "signature": "cgi.parse(fp=None, environ=os.environ, keep_blank_values=False, strict_parsing=False, separator='&') -> dict",
+                "description": "Parses form data into a dict. Source.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyWsgiref": {
+        "description": (
+            "The wsgiref module for WSGI utilities. simple_server.make_server is dev-only — "
+            "production should use gunicorn or waitress. util.request_uri reconstructs the URL "
+            "from environ and is a source."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["wsgiref"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "make_server": {
+                "signature": "wsgiref.simple_server.make_server(host, port, app, ...) -> WSGIServer",
+                "description": "Creates a development WSGI server. Finding on production use.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "request_uri": {
+                "signature": "wsgiref.util.request_uri(environ, include_query=True) -> str",
+                "description": "Reconstructs the request URL. Source when environ reflects real traffic.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyGetpass": {
+        "description": (
+            "The getpass module. getpass.getpass() prompts for a password without echoing. "
+            "getpass.getuser() returns the current user — source when used for authorization decisions."
+        ),
+        "category": "crypto",
+        "fqns": ["getpass"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "getpass": {
+                "signature": "getpass.getpass(prompt='Password: ', stream=None) -> str",
+                "description": "Prompts for password. Source (user-controlled).",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "getuser": {
+                "signature": "getpass.getuser() -> str",
+                "description": "Returns the current login name. Source when used for access checks (env variables can spoof).",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyGlob": {
+        "description": (
+            "The glob module. glob.glob() resolves shell-style patterns against the filesystem — "
+            "finding when the pattern is user-controlled (can enumerate directories outside intended scope)."
+        ),
+        "category": "file-system",
+        "fqns": ["glob"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "glob": {
+                "signature": "glob.glob(pathname, *, root_dir=None, dir_fd=None, recursive=False, ...) -> list[str]",
+                "description": "Returns matching paths. Finding when pathname is user-controlled.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "iglob": {
+                "signature": "glob.iglob(pathname, *, root_dir=None, ...) -> Iterator[str]",
+                "description": "Like glob() but returns an iterator. Same risk.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Stdlib — FFI / crypto legacy
+    # =====================================================================
+
+    "PyCtypes": {
+        "description": (
+            "The ctypes module for calling C libraries. LoadLibrary / CDLL on user-controlled "
+            "paths loads arbitrary code — code-execution sink. String pointer operations can "
+            "also be memory-safety findings."
+        ),
+        "category": "command-execution",
+        "fqns": ["ctypes"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "CDLL": {
+                "signature": "ctypes.CDLL(name, mode=DEFAULT_MODE, handle=None, use_errno=False, use_last_error=False, winmode=None) -> CDLL",
+                "description": "Loads a shared library. Code-execution sink on user-controlled name.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "WinDLL": {
+                "signature": "ctypes.WinDLL(name, ...) -> WinDLL",
+                "description": "Windows shared library loader. Code-execution sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "LoadLibrary": {
+                "signature": "ctypes.cdll.LoadLibrary(name) -> CDLL",
+                "description": "Loads a shared library. Code-execution sink on user-controlled name.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyCrypt": {
+        "description": (
+            "The crypt module (deprecated in 3.11, removed in 3.13). crypt.crypt() wraps the "
+            "Unix crypt(3) call. Most default methods are weak (DES, MD5). Use passlib or "
+            "hashlib.scrypt / pbkdf2_hmac instead."
+        ),
+        "category": "crypto",
+        "fqns": ["crypt"],
+        "pip_snippet": "# stdlib — deprecated in 3.11, removed in 3.13. Use passlib.",
+        "methods": {
+            "crypt": {
+                "signature": "crypt.crypt(word, salt=None) -> str",
+                "description": "Unix crypt password hashing. Finding — algorithm selection is platform-dependent and often weak.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyDbm": {
+        "description": (
+            "The dbm family (dbm.gnu, dbm.ndbm, dbm.dumb). dbm.open() on untrusted files reads "
+            "a DBM-format database. dbm.dumb is pickle-like and unsafe on untrusted input."
+        ),
+        "category": "deserialization",
+        "fqns": ["dbm"],
+        "pip_snippet": "# stdlib — no install required",
+        "methods": {
+            "open": {
+                "signature": "dbm.open(file, flag='r', mode=0o666) -> dbm",
+                "description": "Opens a DBM database. Finding on untrusted files (dbm.dumb is especially unsafe).",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — web frameworks / servers
+    # =====================================================================
+
+    "PyAiohttp": {
+        "description": (
+            "aiohttp provides async HTTP client and server. ClientSession.get / post and the "
+            "top-level request() are SSRF sinks on user-controlled URLs. aiohttp.web request "
+            "handlers expose sources via request.query, request.post, request.json."
+        ),
+        "category": "http-clients",
+        "fqns": ["aiohttp", "aiohttp.ClientSession", "aiohttp.web"],
+        "pip_snippet": "pip install aiohttp",
+        "methods": {
+            "ClientSession.get": {
+                "signature": "async ClientSession.get(url, *, allow_redirects=True, ...) -> ClientResponse",
+                "description": "Async GET. SSRF sink on url.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "ClientSession.post": {
+                "signature": "async ClientSession.post(url, *, data=None, json=None, ...) -> ClientResponse",
+                "description": "Async POST. SSRF sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "request": {
+                "signature": "async aiohttp.request(method, url, **kwargs) -> ClientResponse",
+                "description": "Top-level async request helper. SSRF sink on url.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "Request.query": {
+                "signature": "request.query: MultiDict[str, str]",
+                "description": "URL query parameters on aiohttp.web handlers. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.post": {
+                "signature": "async request.post() -> MultiDict[str, str]",
+                "description": "Form body. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.json": {
+                "signature": "async request.json(*, loads=json.loads) -> Any",
+                "description": "Parsed JSON body. User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyStarlette": {
+        "description": (
+            "Starlette is the ASGI toolkit behind FastAPI. Request exposes HTTP input; the "
+            "responses module provides HTMLResponse / RedirectResponse / FileResponse (sinks for "
+            "XSS, open-redirect, path-traversal respectively)."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["starlette", "starlette.requests", "starlette.responses"],
+        "pip_snippet": "pip install starlette",
+        "methods": {
+            "Request.query_params": {
+                "signature": "request.query_params: QueryParams",
+                "description": "URL query parameters.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.path_params": {
+                "signature": "request.path_params: dict",
+                "description": "Path parameters.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.form": {
+                "signature": "async request.form() -> FormData",
+                "description": "Form body.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "HTMLResponse": {
+                "signature": "HTMLResponse(content, status_code=200, headers=None, media_type=None, ...) -> Response",
+                "description": "Raw HTML response. XSS sink on tainted content.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "RedirectResponse": {
+                "signature": "RedirectResponse(url, status_code=307, ...) -> Response",
+                "description": "Redirect response. Open-redirect sink.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "FileResponse": {
+                "signature": "FileResponse(path, status_code=200, headers=None, media_type=None, filename=None, ...) -> Response",
+                "description": "Serves a file. Path-traversal sink on user-controlled path.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyRestFramework": {
+        "description": (
+            "Django REST Framework (DRF). request.data is the primary source for JSON / form "
+            "payloads; serializers validate input (sanitizer when is_valid is called with "
+            "raise_exception=True). Response() with tainted data is generally safe due to DRF's "
+            "renderers but render_template is still worth watching."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["rest_framework", "rest_framework.request", "rest_framework.response"],
+        "pip_snippet": "pip install djangorestframework",
+        "methods": {
+            "Request.data": {
+                "signature": "request.data: dict | list",
+                "description": "Parsed body (JSON, form, multipart). User-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Request.query_params": {
+                "signature": "request.query_params: QueryDict",
+                "description": "URL query parameters.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "Serializer.is_valid": {
+                "signature": "Serializer.is_valid(raise_exception=False) -> bool",
+                "description": "Validates input. Sanitizer when raise_exception=True.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "Response": {
+                "signature": "Response(data=None, status=None, template_name=None, headers=None, ...) -> Response",
+                "description": "DRF response. Data is rendered safely; template_name can be an SSTI sink.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyFlaskCors": {
+        "description": (
+            "flask-cors configures CORS headers on Flask apps. CORS(app, origins='*') with "
+            "supports_credentials=True is a major finding (wildcard origin with credentials is "
+            "explicitly forbidden by browsers but some configurations still emit it)."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["flask_cors", "flask_cors.CORS"],
+        "pip_snippet": "pip install flask-cors",
+        "methods": {
+            "CORS": {
+                "signature": "CORS(app=None, *, resources=..., origins=None, supports_credentials=False, ...) -> CORS",
+                "description": "Installs CORS headers. Finding when origins='*' and supports_credentials=True.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "cross_origin": {
+                "signature": "cross_origin(origins=None, methods=None, supports_credentials=False, ...) -> Callable",
+                "description": "Per-view CORS decorator. Same credential wildcard finding applies.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyWerkzeugSecurity": {
+        "description": (
+            "werkzeug.security provides generate_password_hash and check_password_hash. The "
+            "default method is pbkdf2:sha256 with 600_000 iterations. Findings arise when "
+            "method='plain' or a weak hasher is passed explicitly."
+        ),
+        "category": "crypto",
+        "fqns": ["werkzeug.security"],
+        "pip_snippet": "pip install werkzeug",
+        "methods": {
+            "generate_password_hash": {
+                "signature": "werkzeug.security.generate_password_hash(password, method='scrypt', salt_length=16) -> str",
+                "description": "Hashes a password. Safe with default method. Finding when method='plain'.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "check_password_hash": {
+                "signature": "werkzeug.security.check_password_hash(pwhash: str, password: str) -> bool",
+                "description": "Constant-time password verification. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — additional crypto / auth
+    # =====================================================================
+
+    "PyPyjwt": {
+        "description": (
+            "PyJWT decodes and validates JWTs. jwt.decode() with algorithms=['none'] or "
+            "options={'verify_signature': False} accepts unsigned tokens — major finding. "
+            "Always pass algorithms explicitly."
+        ),
+        "category": "crypto",
+        "fqns": ["jwt"],
+        "pip_snippet": "pip install pyjwt",
+        "methods": {
+            "encode": {
+                "signature": "jwt.encode(payload: dict, key: str | bytes, algorithm='HS256', headers=None, json_encoder=None) -> str",
+                "description": "Signs a JWT. Safe with a proper algorithm.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "decode": {
+                "signature": "jwt.decode(jwt: str, key=None, algorithms=None, options=None, audience=None, issuer=None, leeway=0) -> dict",
+                "description": "Verifies and decodes. Finding on algorithms=['none'] or verify_signature=False.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyOauthlib": {
+        "description": (
+            "oauthlib implements the OAuth 1 / OAuth 2 protocols. WebApplicationClient.parse_request_uri_response "
+            "extracts the authorization code from the callback URL — source for subsequent token "
+            "exchange."
+        ),
+        "category": "crypto",
+        "fqns": ["oauthlib"],
+        "pip_snippet": "pip install oauthlib",
+        "methods": {
+            "WebApplicationClient": {
+                "signature": "oauthlib.oauth2.WebApplicationClient(client_id, ...) -> WebApplicationClient",
+                "description": "OAuth 2 client.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "parse_request_uri_response": {
+                "signature": "WebApplicationClient.parse_request_uri_response(uri, state=None) -> dict",
+                "description": "Extracts code / tokens from callback URI. Source for tokens.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyCryptography": {
+        "description": (
+            "The cryptography package provides recipes (Fernet) and primitives (hazmat). Fernet "
+            "is the recommended symmetric encryption helper. Findings arise when hazmat primitives "
+            "are used with obsolete algorithms (MD5, DES, RC4) or ECB mode."
+        ),
+        "category": "crypto",
+        "fqns": ["cryptography", "cryptography.fernet", "cryptography.hazmat"],
+        "pip_snippet": "pip install cryptography",
+        "methods": {
+            "Fernet": {
+                "signature": "cryptography.fernet.Fernet(key: bytes) -> Fernet",
+                "description": "Authenticated symmetric encryption. Safe.",
+                "role": "sanitizer",
+                "tracks": [],
+            },
+            "Fernet.encrypt": {
+                "signature": "Fernet.encrypt(data: bytes) -> bytes",
+                "description": "Encrypts a message. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "Fernet.decrypt": {
+                "signature": "Fernet.decrypt(token: bytes, ttl: int = None) -> bytes",
+                "description": "Decrypts and authenticates. Raises on tampering. Safe.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+            "Cipher": {
+                "signature": "cryptography.hazmat.primitives.ciphers.Cipher(algorithm, mode, backend=None) -> Cipher",
+                "description": "Low-level cipher. Finding when algorithm is DES/3DES/RC4 or mode is ECB.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyHvac": {
+        "description": (
+            "hvac is the Python client for HashiCorp Vault. Client.secrets.kv.v2.read_secret_version "
+            "reads a secret — the returned payload is a source. Client() with verify=False disables "
+            "TLS verification (major finding)."
+        ),
+        "category": "crypto",
+        "fqns": ["hvac", "hvac.Client"],
+        "pip_snippet": "pip install hvac",
+        "methods": {
+            "Client": {
+                "signature": "hvac.Client(url='http://localhost:8200', token=None, verify=True, ...) -> Client",
+                "description": "Vault client. Finding when verify=False.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "secrets.kv.v2.read_secret_version": {
+                "signature": "Client.secrets.kv.v2.read_secret_version(path, mount_point='secret', version=None, ...) -> dict",
+                "description": "Reads a KV secret. Return value carries secret data.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — additional HTTP / sockets
+    # =====================================================================
+
+    "PyPycurl": {
+        "description": (
+            "pycurl wraps libcurl. curl.setopt(pycurl.URL, ...) is an SSRF sink on user-controlled "
+            "URLs. setopt(pycurl.SSL_VERIFYPEER, 0) disables TLS verification."
+        ),
+        "category": "http-clients",
+        "fqns": ["pycurl"],
+        "pip_snippet": "pip install pycurl",
+        "methods": {
+            "Curl": {
+                "signature": "pycurl.Curl() -> Curl",
+                "description": "Creates a cURL handle.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "setopt": {
+                "signature": "Curl.setopt(option, value) -> None",
+                "description": "Sets a cURL option. SSRF sink when option=pycurl.URL and value is user-controlled.",
+                "role": "sink",
+                "tracks": [1],
+            },
+            "perform": {
+                "signature": "Curl.perform() -> None",
+                "description": "Sends the request. Sink in combination with setopt.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPysftp": {
+        "description": (
+            "pysftp wraps paramiko with a simpler SFTP interface. Connection(host, cnopts=...) "
+            "with CnOpts.hostkeys=None disables host-key checking — MITM finding."
+        ),
+        "category": "crypto",
+        "fqns": ["pysftp"],
+        "pip_snippet": "pip install pysftp",
+        "methods": {
+            "Connection": {
+                "signature": "pysftp.Connection(host, username=None, private_key=None, password=None, port=22, cnopts=None, ...) -> Connection",
+                "description": "Opens an SFTP connection. Finding when cnopts.hostkeys is None.",
+                "role": "sink",
+                "tracks": [],
+            },
+            "put": {
+                "signature": "Connection.put(localpath, remotepath=None, callback=None, confirm=True, preserve_mtime=False) -> SFTPAttributes",
+                "description": "Uploads a file. Path-traversal risk on remotepath.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+            "get": {
+                "signature": "Connection.get(remotepath, localpath=None, callback=None, preserve_mtime=False) -> None",
+                "description": "Downloads a file. Path-traversal risk on localpath.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+        },
+        "rules_using": [],
+    },
+
+    # =====================================================================
+    # Third-party — infra / misc
+    # =====================================================================
+
+    "PyDocker": {
+        "description": (
+            "The docker SDK. DockerClient.containers.run with privileged=True is a container-"
+            "escape finding. volumes mounting /var/run/docker.sock into the container grants full "
+            "Docker daemon access."
+        ),
+        "category": "command-execution",
+        "fqns": ["docker", "docker.DockerClient"],
+        "pip_snippet": "pip install docker",
+        "methods": {
+            "from_env": {
+                "signature": "docker.from_env(version=None, timeout=60, ...) -> DockerClient",
+                "description": "Creates a client from DOCKER_HOST env vars.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "containers.run": {
+                "signature": "Container.run(image, command=None, *, privileged=False, volumes=None, ...) -> Container",
+                "description": "Runs a container. Finding when privileged=True or docker.sock is mounted.",
+                "role": "sink",
+                "tracks": [0, 1],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyCelery": {
+        "description": (
+            "Celery is a distributed task queue. Celery(broker=..., backend=...) configures brokers — "
+            "findings when broker URL has insecure defaults (redis:// without TLS, amqp:// without TLS). "
+            "@task decorators accept arbitrary user-controlled args via the queue."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["celery", "celery.Celery"],
+        "pip_snippet": "pip install celery",
+        "methods": {
+            "Celery": {
+                "signature": "celery.Celery(main=None, broker=None, backend=None, ...) -> Celery",
+                "description": "Celery app. Finding when broker scheme is redis:// or amqp:// without TLS.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "task": {
+                "signature": "@celery.task(bind=False, ...) -> Callable",
+                "description": "Registers a task. Arguments are user-controlled sources.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyWaitress": {
+        "description": (
+            "waitress is a production WSGI server. serve() with host='0.0.0.0' exposes the app "
+            "to all interfaces — finding for internal-only services."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["waitress"],
+        "pip_snippet": "pip install waitress",
+        "methods": {
+            "serve": {
+                "signature": "waitress.serve(app, host='0.0.0.0', port=8080, ...) -> None",
+                "description": "Serves a WSGI app. Finding when bound to 0.0.0.0 for internal apps.",
+                "role": "sink",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyGunicorn": {
+        "description": (
+            "gunicorn is a production WSGI server. Commonly run via CLI but programmatic use via "
+            "Application() is possible. bind '0.0.0.0:*' on internal apps is a finding."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["gunicorn"],
+        "pip_snippet": "pip install gunicorn",
+        "methods": {
+            "Application": {
+                "signature": "gunicorn.app.base.BaseApplication() -> BaseApplication",
+                "description": "Gunicorn application base class.",
+                "role": "neutral",
+                "tracks": [],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPyasn1": {
+        "description": (
+            "pyasn1 decodes ASN.1 structures. der_decoder.decode() on untrusted DER bytes can "
+            "trigger denial-of-service via deep nesting. Typically used in certificate / LDAP "
+            "contexts."
+        ),
+        "category": "deserialization",
+        "fqns": ["pyasn1"],
+        "pip_snippet": "pip install pyasn1",
+        "methods": {
+            "der_decoder.decode": {
+                "signature": "pyasn1.codec.der.decoder.decode(substrate, asn1Spec=None, ...) -> (value, rest)",
+                "description": "Decodes DER bytes. Sink for malformed / nested input (DoS).",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyDockerfileParse": {
+        "description": (
+            "dockerfile_parse parses Dockerfiles. Returned structures reflect user-controlled "
+            "file content. Usually a source for linting rules, not a sink."
+        ),
+        "category": "file-system",
+        "fqns": ["dockerfile_parse"],
+        "pip_snippet": "pip install dockerfile-parse",
+        "methods": {
+            "DockerfileParser": {
+                "signature": "dockerfile_parse.DockerfileParser(path=None, cache_content=False, env_replace=True, ...) -> DockerfileParser",
+                "description": "Parses a Dockerfile. Content reflects user input.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyToml": {
+        "description": (
+            "toml parses TOML configuration. toml.load() is a neutral data loader — values "
+            "become sources when the config file is user-supplied. tomllib (stdlib, 3.11+) is "
+            "the modern replacement."
+        ),
+        "category": "deserialization",
+        "fqns": ["toml", "tomllib"],
+        "pip_snippet": "pip install toml  # or use stdlib tomllib on Python 3.11+",
+        "methods": {
+            "load": {
+                "signature": "toml.load(f) -> dict",
+                "description": "Parses TOML from a file. Source when file is user-controlled.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+            "loads": {
+                "signature": "toml.loads(s: str) -> dict",
+                "description": "Parses TOML from a string. Source.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyXmltodict": {
+        "description": (
+            "xmltodict parses XML into nested dicts (uses expat under the hood). Entity expansion "
+            "is disabled by default, but the module's parse() still exposes untrusted XML to the "
+            "app. Not a full XXE defense."
+        ),
+        "category": "deserialization",
+        "fqns": ["xmltodict"],
+        "pip_snippet": "pip install xmltodict",
+        "methods": {
+            "parse": {
+                "signature": "xmltodict.parse(xml_input, encoding=None, expat=expat, process_namespaces=False, ...) -> dict",
+                "description": "Parses XML to dict. Source for user-controlled XML content.",
+                "role": "source",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyWtforms": {
+        "description": (
+            "WTForms provides form validation for Flask / Django-style apps. Form().validate_on_submit() "
+            "is a sanitizer for field-level validation. Still, string field values reach templates / "
+            "SQL if fed directly without additional escaping."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["wtforms"],
+        "pip_snippet": "pip install wtforms",
+        "methods": {
+            "Form": {
+                "signature": "wtforms.Form(formdata=None, obj=None, prefix='', **kwargs) -> Form",
+                "description": "Creates a form.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "Form.validate": {
+                "signature": "Form.validate() -> bool",
+                "description": "Validates all fields. Sanitizer for shape / type; strings remain tainted.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyDjangoFilters": {
+        "description": (
+            "django-filter builds Django QuerySet filters from query params. FilterSet.qs runs the "
+            "filtered query — injection is impossible via the FilterSet, but custom filter methods "
+            "that build raw SQL are sinks."
+        ),
+        "category": "web-frameworks",
+        "fqns": ["django_filters"],
+        "pip_snippet": "pip install django-filter",
+        "methods": {
+            "FilterSet": {
+                "signature": "django_filters.FilterSet(data=None, queryset=None, request=None, prefix=None)",
+                "description": "Builds filtered QuerySet from query params.",
+                "role": "sanitizer",
+                "tracks": ["return"],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyPexpect": {
+        "description": (
+            "pexpect spawns interactive subprocesses with expect/respond patterns. spawn(cmd, ...) "
+            "on user-controlled cmd is a command-injection sink, equivalent to subprocess with shell=True."
+        ),
+        "category": "command-execution",
+        "fqns": ["pexpect"],
+        "pip_snippet": "pip install pexpect",
+        "methods": {
+            "spawn": {
+                "signature": "pexpect.spawn(command, args=[], timeout=30, ...) -> spawn",
+                "description": "Spawns a child process. Command-injection sink on user-controlled command.",
+                "role": "sink",
+                "tracks": [0],
+            },
+            "run": {
+                "signature": "pexpect.run(command, timeout=30, events=None, extra_args=None, logfile=None, ...) -> bytes",
+                "description": "Runs a command and returns output. Sink on user-controlled command.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+
+    "PyCffi": {
+        "description": (
+            "cffi calls C libraries without writing a C extension. FFI.dlopen() loads a shared "
+            "library at runtime — code-execution sink on user-controlled path. FFI.cdef parses "
+            "C declarations — neutral unless the definitions are user-controlled."
+        ),
+        "category": "command-execution",
+        "fqns": ["cffi", "cffi.FFI"],
+        "pip_snippet": "pip install cffi",
+        "methods": {
+            "FFI": {
+                "signature": "cffi.FFI() -> FFI",
+                "description": "FFI instance.",
+                "role": "neutral",
+                "tracks": [],
+            },
+            "dlopen": {
+                "signature": "FFI.dlopen(name, flags=0) -> Library",
+                "description": "Loads a shared library. Code-execution sink on user-controlled name.",
+                "role": "sink",
+                "tracks": [0],
+            },
+        },
+        "rules_using": [],
+    },
+}

--- a/python-sdk/codepathfinder/python_rule_meta.py
+++ b/python-sdk/codepathfinder/python_rule_meta.py
@@ -11,11 +11,9 @@
 # the FQN is the dotted path (e.g., "sqlite3.Cursor", "psycopg2.extensions.cursor").
 
 SDK_META: dict = {
-
     # =====================================================================
     # Command execution
     # =====================================================================
-
     "PySubprocess": {
         "description": (
             "The subprocess standard library module for spawning child processes. "
@@ -91,7 +89,6 @@ def detect_subprocess_shell_injection():
 """,
         "rules_using": [],
     },
-
     "PyOS": {
         "description": (
             "The os standard library module. os.system() and os.popen() always invoke a shell "
@@ -147,11 +144,9 @@ def detect_subprocess_shell_injection():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Deserialization
     # =====================================================================
-
     "PyPickle": {
         "description": (
             "The pickle module for Python object serialization. pickle.load() and pickle.loads() "
@@ -212,7 +207,6 @@ def detect_pickle_deserialization():
 """,
         "rules_using": ["PYTHON-DESER-001"],
     },
-
     "PyMarshal": {
         "description": (
             "The marshal module for Python internal object serialization. Like pickle, "
@@ -238,11 +232,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Databases — stdlib
     # =====================================================================
-
     "PySqlite3": {
         "description": (
             "The sqlite3 module wraps the SQLite C library. cursor.execute() and executemany() "
@@ -280,11 +272,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Databases — third party
     # =====================================================================
-
     "PyPsycopg2": {
         "description": (
             "psycopg2 is the canonical PostgreSQL driver for Python. Cursor.execute() and "
@@ -322,7 +312,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPyMongo": {
         "description": (
             "PyMongo is the official MongoDB driver for Python. Collection methods accept filter "
@@ -366,7 +355,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyRedis": {
         "description": (
             "redis-py is the de-facto Redis client for Python. Most commands are typed and safe. "
@@ -410,11 +398,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Web frameworks
     # =====================================================================
-
     "PyFlask": {
         "description": (
             "Flask is a popular Python web microframework. The flask.request global exposes all "
@@ -476,7 +462,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyDjango": {
         "description": (
             "Django is a full-featured Python web framework. HttpRequest exposes request data; "
@@ -526,7 +511,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyFastAPI": {
         "description": (
             "FastAPI is a modern Python web framework built on Starlette and Pydantic. Path / query / "
@@ -576,11 +560,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Templating
     # =====================================================================
-
     "PyJinja2": {
         "description": (
             "Jinja2 is the template engine behind Flask and many Python frameworks. "
@@ -613,11 +595,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # HTTP clients
     # =====================================================================
-
     "PyRequests": {
         "description": (
             "requests is the most popular HTTP client for Python. All top-level methods and "
@@ -661,7 +641,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyUrllib": {
         "description": (
             "urllib.request (stdlib) is the lowest-level HTTP client in Python. urlopen() accepts "
@@ -687,11 +666,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Deserialization — third party
     # =====================================================================
-
     "PyYaml": {
         "description": (
             "PyYAML is the standard YAML library. yaml.load() with the default Loader (or "
@@ -735,11 +712,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # File system
     # =====================================================================
-
     "PyOSPath": {
         "description": (
             "The os.path module for path manipulation. join() concatenates path components but "
@@ -778,7 +753,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyTempfile": {
         "description": (
             "The tempfile module. mktemp() is deprecated and insecure (race condition between "
@@ -810,11 +784,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Archives
     # =====================================================================
-
     "PyTarfile": {
         "description": (
             "The tarfile module. extractall() and extract() follow archive entry paths as-is — "
@@ -846,7 +818,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyZipfile": {
         "description": (
             "The zipfile module. ZipFile.extractall() and extract() are zip-slip sinks when the "
@@ -872,11 +843,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Cryptography
     # =====================================================================
-
     "PyHashlib": {
         "description": (
             "The hashlib module provides cryptographic hash functions. md5 and sha1 are "
@@ -920,7 +889,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyHmac": {
         "description": (
             "The hmac module for keyed message authentication. compare_digest is the only "
@@ -945,7 +913,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PySecrets": {
         "description": (
             "The secrets module provides cryptographically strong random values suitable for "
@@ -989,7 +956,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyRandom": {
         "description": (
             "The random module uses a Mersenne Twister PRNG — NOT suitable for cryptography. "
@@ -1033,7 +999,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PySsl": {
         "description": (
             "The ssl module for TLS / SSL. SSLContext with verify_mode=CERT_NONE disables "
@@ -1071,11 +1036,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — parsers & eval
     # =====================================================================
-
     "PyAst": {
         "description": (
             "The ast module exposes Python's abstract syntax tree. ast.literal_eval is a safe "
@@ -1119,7 +1082,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyJson": {
         "description": (
             "The json module for JSON encode / decode. Unlike pickle, json is safe by default — "
@@ -1157,11 +1119,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — HTTP / networking
     # =====================================================================
-
     "PyHttpClient": {
         "description": (
             "The http.client module provides low-level HTTP primitives. HTTPConnection / "
@@ -1169,7 +1129,11 @@ def detect_pickle_deserialization():
             "HTTPSConnection with context=None falls back to system default TLS settings."
         ),
         "category": "http-clients",
-        "fqns": ["http.client", "http.client.HTTPConnection", "http.client.HTTPSConnection"],
+        "fqns": [
+            "http.client",
+            "http.client.HTTPConnection",
+            "http.client.HTTPSConnection",
+        ],
         "pip_snippet": "# stdlib — no install required",
         "methods": {
             "HTTPConnection": {
@@ -1193,7 +1157,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PySocket": {
         "description": (
             "The socket module for low-level network operations. socket.connect() is an SSRF "
@@ -1231,7 +1194,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyUrllibParse": {
         "description": (
             "The urllib.parse module for URL parsing and building. urljoin is commonly used to "
@@ -1269,7 +1231,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyFtplib": {
         "description": (
             "The ftplib module for FTP (insecure plaintext protocol). FTP() connects unencrypted; "
@@ -1295,7 +1256,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyTelnetlib": {
         "description": (
             "The telnetlib module for Telnet (insecure plaintext protocol). Any use of Telnet is "
@@ -1314,7 +1274,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PySmtplib": {
         "description": (
             "The smtplib module for SMTP. SMTP() uses plaintext unless starttls() is called. "
@@ -1346,11 +1305,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — file system
     # =====================================================================
-
     "PyPathlib": {
         "description": (
             "The pathlib module is the modern OO path API. Path.resolve() expands symlinks "
@@ -1394,7 +1351,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyShutil": {
         "description": (
             "The shutil module for high-level file operations. unpack_archive automatically "
@@ -1438,7 +1394,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyShlex": {
         "description": (
             "The shlex module provides shell-compatible tokenization and quoting. shlex.quote "
@@ -1470,11 +1425,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — XML
     # =====================================================================
-
     "PyXmlEtree": {
         "description": (
             "xml.etree.ElementTree is the stdlib XML parser. The C-accelerated parser has some "
@@ -1506,7 +1459,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyXmlSax": {
         "description": (
             "xml.sax is the stdlib SAX parser. By default it resolves external entities — XXE "
@@ -1538,7 +1490,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyXmlDom": {
         "description": (
             "xml.dom.minidom for DOM-style XML parsing. Built on pyexpat which by default does "
@@ -1564,7 +1515,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyXmlrpc": {
         "description": (
             "xmlrpc.client and xmlrpc.server. ServerProxy RPCs execute arbitrary methods — "
@@ -1590,11 +1540,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — misc
     # =====================================================================
-
     "PyZlib": {
         "description": (
             "The zlib module for compression. decompress() on untrusted input can consume "
@@ -1619,7 +1567,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyShelve": {
         "description": (
             "The shelve module persists arbitrary Python objects — backed by pickle under the "
@@ -1639,7 +1586,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyLogging": {
         "description": (
             "The logging module. Most uses are neutral. Log-injection findings arise when "
@@ -1677,11 +1623,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — databases
     # =====================================================================
-
     "PySqlalchemy": {
         "description": (
             "SQLAlchemy is the most-used Python ORM. The text() wrapper and raw execute() are "
@@ -1719,7 +1663,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPymysql": {
         "description": (
             "PyMySQL is a pure-Python MySQL driver. Cursor.execute() accepts a raw query and "
@@ -1751,7 +1694,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyMysqlDb": {
         "description": (
             "MySQLdb (mysqlclient) is a C-extension MySQL driver. Cursor.execute() is an SQL "
@@ -1782,11 +1724,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — HTTP
     # =====================================================================
-
     "PyHttpx": {
         "description": (
             "httpx is a modern async-capable HTTP client. Identical SSRF surface to requests — "
@@ -1830,7 +1770,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyHttplib2": {
         "description": (
             "httplib2 is an HTTP client with advanced caching features. Http.request() is an "
@@ -1855,11 +1794,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — XML / parsing
     # =====================================================================
-
     "PyLxml": {
         "description": (
             "lxml is the C-backed XML / HTML parser. etree.parse / fromstring with a custom "
@@ -1897,7 +1834,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyDefusedXml": {
         "description": (
             "defusedxml is the hardened XML parser suite. It wraps xml.etree, xml.sax, xml.dom, "
@@ -1923,11 +1859,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — auth / crypto
     # =====================================================================
-
     "PyJose": {
         "description": (
             "python-jose implements JWT / JWS / JWE. jwt.decode() is the canonical validation "
@@ -1965,7 +1899,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyAuthlib": {
         "description": (
             "Authlib is a comprehensive OAuth / OpenID / JWT library. JsonWebToken.decode() and "
@@ -1990,7 +1923,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyParamiko": {
         "description": (
             "paramiko is the SSH / SFTP client for Python. SSHClient.set_missing_host_key_policy "
@@ -2028,7 +1960,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyLdap3": {
         "description": (
             "ldap3 is a pure-Python LDAP client. Connection.search() accepts a search_filter — "
@@ -2060,11 +1991,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — misc
     # =====================================================================
-
     "PyBleach": {
         "description": (
             "bleach is an HTML sanitizer library. bleach.clean() strips dangerous tags and "
@@ -2089,7 +2018,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyWerkzeug": {
         "description": (
             "Werkzeug is the WSGI toolkit Flask is built on. safe_join() is the canonical "
@@ -2121,7 +2049,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyJsonschema": {
         "description": (
             "jsonschema validates JSON documents against a schema. validate() is a sanitizer for "
@@ -2140,7 +2067,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPydantic": {
         "description": (
             "Pydantic provides strict type-validated models. BaseModel parses / coerces input and "
@@ -2172,7 +2098,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyBoto3": {
         "description": (
             "boto3 is the AWS SDK for Python. client('s3').get_object(...) and similar operations "
@@ -2198,7 +2123,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyAiofiles": {
         "description": (
             "aiofiles provides async file I/O. aiofiles.open() is a path-traversal sink when "
@@ -2217,11 +2141,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — HTML / escaping / templating
     # =====================================================================
-
     "PyHtml": {
         "description": (
             "The html module. html.escape() is the canonical XSS sanitizer for writing user "
@@ -2247,7 +2169,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyStringTemplate": {
         "description": (
             "string.Template and string.Formatter. Template($var) substitution is safe when "
@@ -2273,11 +2194,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — regex / validation
     # =====================================================================
-
     "PyRe": {
         "description": (
             "The re module. Catastrophic backtracking in regex patterns (ReDoS) — finding when a "
@@ -2315,7 +2234,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyIpaddress": {
         "description": (
             "The ipaddress module for IP address parsing and classification. IPv4Address / "
@@ -2341,11 +2259,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — CSV / email / config
     # =====================================================================
-
     "PyCsv": {
         "description": (
             "The csv module. csv.writer + writerow on user-controlled cells produces CSV-formula "
@@ -2383,7 +2299,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyEmail": {
         "description": (
             "The email package. email.message.EmailMessage assembly with user-controlled Subject, "
@@ -2415,7 +2330,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyConfigparser": {
         "description": (
             "The configparser module reads INI-style config files. Values read via get() are "
@@ -2447,11 +2361,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — HTTP server / cookies / IMAP / POP3 / CGI / WSGI
     # =====================================================================
-
     "PyHttpServer": {
         "description": (
             "The http.server module. SimpleHTTPRequestHandler serves files from the current "
@@ -2477,7 +2389,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyHttpCookies": {
         "description": (
             "The http.cookies module for cookie parsing. SimpleCookie accepts raw Cookie headers "
@@ -2503,7 +2414,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyImaplib": {
         "description": (
             "The imaplib module. IMAP4() uses plaintext; IMAP4_SSL is the encrypted variant. "
@@ -2528,7 +2438,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPoplib": {
         "description": (
             "The poplib module. POP3() is plaintext; POP3_SSL encrypts. Plaintext POP3 is a "
@@ -2553,7 +2462,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyCgi": {
         "description": (
             "The cgi module (deprecated in 3.11, removed in 3.13). cgi.FieldStorage collects form "
@@ -2578,7 +2486,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyWsgiref": {
         "description": (
             "The wsgiref module for WSGI utilities. simple_server.make_server is dev-only — "
@@ -2604,7 +2511,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyGetpass": {
         "description": (
             "The getpass module. getpass.getpass() prompts for a password without echoing. "
@@ -2629,7 +2535,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyGlob": {
         "description": (
             "The glob module. glob.glob() resolves shell-style patterns against the filesystem — "
@@ -2654,11 +2559,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Stdlib — FFI / crypto legacy
     # =====================================================================
-
     "PyCtypes": {
         "description": (
             "The ctypes module for calling C libraries. LoadLibrary / CDLL on user-controlled "
@@ -2690,7 +2593,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyCrypt": {
         "description": (
             "The crypt module (deprecated in 3.11, removed in 3.13). crypt.crypt() wraps the "
@@ -2710,7 +2612,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyDbm": {
         "description": (
             "The dbm family (dbm.gnu, dbm.ndbm, dbm.dumb). dbm.open() on untrusted files reads "
@@ -2729,11 +2630,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — web frameworks / servers
     # =====================================================================
-
     "PyAiohttp": {
         "description": (
             "aiohttp provides async HTTP client and server. ClientSession.get / post and the "
@@ -2783,7 +2682,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyStarlette": {
         "description": (
             "Starlette is the ASGI toolkit behind FastAPI. Request exposes HTTP input; the "
@@ -2833,7 +2731,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyRestFramework": {
         "description": (
             "Django REST Framework (DRF). request.data is the primary source for JSON / form "
@@ -2872,7 +2769,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyFlaskCors": {
         "description": (
             "flask-cors configures CORS headers on Flask apps. CORS(app, origins='*') with "
@@ -2898,7 +2794,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyWerkzeugSecurity": {
         "description": (
             "werkzeug.security provides generate_password_hash and check_password_hash. The "
@@ -2924,11 +2819,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — additional crypto / auth
     # =====================================================================
-
     "PyPyjwt": {
         "description": (
             "PyJWT decodes and validates JWTs. jwt.decode() with algorithms=['none'] or "
@@ -2954,7 +2847,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyOauthlib": {
         "description": (
             "oauthlib implements the OAuth 1 / OAuth 2 protocols. WebApplicationClient.parse_request_uri_response "
@@ -2980,7 +2872,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyCryptography": {
         "description": (
             "The cryptography package provides recipes (Fernet) and primitives (hazmat). Fernet "
@@ -3018,7 +2909,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyHvac": {
         "description": (
             "hvac is the Python client for HashiCorp Vault. Client.secrets.kv.v2.read_secret_version "
@@ -3044,11 +2934,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — additional HTTP / sockets
     # =====================================================================
-
     "PyPycurl": {
         "description": (
             "pycurl wraps libcurl. curl.setopt(pycurl.URL, ...) is an SSRF sink on user-controlled "
@@ -3079,7 +2967,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPysftp": {
         "description": (
             "pysftp wraps paramiko with a simpler SFTP interface. Connection(host, cnopts=...) "
@@ -3110,11 +2997,9 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     # =====================================================================
     # Third-party — infra / misc
     # =====================================================================
-
     "PyDocker": {
         "description": (
             "The docker SDK. DockerClient.containers.run with privileged=True is a container-"
@@ -3140,7 +3025,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyCelery": {
         "description": (
             "Celery is a distributed task queue. Celery(broker=..., backend=...) configures brokers — "
@@ -3166,7 +3050,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyWaitress": {
         "description": (
             "waitress is a production WSGI server. serve() with host='0.0.0.0' exposes the app "
@@ -3185,7 +3068,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyGunicorn": {
         "description": (
             "gunicorn is a production WSGI server. Commonly run via CLI but programmatic use via "
@@ -3204,7 +3086,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPyasn1": {
         "description": (
             "pyasn1 decodes ASN.1 structures. der_decoder.decode() on untrusted DER bytes can "
@@ -3224,7 +3105,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyDockerfileParse": {
         "description": (
             "dockerfile_parse parses Dockerfiles. Returned structures reflect user-controlled "
@@ -3243,7 +3123,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyToml": {
         "description": (
             "toml parses TOML configuration. toml.load() is a neutral data loader — values "
@@ -3269,7 +3148,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyXmltodict": {
         "description": (
             "xmltodict parses XML into nested dicts (uses expat under the hood). Entity expansion "
@@ -3289,7 +3167,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyWtforms": {
         "description": (
             "WTForms provides form validation for Flask / Django-style apps. Form().validate_on_submit() "
@@ -3315,7 +3192,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyDjangoFilters": {
         "description": (
             "django-filter builds Django QuerySet filters from query params. FilterSet.qs runs the "
@@ -3335,7 +3211,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyPexpect": {
         "description": (
             "pexpect spawns interactive subprocesses with expect/respond patterns. spawn(cmd, ...) "
@@ -3360,7 +3235,6 @@ def detect_pickle_deserialization():
         },
         "rules_using": [],
     },
-
     "PyCffi": {
         "description": (
             "cffi calls C libraries without writing a C extension. FFI.dlopen() loads a shared "

--- a/python-sdk/scripts/generate_sdk_manifest.py
+++ b/python-sdk/scripts/generate_sdk_manifest.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import argparse
 import importlib
-import inspect
 import json
 import sys
 from datetime import datetime, timezone
@@ -31,8 +30,8 @@ from typing import Any
 
 # ── Resolve paths ──────────────────────────────────────────────────────────────
 SCRIPT_DIR = Path(__file__).parent
-SDK_ROOT    = SCRIPT_DIR.parent
-RULES_DIR   = SDK_ROOT / "rules"
+SDK_ROOT = SCRIPT_DIR.parent
+RULES_DIR = SDK_ROOT / "rules"
 OUTPUT_DEFAULT = SDK_ROOT.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
 
 sys.path.insert(0, str(SDK_ROOT))
@@ -48,13 +47,33 @@ LANGUAGE_CONFIG: dict[str, dict] = {
         "import_prefix": "from codepathfinder.go_rule import ",
         "install": "pip install codepathfinder",
         "meta_module": "codepathfinder.go_rule_meta",
-        "sdk_module":  "codepathfinder.go_rule",
+        "sdk_module": "codepathfinder.go_rule",
         "categories": [
-            {"id": "web-frameworks", "name": "Web Frameworks",  "description": "HTTP sources for Gin, Echo, Fiber, Chi, Gorilla Mux"},
-            {"id": "databases",      "name": "Databases",        "description": "ORM and driver sinks: GORM, sqlx, pgx, database/sql"},
-            {"id": "stdlib",         "name": "Standard Library", "description": "Go stdlib: os/exec, net/http, path/filepath, strconv"},
-            {"id": "http-clients",   "name": "HTTP Clients",     "description": "Outbound HTTP: net/http, go-resty — SSRF sinks"},
-            {"id": "auth-config",    "name": "Auth & Config",    "description": "JWT verification, gRPC, Viper, YAML"},
+            {
+                "id": "web-frameworks",
+                "name": "Web Frameworks",
+                "description": "HTTP sources for Gin, Echo, Fiber, Chi, Gorilla Mux",
+            },
+            {
+                "id": "databases",
+                "name": "Databases",
+                "description": "ORM and driver sinks: GORM, sqlx, pgx, database/sql",
+            },
+            {
+                "id": "stdlib",
+                "name": "Standard Library",
+                "description": "Go stdlib: os/exec, net/http, path/filepath, strconv",
+            },
+            {
+                "id": "http-clients",
+                "name": "HTTP Clients",
+                "description": "Outbound HTTP: net/http, go-resty — SSRF sinks",
+            },
+            {
+                "id": "auth-config",
+                "name": "Auth & Config",
+                "description": "JWT verification, gRPC, Viper, YAML",
+            },
         ],
     },
     "python": {
@@ -65,23 +84,60 @@ LANGUAGE_CONFIG: dict[str, dict] = {
         "import_prefix": "from codepathfinder import calls, flows\nfrom codepathfinder.python_decorators import python_rule",
         "install": "pip install codepathfinder",
         "meta_module": "codepathfinder.python_rule_meta",
-        "sdk_module":  None,  # Python rules use calls() not QueryType
+        "sdk_module": None,  # Python rules use calls() not QueryType
         "categories": [
-            {"id": "web-frameworks",    "name": "Web Frameworks",    "description": "Flask, Django, FastAPI request sources and response sinks"},
-            {"id": "command-execution", "name": "Command Execution", "description": "subprocess, os — command injection sinks"},
-            {"id": "databases",         "name": "Databases",          "description": "sqlite3, psycopg2, pymongo, redis — SQL and NoSQL sinks"},
-            {"id": "deserialization",   "name": "Deserialization",    "description": "pickle, marshal, yaml — unsafe deserialization"},
-            {"id": "http-clients",      "name": "HTTP Clients",       "description": "requests, httpx, urllib — SSRF sinks"},
-            {"id": "file-system",       "name": "File System",        "description": "os.path, tempfile, pathlib — path traversal and temp file handling"},
-            {"id": "archives",          "name": "Archives",           "description": "tarfile, zipfile — archive extraction (zip slip, bombs)"},
-            {"id": "crypto",            "name": "Cryptography",       "description": "hashlib, hmac, ssl, secrets — weak crypto detection"},
-            {"id": "templating",        "name": "Templating",         "description": "jinja2, string.Template — SSTI and XSS sinks"},
+            {
+                "id": "web-frameworks",
+                "name": "Web Frameworks",
+                "description": "Flask, Django, FastAPI request sources and response sinks",
+            },
+            {
+                "id": "command-execution",
+                "name": "Command Execution",
+                "description": "subprocess, os — command injection sinks",
+            },
+            {
+                "id": "databases",
+                "name": "Databases",
+                "description": "sqlite3, psycopg2, pymongo, redis — SQL and NoSQL sinks",
+            },
+            {
+                "id": "deserialization",
+                "name": "Deserialization",
+                "description": "pickle, marshal, yaml — unsafe deserialization",
+            },
+            {
+                "id": "http-clients",
+                "name": "HTTP Clients",
+                "description": "requests, httpx, urllib — SSRF sinks",
+            },
+            {
+                "id": "file-system",
+                "name": "File System",
+                "description": "os.path, tempfile, pathlib — path traversal and temp file handling",
+            },
+            {
+                "id": "archives",
+                "name": "Archives",
+                "description": "tarfile, zipfile — archive extraction (zip slip, bombs)",
+            },
+            {
+                "id": "crypto",
+                "name": "Cryptography",
+                "description": "hashlib, hmac, ssl, secrets — weak crypto detection",
+            },
+            {
+                "id": "templating",
+                "name": "Templating",
+                "description": "jinja2, string.Template — SSTI and XSS sinks",
+            },
         ],
     },
 }
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
+
 
 def _collect_all_meta() -> dict[str, dict]:
     """
@@ -97,11 +153,15 @@ def _collect_all_meta() -> dict[str, dict]:
         except ModuleNotFoundError:
             print(f"  [skip] {meta_module_name} not found — skipping {lang_id}")
         except AttributeError:
-            print(f"  [warn] {meta_module_name} has no SDK_META dict — skipping {lang_id}")
+            print(
+                f"  [warn] {meta_module_name} has no SDK_META dict — skipping {lang_id}"
+            )
     return results
 
 
-def _validate_methods(class_name: str, meta_methods: dict, sdk_module_name: str | None) -> list[str]:
+def _validate_methods(
+    class_name: str, meta_methods: dict, sdk_module_name: str | None
+) -> list[str]:
     """
     Check that methods listed in SDK_META exist on the real SDK class.
     Returns a list of validation warnings (empty = all good).
@@ -150,18 +210,30 @@ def _build_class_manifest(
     """Build the per-class entry for sdk-manifest.json."""
     methods_out = []
     for method_name, mdata in meta.get("methods", {}).items():
-        methods_out.append({
-            "name": method_name,
-            "signature": mdata.get("signature", f"{method_name}(...)"),
-            "description": mdata.get("description", ""),
-            "role": mdata.get("role", "neutral"),  # source | sink | sanitizer | neutral
-            "tracks": mdata.get("tracks", []),
-            "where_example": mdata.get("where_example"),
-        })
+        methods_out.append(
+            {
+                "name": method_name,
+                "signature": mdata.get("signature", f"{method_name}(...)"),
+                "description": mdata.get("description", ""),
+                "role": mdata.get(
+                    "role", "neutral"
+                ),  # source | sink | sanitizer | neutral
+                "tracks": mdata.get("tracks", []),
+                "where_example": mdata.get("where_example"),
+            }
+        )
 
     # FQNs: prefer real SDK class attrs, fall back to meta-provided fqns
-    fqns     = getattr(sdk_class, "fqns",     meta.get("fqns",     [])) if sdk_class else meta.get("fqns",     [])
-    patterns = getattr(sdk_class, "patterns", meta.get("patterns", [])) if sdk_class else meta.get("patterns", [])
+    fqns = (
+        getattr(sdk_class, "fqns", meta.get("fqns", []))
+        if sdk_class
+        else meta.get("fqns", [])
+    )
+    patterns = (
+        getattr(sdk_class, "patterns", meta.get("patterns", []))
+        if sdk_class
+        else meta.get("patterns", [])
+    )
 
     return {
         "id": class_name,
@@ -181,6 +253,7 @@ def _build_class_manifest(
 
 
 # ── Main ───────────────────────────────────────────────────────────────────────
+
 
 def generate(out_path: Path, verbose: bool = False) -> None:
     print(f"Generating SDK manifest → {out_path}")
@@ -216,7 +289,9 @@ def generate(out_path: Path, verbose: bool = False) -> None:
 
         for class_name, meta in sdk_meta.items():
             sdk_class = getattr(sdk_mod, class_name, None) if sdk_mod else None
-            warnings = _validate_methods(class_name, meta.get("methods", {}), sdk_module_name)
+            warnings = _validate_methods(
+                class_name, meta.get("methods", {}), sdk_module_name
+            )
             all_warnings.extend(warnings)
 
             classes_out[class_name] = _build_class_manifest(
@@ -224,7 +299,9 @@ def generate(out_path: Path, verbose: bool = False) -> None:
             )
             if verbose:
                 method_count = len(meta.get("methods", {}))
-                print(f"    {class_name}: {method_count} methods, {usage_counts.get(class_name, 0)} rules")
+                print(
+                    f"    {class_name}: {method_count} methods, {usage_counts.get(class_name, 0)} rules"
+                )
 
         if all_warnings:
             print(f"  Validation warnings for {lang_id}:")
@@ -235,15 +312,18 @@ def generate(out_path: Path, verbose: bool = False) -> None:
         categories_out = []
         for cat in lang_cfg["categories"]:
             cat_classes = [
-                cid for cid, cmeta in sdk_meta.items()
+                cid
+                for cid, cmeta in sdk_meta.items()
                 if cmeta.get("category") == cat["id"]
             ]
-            categories_out.append({
-                "id": cat["id"],
-                "name": cat["name"],
-                "description": cat["description"],
-                "class_ids": cat_classes,
-            })
+            categories_out.append(
+                {
+                    "id": cat["id"],
+                    "name": cat["name"],
+                    "description": cat["description"],
+                    "class_ids": cat_classes,
+                }
+            )
 
         manifest["languages"][lang_id] = {
             "id": lang_id,
@@ -259,8 +339,10 @@ def generate(out_path: Path, verbose: bool = False) -> None:
             "total_methods": sum(len(c["methods"]) for c in classes_out.values()),
         }
 
-        print(f"  {lang_id}: {len(classes_out)} classes, "
-              f"{manifest['languages'][lang_id]['total_methods']} methods")
+        print(
+            f"  {lang_id}: {len(classes_out)} classes, "
+            f"{manifest['languages'][lang_id]['total_methods']} methods"
+        )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
@@ -283,11 +365,14 @@ if __name__ == "__main__":
         # Chain CDN indexers: stubs for every CDN module we don't cover by hand.
         print()
         import subprocess
+
         for indexer_name in ("index_python_from_cdn.py", "index_go_from_cdn.py"):
             indexer = SCRIPT_DIR / indexer_name
             if indexer.exists():
                 result = subprocess.run([sys.executable, str(indexer)], check=False)
                 if result.returncode != 0:
-                    print(f"[warn] {indexer_name} returned non-zero — handcrafted manifest still written.")
+                    print(
+                        f"[warn] {indexer_name} returned non-zero — handcrafted manifest still written."
+                    )
             else:
                 print(f"[info] CDN indexer not found at {indexer} — skipping.")

--- a/python-sdk/scripts/generate_sdk_manifest.py
+++ b/python-sdk/scripts/generate_sdk_manifest.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+generate_sdk_manifest.py — Build sdk-manifest.json from _meta.py companion files.
+
+Usage:
+    python scripts/generate_sdk_manifest.py --out public/sdk-manifest.json
+
+The generator:
+1. Imports each *_meta.py companion file (go_rule_meta, python_rule_meta, etc.)
+2. Loads the corresponding QueryType class from the real SDK source
+3. Validates that every method listed in SDK_META actually exists on the class
+4. Cross-references rules/* to count how many rules use each class
+5. Emits sdk-manifest.json consumed by the cpf-website /sdk/ pages
+
+Adding a new language:
+  - Create codepathfinder/{lang}_rule_meta.py with SDK_META dict
+  - Import it in _collect_all_meta() below
+  - Re-run this script
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ── Resolve paths ──────────────────────────────────────────────────────────────
+SCRIPT_DIR = Path(__file__).parent
+SDK_ROOT    = SCRIPT_DIR.parent
+RULES_DIR   = SDK_ROOT / "rules"
+OUTPUT_DEFAULT = SDK_ROOT.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+
+sys.path.insert(0, str(SDK_ROOT))
+
+
+# ── Language-level config (not in _meta.py — structural, not per-class) ───────
+LANGUAGE_CONFIG: dict[str, dict] = {
+    "golang": {
+        "name": "Go",
+        "version": "1.21+",
+        "description": "Type-aware security analysis for Go applications. QueryType classes resolve to fully-qualified Go module paths.",
+        "decorator": "@go_rule",
+        "import_prefix": "from codepathfinder.go_rule import ",
+        "install": "pip install codepathfinder",
+        "meta_module": "codepathfinder.go_rule_meta",
+        "sdk_module":  "codepathfinder.go_rule",
+        "categories": [
+            {"id": "web-frameworks", "name": "Web Frameworks",  "description": "HTTP sources for Gin, Echo, Fiber, Chi, Gorilla Mux"},
+            {"id": "databases",      "name": "Databases",        "description": "ORM and driver sinks: GORM, sqlx, pgx, database/sql"},
+            {"id": "stdlib",         "name": "Standard Library", "description": "Go stdlib: os/exec, net/http, path/filepath, strconv"},
+            {"id": "http-clients",   "name": "HTTP Clients",     "description": "Outbound HTTP: net/http, go-resty — SSRF sinks"},
+            {"id": "auth-config",    "name": "Auth & Config",    "description": "JWT verification, gRPC, Viper, YAML"},
+        ],
+    },
+    "python": {
+        "name": "Python",
+        "version": "3.9+",
+        "description": "Taint analysis for Python applications. Supports Flask, Django, FastAPI, and standard library sources/sinks.",
+        "decorator": "@python_rule",
+        "import_prefix": "from codepathfinder import calls, flows\nfrom codepathfinder.python_decorators import python_rule",
+        "install": "pip install codepathfinder",
+        "meta_module": "codepathfinder.python_rule_meta",
+        "sdk_module":  None,  # Python rules use calls() not QueryType
+        "categories": [
+            {"id": "web-frameworks",    "name": "Web Frameworks",    "description": "Flask, Django, FastAPI request sources and response sinks"},
+            {"id": "command-execution", "name": "Command Execution", "description": "subprocess, os — command injection sinks"},
+            {"id": "databases",         "name": "Databases",          "description": "sqlite3, psycopg2, pymongo, redis — SQL and NoSQL sinks"},
+            {"id": "deserialization",   "name": "Deserialization",    "description": "pickle, marshal, yaml — unsafe deserialization"},
+            {"id": "http-clients",      "name": "HTTP Clients",       "description": "requests, httpx, urllib — SSRF sinks"},
+            {"id": "file-system",       "name": "File System",        "description": "os.path, tempfile, pathlib — path traversal and temp file handling"},
+            {"id": "archives",          "name": "Archives",           "description": "tarfile, zipfile — archive extraction (zip slip, bombs)"},
+            {"id": "crypto",            "name": "Cryptography",       "description": "hashlib, hmac, ssl, secrets — weak crypto detection"},
+            {"id": "templating",        "name": "Templating",         "description": "jinja2, string.Template — SSTI and XSS sinks"},
+        ],
+    },
+}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _collect_all_meta() -> dict[str, dict]:
+    """
+    Import each *_meta.py and return a mapping of
+    language_id -> SDK_META dict.
+    """
+    results: dict[str, dict] = {}
+    for lang_id, cfg in LANGUAGE_CONFIG.items():
+        meta_module_name = cfg["meta_module"]
+        try:
+            mod = importlib.import_module(meta_module_name)
+            results[lang_id] = mod.SDK_META  # type: ignore[attr-defined]
+        except ModuleNotFoundError:
+            print(f"  [skip] {meta_module_name} not found — skipping {lang_id}")
+        except AttributeError:
+            print(f"  [warn] {meta_module_name} has no SDK_META dict — skipping {lang_id}")
+    return results
+
+
+def _validate_methods(class_name: str, meta_methods: dict, sdk_module_name: str | None) -> list[str]:
+    """
+    Check that methods listed in SDK_META exist on the real SDK class.
+    Returns a list of validation warnings (empty = all good).
+    """
+    warnings: list[str] = []
+    if sdk_module_name is None:
+        return warnings  # Python rules use calls() — no class to introspect
+
+    try:
+        mod = importlib.import_module(sdk_module_name)
+        cls = getattr(mod, class_name, None)
+        if cls is None:
+            warnings.append(f"{class_name}: class not found in {sdk_module_name}")
+            return warnings
+        # QueryType classes expose .method() — we can't introspect Go receiver methods
+        # but we can check that the meta methods list is non-empty
+        if not meta_methods:
+            warnings.append(f"{class_name}: no methods listed in SDK_META")
+    except Exception as exc:
+        warnings.append(f"{class_name}: import error — {exc}")
+    return warnings
+
+
+def _count_rule_usages(class_names: list[str]) -> dict[str, int]:
+    """
+    Scan rules/ for import lines to count how many rules reference each class.
+    """
+    counts: dict[str, int] = {name: 0 for name in class_names}
+    for rule_file in RULES_DIR.rglob("*.py"):
+        try:
+            text = rule_file.read_text(encoding="utf-8")
+            for name in class_names:
+                if name in text:
+                    counts[name] += 1
+        except Exception:
+            pass
+    return counts
+
+
+def _build_class_manifest(
+    class_name: str,
+    meta: dict,
+    sdk_class: Any,
+    usage_count: int,
+) -> dict:
+    """Build the per-class entry for sdk-manifest.json."""
+    methods_out = []
+    for method_name, mdata in meta.get("methods", {}).items():
+        methods_out.append({
+            "name": method_name,
+            "signature": mdata.get("signature", f"{method_name}(...)"),
+            "description": mdata.get("description", ""),
+            "role": mdata.get("role", "neutral"),  # source | sink | sanitizer | neutral
+            "tracks": mdata.get("tracks", []),
+            "where_example": mdata.get("where_example"),
+        })
+
+    # FQNs: prefer real SDK class attrs, fall back to meta-provided fqns
+    fqns     = getattr(sdk_class, "fqns",     meta.get("fqns",     [])) if sdk_class else meta.get("fqns",     [])
+    patterns = getattr(sdk_class, "patterns", meta.get("patterns", [])) if sdk_class else meta.get("patterns", [])
+
+    return {
+        "id": class_name,
+        "name": class_name,
+        "description": meta.get("description", ""),
+        "category": meta.get("category", "stdlib"),
+        "fqns": fqns,
+        "patterns": patterns,
+        "go_mod": meta.get("go_mod"),
+        "pip_snippet": meta.get("pip_snippet"),
+        "import_stmt": f"from codepathfinder.go_rule import {class_name}",
+        "methods": methods_out,
+        "example_rule": meta.get("example_rule"),
+        "rules_using": meta.get("rules_using", []),
+        "usage_count": usage_count,
+    }
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def generate(out_path: Path, verbose: bool = False) -> None:
+    print(f"Generating SDK manifest → {out_path}")
+
+    all_meta = _collect_all_meta()
+    manifest: dict = {
+        "version": "1.0.0",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "languages": {},
+    }
+
+    for lang_id, lang_cfg in LANGUAGE_CONFIG.items():
+        if lang_id not in all_meta:
+            continue
+
+        sdk_meta = all_meta[lang_id]
+        sdk_module_name = lang_cfg["sdk_module"]
+
+        # Load SDK module for introspection
+        sdk_mod = None
+        if sdk_module_name:
+            try:
+                sdk_mod = importlib.import_module(sdk_module_name)
+            except ModuleNotFoundError:
+                print(f"  [warn] Cannot import {sdk_module_name} — FQNs will be empty")
+
+        # Count rule usages across all classes in this language
+        class_names = list(sdk_meta.keys())
+        usage_counts = _count_rule_usages(class_names)
+
+        classes_out: dict[str, dict] = {}
+        all_warnings: list[str] = []
+
+        for class_name, meta in sdk_meta.items():
+            sdk_class = getattr(sdk_mod, class_name, None) if sdk_mod else None
+            warnings = _validate_methods(class_name, meta.get("methods", {}), sdk_module_name)
+            all_warnings.extend(warnings)
+
+            classes_out[class_name] = _build_class_manifest(
+                class_name, meta, sdk_class, usage_counts.get(class_name, 0)
+            )
+            if verbose:
+                method_count = len(meta.get("methods", {}))
+                print(f"    {class_name}: {method_count} methods, {usage_counts.get(class_name, 0)} rules")
+
+        if all_warnings:
+            print(f"  Validation warnings for {lang_id}:")
+            for w in all_warnings:
+                print(f"    ⚠  {w}")
+
+        # Build category class lists in order
+        categories_out = []
+        for cat in lang_cfg["categories"]:
+            cat_classes = [
+                cid for cid, cmeta in sdk_meta.items()
+                if cmeta.get("category") == cat["id"]
+            ]
+            categories_out.append({
+                "id": cat["id"],
+                "name": cat["name"],
+                "description": cat["description"],
+                "class_ids": cat_classes,
+            })
+
+        manifest["languages"][lang_id] = {
+            "id": lang_id,
+            "name": lang_cfg["name"],
+            "version": lang_cfg["version"],
+            "description": lang_cfg["description"],
+            "decorator": lang_cfg["decorator"],
+            "import_prefix": lang_cfg["import_prefix"],
+            "install": lang_cfg["install"],
+            "categories": categories_out,
+            "classes": classes_out,
+            "total_classes": len(classes_out),
+            "total_methods": sum(len(c["methods"]) for c in classes_out.values()),
+        }
+
+        print(f"  {lang_id}: {len(classes_out)} classes, "
+              f"{manifest['languages'][lang_id]['total_methods']} methods")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"Done. Written to {out_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate sdk-manifest.json")
+    parser.add_argument("--out", type=Path, default=OUTPUT_DEFAULT, help="Output path")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument(
+        "--skip-cdn-index",
+        action="store_true",
+        help="Skip the CDN stub-indexing pass (default: run it after handcrafted meta).",
+    )
+    args = parser.parse_args()
+    generate(args.out, verbose=args.verbose)
+
+    if not args.skip_cdn_index:
+        # Chain CDN indexers: stubs for every CDN module we don't cover by hand.
+        print()
+        import subprocess
+        for indexer_name in ("index_python_from_cdn.py", "index_go_from_cdn.py"):
+            indexer = SCRIPT_DIR / indexer_name
+            if indexer.exists():
+                result = subprocess.run([sys.executable, str(indexer)], check=False)
+                if result.returncode != 0:
+                    print(f"[warn] {indexer_name} returned non-zero — handcrafted manifest still written.")
+            else:
+                print(f"[info] CDN indexer not found at {indexer} — skipping.")

--- a/python-sdk/scripts/index_go_from_cdn.py
+++ b/python-sdk/scripts/index_go_from_cdn.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+index_go_from_cdn.py — Merge Go stdlib + third-party registries from CDN into sdk-manifest.json.
+
+Runs AFTER generate_sdk_manifest.py. For each Go package on the CDN that isn't already
+covered by a handcrafted go_rule_meta.py entry, generate a stub so rule writers and
+code-quality reviewers can still discover it.
+
+Usage:
+    python scripts/index_go_from_cdn.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).parent
+MANIFEST_PATH = SCRIPT_DIR.parent.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+
+STDLIB_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/go1.21/stdlib/v1/manifest.json"
+THIRDPARTY_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/go-thirdparty/v1/manifest.json"
+
+# Category rules applied in order. Head of the import path is checked first.
+CATEGORY_EXACT: dict[str, str] = {
+    # stdlib security-relevant (already covered by handcrafted entries; these are fallbacks)
+    "os": "stdlib", "os/exec": "stdlib", "net/http": "stdlib", "net": "stdlib",
+    "net/url": "stdlib", "net/smtp": "stdlib", "crypto": "stdlib", "crypto/tls": "stdlib",
+    "crypto/x509": "stdlib", "crypto/aes": "stdlib", "crypto/cipher": "stdlib",
+    "crypto/hmac": "stdlib", "crypto/rand": "stdlib", "crypto/sha256": "stdlib",
+    "crypto/sha512": "stdlib", "encoding/json": "stdlib", "encoding/xml": "stdlib",
+    "encoding/base64": "stdlib", "encoding/binary": "stdlib", "encoding/csv": "stdlib",
+    "encoding/gob": "stdlib", "encoding/hex": "stdlib", "database/sql": "stdlib",
+    "path/filepath": "stdlib", "io": "stdlib", "io/fs": "stdlib", "bufio": "stdlib",
+    "archive/tar": "stdlib", "archive/zip": "stdlib", "html/template": "stdlib",
+    "text/template": "stdlib", "mime/multipart": "stdlib", "log": "stdlib",
+    "log/slog": "stdlib", "math/rand": "stdlib", "plugin": "stdlib",
+    "reflect": "stdlib", "regexp": "stdlib", "runtime": "stdlib",
+    "strconv": "stdlib", "strings": "stdlib", "sync": "stdlib", "syscall": "stdlib",
+    "time": "stdlib", "fmt": "stdlib", "context": "stdlib",
+}
+
+# Prefix-based routing for third-party packages
+THIRD_PARTY_PREFIXES: list[tuple[str, str]] = [
+    # Web frameworks
+    ("github.com/gin-gonic/gin", "web-frameworks"),
+    ("github.com/labstack/echo", "web-frameworks"),
+    ("github.com/gofiber/fiber", "web-frameworks"),
+    ("github.com/go-chi/chi", "web-frameworks"),
+    ("github.com/gorilla/mux", "web-frameworks"),
+    ("github.com/flosch/pongo2", "web-frameworks"),
+    ("github.com/go-playground/validator", "web-frameworks"),
+
+    # Databases
+    ("gorm.io/gorm", "databases"),
+    ("github.com/jackc/pgx", "databases"),
+    ("github.com/jmoiron/sqlx", "databases"),
+    ("github.com/redis/go-redis", "databases"),
+    ("go.mongodb.org/mongo-driver", "databases"),
+    ("k8s.io/client-go", "databases"),
+
+    # HTTP clients
+    ("github.com/go-resty/resty", "http-clients"),
+    ("github.com/aws/aws-sdk-go-v2", "http-clients"),
+    ("cloud.google.com/go", "http-clients"),
+
+    # Auth / Config
+    ("github.com/golang-jwt/jwt", "auth-config"),
+    ("github.com/spf13/viper", "auth-config"),
+    ("github.com/spf13/afero", "auth-config"),
+    ("gopkg.in/yaml.v3", "auth-config"),
+    ("github.com/pelletier/go-toml", "auth-config"),
+    ("google.golang.org/grpc", "auth-config"),
+
+    # Logging / observability
+    ("github.com/sirupsen/logrus", "auth-config"),
+    ("go.uber.org/zap", "auth-config"),
+
+    # Testing
+    ("github.com/stretchr/testify", "auth-config"),
+
+    # CLI
+    ("github.com/codeskyblue/go-sh", "auth-config"),
+]
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": "codepathfinder-indexer/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def to_pascal_case_go(import_path: str) -> str:
+    """Convert Go import path to a PascalCase class id.
+
+    github.com/sirupsen/logrus         -> GoLogrus
+    github.com/aws/aws-sdk-go-v2       -> GoAwsSdkGoV2
+    cloud.google.com/go                -> GoCloudGoogle
+    crypto/sha256                      -> GoCryptoSha256
+    net/http                           -> GoNetHttp
+    """
+    # Strip common prefixes
+    segs = import_path.replace("github.com/", "").replace("gopkg.in/", "").split("/")
+    segs = [s for s in segs if s and s not in ("go",)]  # drop trailing /go segment
+    if not segs:
+        segs = import_path.split("/")
+
+    out_parts: list[str] = []
+    for seg in segs:
+        # Remove version suffixes like /v2, /v5 at end of path segment
+        if re.fullmatch(r"v\d+", seg):
+            continue
+        # Split by . or -
+        sub = re.split(r"[.\-]+", seg)
+        for s in sub:
+            if s and not re.fullmatch(r"v\d+", s):
+                out_parts.append(s[:1].upper() + s[1:].lower())
+
+    if not out_parts:
+        return "GoUnknown"
+    return "Go" + "".join(out_parts)
+
+
+def categorize_stdlib(import_path: str) -> str:
+    """Go stdlib all land in the 'stdlib' category by definition."""
+    return "stdlib"
+
+
+def categorize_thirdparty(import_path: str) -> str:
+    for prefix, cat in THIRD_PARTY_PREFIXES:
+        if import_path == prefix or import_path.startswith(prefix + "/"):
+            return cat
+    # Default third-party bucket
+    return "auth-config"
+
+
+def extract_top_symbols(detail: dict, limit: int = 10) -> list[dict]:
+    """Pull top functions, types, and methods from a Go per-package CDN detail JSON."""
+    methods: list[dict] = []
+
+    # Functions
+    for fn_name, fn in (detail.get("functions") or {}).items():
+        if fn_name.startswith("_") or fn_name[:1].islower():
+            continue  # unexported
+        params = fn.get("parameters") or fn.get("params") or []
+        param_strs: list[str] = []
+        for p in params:
+            if isinstance(p, dict):
+                n = p.get("name") or ""
+                t = p.get("type") or p.get("type_name") or ""
+                param_strs.append(f"{n} {t}".strip() if n and t else (n or t or ""))
+            elif isinstance(p, str):
+                param_strs.append(p)
+        returns = fn.get("returns") or fn.get("return_types") or []
+        ret_str = ""
+        if returns:
+            ret_types: list[str] = []
+            for r in returns:
+                if isinstance(r, dict):
+                    ret_types.append(r.get("type") or r.get("type_name") or "")
+                elif isinstance(r, str):
+                    ret_types.append(r)
+            if len(ret_types) == 1:
+                ret_str = " " + ret_types[0]
+            elif ret_types:
+                ret_str = " (" + ", ".join(t for t in ret_types if t) + ")"
+        sig = f"{fn_name}({', '.join(param_strs)}){ret_str}".strip()
+        doc = (fn.get("docstring") or fn.get("description") or "").strip().split("\n")[0][:180] or f"{fn_name} function."
+        methods.append({
+            "name": fn_name,
+            "signature": sig,
+            "description": doc,
+            "role": "neutral",
+            "tracks": [],
+        })
+        if len(methods) >= limit:
+            return methods
+
+    # Types (structs / interfaces)
+    for type_name, tdef in (detail.get("types") or {}).items():
+        if type_name.startswith("_") or type_name[:1].islower():
+            continue
+        doc = (tdef.get("docstring") or tdef.get("description") or "").strip().split("\n")[0][:180] or f"{type_name} type."
+        methods.append({
+            "name": type_name,
+            "signature": f"type {type_name} ...",
+            "description": doc,
+            "role": "neutral",
+            "tracks": [],
+        })
+        if len(methods) >= limit:
+            return methods
+
+    return methods
+
+
+def try_fetch_detail(base_url: str, filename: str) -> dict | None:
+    try:
+        return fetch_json(f"{base_url}/{filename}")
+    except Exception as e:
+        print(f"  [skip] {filename}: {e}", file=sys.stderr)
+        return None
+
+
+def build_stub(
+    *,
+    import_path: str,
+    source: str,
+    base_url: str,
+    file_hint: str,
+    go_mod: str | None,
+    category: str,
+) -> dict:
+    detail = try_fetch_detail(base_url, file_hint) or {}
+    methods = extract_top_symbols(detail, limit=10)
+    class_id = to_pascal_case_go(import_path)
+    return {
+        "id": class_id,
+        "name": class_id,
+        "description": (
+            f"{source} package — {import_path}. Auto-indexed from CDN. "
+            "Method-level security roles have not been annotated; rule writers should inspect the source before use."
+        ),
+        "category": category,
+        "fqns": [import_path],
+        "patterns": [],
+        "go_mod": go_mod,
+        "pip_snippet": None,
+        "import_stmt": f"from codepathfinder.go_rule import ...  # {import_path}",
+        "methods": methods,
+        "example_rule": None,
+        "rules_using": [],
+        "usage_count": 0,
+    }
+
+
+def main() -> None:
+    if not MANIFEST_PATH.exists():
+        raise SystemExit(f"Manifest not found at {MANIFEST_PATH}. Run generate_sdk_manifest.py first.")
+
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    go = manifest["languages"].setdefault("golang", {})
+    classes: dict[str, Any] = go.setdefault("classes", {})
+    categories = go.setdefault("categories", [])
+
+    # Build set of covered import paths from existing fqns
+    covered_paths: set[str] = set()
+    covered_ids: set[str] = set(classes.keys())
+    for cid, centry in classes.items():
+        for fqn in centry.get("fqns", []) or []:
+            # strip .TypeName suffix where present
+            if "/" in fqn:
+                last = fqn.split("/")[-1]
+                if "." in last:
+                    path = fqn.rsplit(".", 1)[0]
+                    covered_paths.add(path)
+                    covered_paths.add(fqn)
+                else:
+                    covered_paths.add(fqn)
+            else:
+                covered_paths.add(fqn)
+                if "." in fqn:
+                    covered_paths.add(fqn.split(".", 1)[0])
+
+    # Fetch CDN manifests
+    print("Fetching Go CDN manifests...")
+    stdlib = fetch_json(STDLIB_MANIFEST_URL)
+    thirdparty = fetch_json(THIRDPARTY_MANIFEST_URL)
+
+    stdlib_base = stdlib.get("base_url", STDLIB_MANIFEST_URL.rsplit("/", 1)[0])
+    thirdparty_base = thirdparty.get("base_url", THIRDPARTY_MANIFEST_URL.rsplit("/", 1)[0])
+
+    added = 0
+    skipped = 0
+    collisions = 0
+
+    # stdlib
+    for pkg in stdlib.get("packages", []):
+        import_path = pkg["import_path"]
+        if import_path in covered_paths:
+            skipped += 1
+            continue
+        cat = "stdlib"
+        class_id = to_pascal_case_go(import_path)
+        if class_id in covered_ids:
+            # Rare collision (different import paths producing the same class id); disambiguate
+            class_id = class_id + "Stdlib"
+            collisions += 1
+        stub = build_stub(
+            import_path=import_path,
+            source="Go stdlib",
+            base_url=stdlib_base,
+            file_hint=f"{import_path.replace('/', '_')}_stdlib.json",
+            go_mod="// standard library — no go.mod entry required",
+            category=cat,
+        )
+        stub["id"] = class_id
+        stub["name"] = class_id
+        classes[class_id] = stub
+        covered_ids.add(class_id)
+        added += 1
+
+    # third-party
+    for pkg in thirdparty.get("packages", []):
+        import_path = pkg["import_path"]
+        if import_path in covered_paths:
+            skipped += 1
+            continue
+        cat = categorize_thirdparty(import_path)
+        class_id = to_pascal_case_go(import_path)
+        if class_id in covered_ids:
+            class_id = class_id + "Pkg"
+            collisions += 1
+        # For third-party, file hint uses different encoding per CDN docs
+        file_hint = import_path.replace("/", "_") + ".json"
+        stub = build_stub(
+            import_path=import_path,
+            source="Go third-party",
+            base_url=thirdparty_base,
+            file_hint=file_hint,
+            go_mod=f"require {import_path} latest",
+            category=cat,
+        )
+        stub["id"] = class_id
+        stub["name"] = class_id
+        classes[class_id] = stub
+        covered_ids.add(class_id)
+        added += 1
+
+    # Rebuild category class_ids lists from scratch
+    id_by_cat: dict[str, list[str]] = {c["id"]: [] for c in categories}
+    for cid, centry in classes.items():
+        cat = centry.get("category", "stdlib")
+        if cat not in id_by_cat:
+            # Unknown category encountered; register it
+            categories.append({"id": cat, "name": cat.replace("-", " ").title(), "description": "", "class_ids": []})
+            id_by_cat[cat] = []
+        id_by_cat[cat].append(cid)
+
+    for cat in categories:
+        cat["class_ids"] = sorted(id_by_cat.get(cat["id"], []))
+
+    go["total_classes"] = len(classes)
+    go["total_methods"] = sum(len(c["methods"]) for c in classes.values())
+
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2))
+    print(f"Added {added} Go stubs, skipped {skipped} already-covered packages, resolved {collisions} id collisions.")
+    print(f"Go total: {go['total_classes']} classes, {go['total_methods']} methods")
+
+
+if __name__ == "__main__":
+    main()

--- a/python-sdk/scripts/index_go_from_cdn.py
+++ b/python-sdk/scripts/index_go_from_cdn.py
@@ -20,28 +20,66 @@ from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).parent
-MANIFEST_PATH = SCRIPT_DIR.parent.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+MANIFEST_PATH = (
+    SCRIPT_DIR.parent.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+)
 
-STDLIB_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/go1.21/stdlib/v1/manifest.json"
-THIRDPARTY_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/go-thirdparty/v1/manifest.json"
+STDLIB_MANIFEST_URL = (
+    "https://assets.codepathfinder.dev/registries/go1.21/stdlib/v1/manifest.json"
+)
+THIRDPARTY_MANIFEST_URL = (
+    "https://assets.codepathfinder.dev/registries/go-thirdparty/v1/manifest.json"
+)
 
 # Category rules applied in order. Head of the import path is checked first.
 CATEGORY_EXACT: dict[str, str] = {
     # stdlib security-relevant (already covered by handcrafted entries; these are fallbacks)
-    "os": "stdlib", "os/exec": "stdlib", "net/http": "stdlib", "net": "stdlib",
-    "net/url": "stdlib", "net/smtp": "stdlib", "crypto": "stdlib", "crypto/tls": "stdlib",
-    "crypto/x509": "stdlib", "crypto/aes": "stdlib", "crypto/cipher": "stdlib",
-    "crypto/hmac": "stdlib", "crypto/rand": "stdlib", "crypto/sha256": "stdlib",
-    "crypto/sha512": "stdlib", "encoding/json": "stdlib", "encoding/xml": "stdlib",
-    "encoding/base64": "stdlib", "encoding/binary": "stdlib", "encoding/csv": "stdlib",
-    "encoding/gob": "stdlib", "encoding/hex": "stdlib", "database/sql": "stdlib",
-    "path/filepath": "stdlib", "io": "stdlib", "io/fs": "stdlib", "bufio": "stdlib",
-    "archive/tar": "stdlib", "archive/zip": "stdlib", "html/template": "stdlib",
-    "text/template": "stdlib", "mime/multipart": "stdlib", "log": "stdlib",
-    "log/slog": "stdlib", "math/rand": "stdlib", "plugin": "stdlib",
-    "reflect": "stdlib", "regexp": "stdlib", "runtime": "stdlib",
-    "strconv": "stdlib", "strings": "stdlib", "sync": "stdlib", "syscall": "stdlib",
-    "time": "stdlib", "fmt": "stdlib", "context": "stdlib",
+    "os": "stdlib",
+    "os/exec": "stdlib",
+    "net/http": "stdlib",
+    "net": "stdlib",
+    "net/url": "stdlib",
+    "net/smtp": "stdlib",
+    "crypto": "stdlib",
+    "crypto/tls": "stdlib",
+    "crypto/x509": "stdlib",
+    "crypto/aes": "stdlib",
+    "crypto/cipher": "stdlib",
+    "crypto/hmac": "stdlib",
+    "crypto/rand": "stdlib",
+    "crypto/sha256": "stdlib",
+    "crypto/sha512": "stdlib",
+    "encoding/json": "stdlib",
+    "encoding/xml": "stdlib",
+    "encoding/base64": "stdlib",
+    "encoding/binary": "stdlib",
+    "encoding/csv": "stdlib",
+    "encoding/gob": "stdlib",
+    "encoding/hex": "stdlib",
+    "database/sql": "stdlib",
+    "path/filepath": "stdlib",
+    "io": "stdlib",
+    "io/fs": "stdlib",
+    "bufio": "stdlib",
+    "archive/tar": "stdlib",
+    "archive/zip": "stdlib",
+    "html/template": "stdlib",
+    "text/template": "stdlib",
+    "mime/multipart": "stdlib",
+    "log": "stdlib",
+    "log/slog": "stdlib",
+    "math/rand": "stdlib",
+    "plugin": "stdlib",
+    "reflect": "stdlib",
+    "regexp": "stdlib",
+    "runtime": "stdlib",
+    "strconv": "stdlib",
+    "strings": "stdlib",
+    "sync": "stdlib",
+    "syscall": "stdlib",
+    "time": "stdlib",
+    "fmt": "stdlib",
+    "context": "stdlib",
 }
 
 # Prefix-based routing for third-party packages
@@ -54,7 +92,6 @@ THIRD_PARTY_PREFIXES: list[tuple[str, str]] = [
     ("github.com/gorilla/mux", "web-frameworks"),
     ("github.com/flosch/pongo2", "web-frameworks"),
     ("github.com/go-playground/validator", "web-frameworks"),
-
     # Databases
     ("gorm.io/gorm", "databases"),
     ("github.com/jackc/pgx", "databases"),
@@ -62,12 +99,10 @@ THIRD_PARTY_PREFIXES: list[tuple[str, str]] = [
     ("github.com/redis/go-redis", "databases"),
     ("go.mongodb.org/mongo-driver", "databases"),
     ("k8s.io/client-go", "databases"),
-
     # HTTP clients
     ("github.com/go-resty/resty", "http-clients"),
     ("github.com/aws/aws-sdk-go-v2", "http-clients"),
     ("cloud.google.com/go", "http-clients"),
-
     # Auth / Config
     ("github.com/golang-jwt/jwt", "auth-config"),
     ("github.com/spf13/viper", "auth-config"),
@@ -75,23 +110,23 @@ THIRD_PARTY_PREFIXES: list[tuple[str, str]] = [
     ("gopkg.in/yaml.v3", "auth-config"),
     ("github.com/pelletier/go-toml", "auth-config"),
     ("google.golang.org/grpc", "auth-config"),
-
     # Logging / observability
     ("github.com/sirupsen/logrus", "auth-config"),
     ("go.uber.org/zap", "auth-config"),
-
     # Testing
     ("github.com/stretchr/testify", "auth-config"),
-
     # CLI
     ("github.com/codeskyblue/go-sh", "auth-config"),
 ]
 
 
 def fetch_json(url: str) -> dict:
-    req = urllib.request.Request(url, headers={"User-Agent": "codepathfinder-indexer/1.0"})
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "codepathfinder-indexer/1.0"}
+    )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        data: dict = json.loads(resp.read().decode("utf-8"))
+        return data
 
 
 def to_pascal_case_go(import_path: str) -> str:
@@ -169,14 +204,18 @@ def extract_top_symbols(detail: dict, limit: int = 10) -> list[dict]:
             elif ret_types:
                 ret_str = " (" + ", ".join(t for t in ret_types if t) + ")"
         sig = f"{fn_name}({', '.join(param_strs)}){ret_str}".strip()
-        doc = (fn.get("docstring") or fn.get("description") or "").strip().split("\n")[0][:180] or f"{fn_name} function."
-        methods.append({
-            "name": fn_name,
-            "signature": sig,
-            "description": doc,
-            "role": "neutral",
-            "tracks": [],
-        })
+        doc = (fn.get("docstring") or fn.get("description") or "").strip().split("\n")[
+            0
+        ][:180] or f"{fn_name} function."
+        methods.append(
+            {
+                "name": fn_name,
+                "signature": sig,
+                "description": doc,
+                "role": "neutral",
+                "tracks": [],
+            }
+        )
         if len(methods) >= limit:
             return methods
 
@@ -184,14 +223,18 @@ def extract_top_symbols(detail: dict, limit: int = 10) -> list[dict]:
     for type_name, tdef in (detail.get("types") or {}).items():
         if type_name.startswith("_") or type_name[:1].islower():
             continue
-        doc = (tdef.get("docstring") or tdef.get("description") or "").strip().split("\n")[0][:180] or f"{type_name} type."
-        methods.append({
-            "name": type_name,
-            "signature": f"type {type_name} ...",
-            "description": doc,
-            "role": "neutral",
-            "tracks": [],
-        })
+        doc = (tdef.get("docstring") or tdef.get("description") or "").strip().split(
+            "\n"
+        )[0][:180] or f"{type_name} type."
+        methods.append(
+            {
+                "name": type_name,
+                "signature": f"type {type_name} ...",
+                "description": doc,
+                "role": "neutral",
+                "tracks": [],
+            }
+        )
         if len(methods) >= limit:
             return methods
 
@@ -240,7 +283,9 @@ def build_stub(
 
 def main() -> None:
     if not MANIFEST_PATH.exists():
-        raise SystemExit(f"Manifest not found at {MANIFEST_PATH}. Run generate_sdk_manifest.py first.")
+        raise SystemExit(
+            f"Manifest not found at {MANIFEST_PATH}. Run generate_sdk_manifest.py first."
+        )
 
     manifest = json.loads(MANIFEST_PATH.read_text())
     go = manifest["languages"].setdefault("golang", {})
@@ -272,7 +317,9 @@ def main() -> None:
     thirdparty = fetch_json(THIRDPARTY_MANIFEST_URL)
 
     stdlib_base = stdlib.get("base_url", STDLIB_MANIFEST_URL.rsplit("/", 1)[0])
-    thirdparty_base = thirdparty.get("base_url", THIRDPARTY_MANIFEST_URL.rsplit("/", 1)[0])
+    thirdparty_base = thirdparty.get(
+        "base_url", THIRDPARTY_MANIFEST_URL.rsplit("/", 1)[0]
+    )
 
     added = 0
     skipped = 0
@@ -337,7 +384,14 @@ def main() -> None:
         cat = centry.get("category", "stdlib")
         if cat not in id_by_cat:
             # Unknown category encountered; register it
-            categories.append({"id": cat, "name": cat.replace("-", " ").title(), "description": "", "class_ids": []})
+            categories.append(
+                {
+                    "id": cat,
+                    "name": cat.replace("-", " ").title(),
+                    "description": "",
+                    "class_ids": [],
+                }
+            )
             id_by_cat[cat] = []
         id_by_cat[cat].append(cid)
 
@@ -348,7 +402,9 @@ def main() -> None:
     go["total_methods"] = sum(len(c["methods"]) for c in classes.values())
 
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=2))
-    print(f"Added {added} Go stubs, skipped {skipped} already-covered packages, resolved {collisions} id collisions.")
+    print(
+        f"Added {added} Go stubs, skipped {skipped} already-covered packages, resolved {collisions} id collisions."
+    )
     print(f"Go total: {go['total_classes']} classes, {go['total_methods']} methods")
 
 

--- a/python-sdk/scripts/index_python_from_cdn.py
+++ b/python-sdk/scripts/index_python_from_cdn.py
@@ -24,162 +24,462 @@ from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).parent
-MANIFEST_PATH = SCRIPT_DIR.parent.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+MANIFEST_PATH = (
+    SCRIPT_DIR.parent.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+)
 
-STDLIB_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/python3.11/stdlib/v1/manifest.json"
-THIRDPARTY_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/thirdparty/v1/manifest.json"
+STDLIB_MANIFEST_URL = (
+    "https://assets.codepathfinder.dev/registries/python3.11/stdlib/v1/manifest.json"
+)
+THIRDPARTY_MANIFEST_URL = (
+    "https://assets.codepathfinder.dev/registries/thirdparty/v1/manifest.json"
+)
 
 # Category rules applied in order. First match wins.
 # Modules not matching any rule land in "utilities".
 CATEGORY_EXACT: dict[str, str] = {
     # command-execution
-    "subprocess": "command-execution", "os": "command-execution", "pty": "command-execution",
-    "pexpect": "command-execution", "docker": "command-execution", "ctypes": "command-execution",
-    "cffi": "command-execution", "fcntl": "command-execution", "signal": "command-execution",
-
+    "subprocess": "command-execution",
+    "os": "command-execution",
+    "pty": "command-execution",
+    "pexpect": "command-execution",
+    "docker": "command-execution",
+    "ctypes": "command-execution",
+    "cffi": "command-execution",
+    "fcntl": "command-execution",
+    "signal": "command-execution",
     # deserialization
-    "pickle": "deserialization", "pickletools": "deserialization", "marshal": "deserialization",
-    "json": "deserialization", "simplejson": "deserialization", "yaml": "deserialization",
-    "csv": "deserialization", "xml": "deserialization", "lxml": "deserialization",
-    "defusedxml": "deserialization", "xmltodict": "deserialization", "xmlrpc": "deserialization",
-    "shelve": "deserialization", "dbm": "deserialization", "pyasn1": "deserialization",
-    "toml": "deserialization", "tomllib": "deserialization", "plistlib": "deserialization",
-    "ast": "deserialization", "pyexpat": "deserialization",
-
+    "pickle": "deserialization",
+    "pickletools": "deserialization",
+    "marshal": "deserialization",
+    "json": "deserialization",
+    "simplejson": "deserialization",
+    "yaml": "deserialization",
+    "csv": "deserialization",
+    "xml": "deserialization",
+    "lxml": "deserialization",
+    "defusedxml": "deserialization",
+    "xmltodict": "deserialization",
+    "xmlrpc": "deserialization",
+    "shelve": "deserialization",
+    "dbm": "deserialization",
+    "pyasn1": "deserialization",
+    "toml": "deserialization",
+    "tomllib": "deserialization",
+    "plistlib": "deserialization",
+    "ast": "deserialization",
+    "pyexpat": "deserialization",
     # databases
-    "sqlite3": "databases", "psycopg2": "databases", "pymongo": "databases",
-    "redis": "databases", "sqlalchemy": "databases", "pymysql": "databases",
-    "MySQLdb": "databases", "ldap3": "databases", "hdbcli": "databases",
-    "ibm_db": "databases", "playhouse": "databases", "pony": "databases",
-
+    "sqlite3": "databases",
+    "psycopg2": "databases",
+    "pymongo": "databases",
+    "redis": "databases",
+    "sqlalchemy": "databases",
+    "pymysql": "databases",
+    "MySQLdb": "databases",
+    "ldap3": "databases",
+    "hdbcli": "databases",
+    "ibm_db": "databases",
+    "playhouse": "databases",
+    "pony": "databases",
     # http-clients
-    "requests": "http-clients", "urllib": "http-clients", "http": "http-clients",
-    "socket": "http-clients", "ftplib": "http-clients", "telnetlib": "http-clients",
-    "smtplib": "http-clients", "smtpd": "http-clients", "httpx": "http-clients",
-    "httplib2": "http-clients", "aiohttp": "http-clients", "pycurl": "http-clients",
-    "imaplib": "http-clients", "poplib": "http-clients", "nntplib": "http-clients",
-    "email": "http-clients", "ipaddress": "http-clients", "netaddr": "http-clients",
-    "netifaces": "http-clients", "boto3": "http-clients", "aws_xray_sdk": "http-clients",
-    "mailbox": "http-clients", "mailcap": "http-clients", "netrc": "http-clients",
-    "webob": "http-clients", "slumber": "http-clients", "pika": "http-clients",
+    "requests": "http-clients",
+    "urllib": "http-clients",
+    "http": "http-clients",
+    "socket": "http-clients",
+    "ftplib": "http-clients",
+    "telnetlib": "http-clients",
+    "smtplib": "http-clients",
+    "smtpd": "http-clients",
+    "httpx": "http-clients",
+    "httplib2": "http-clients",
+    "aiohttp": "http-clients",
+    "pycurl": "http-clients",
+    "imaplib": "http-clients",
+    "poplib": "http-clients",
+    "nntplib": "http-clients",
+    "email": "http-clients",
+    "ipaddress": "http-clients",
+    "netaddr": "http-clients",
+    "netifaces": "http-clients",
+    "boto3": "http-clients",
+    "aws_xray_sdk": "http-clients",
+    "mailbox": "http-clients",
+    "mailcap": "http-clients",
+    "netrc": "http-clients",
+    "webob": "http-clients",
+    "slumber": "http-clients",
+    "pika": "http-clients",
     "pysocks": "http-clients",
-
     # file-system
-    "pathlib": "file-system", "tempfile": "file-system", "shutil": "file-system",
-    "logging": "file-system", "aiofiles": "file-system", "glob": "file-system",
-    "fnmatch": "file-system", "re": "file-system", "regex": "file-system",
-    "configparser": "file-system", "dockerfile_parse": "file-system", "mimetypes": "file-system",
+    "pathlib": "file-system",
+    "tempfile": "file-system",
+    "shutil": "file-system",
+    "logging": "file-system",
+    "aiofiles": "file-system",
+    "glob": "file-system",
+    "fnmatch": "file-system",
+    "re": "file-system",
+    "regex": "file-system",
+    "configparser": "file-system",
+    "dockerfile_parse": "file-system",
+    "mimetypes": "file-system",
     "fileinput": "file-system",
-
     # archives
-    "tarfile": "archives", "zipfile": "archives", "zlib": "archives",
-    "gzip": "archives", "bz2": "archives", "lzma": "archives",
-    "zipapp": "archives", "zipimport": "archives", "zstd": "archives",
-
+    "tarfile": "archives",
+    "zipfile": "archives",
+    "zlib": "archives",
+    "gzip": "archives",
+    "bz2": "archives",
+    "lzma": "archives",
+    "zipapp": "archives",
+    "zipimport": "archives",
+    "zstd": "archives",
     # crypto
-    "hashlib": "crypto", "hmac": "crypto", "secrets": "crypto",
-    "random": "crypto", "ssl": "crypto", "jose": "crypto",
-    "authlib": "crypto", "paramiko": "crypto", "getpass": "crypto",
-    "crypt": "crypto", "pysftp": "crypto", "jwt": "crypto",
-    "jwcrypto": "crypto", "jks": "crypto", "oauthlib": "crypto",
-    "requests_oauthlib": "crypto", "auth0": "crypto", "hvac": "crypto",
-    "passpy": "crypto", "tgcrypto": "crypto", "zxcvbn": "crypto",
+    "hashlib": "crypto",
+    "hmac": "crypto",
+    "secrets": "crypto",
+    "random": "crypto",
+    "ssl": "crypto",
+    "jose": "crypto",
+    "authlib": "crypto",
+    "paramiko": "crypto",
+    "getpass": "crypto",
+    "crypt": "crypto",
+    "pysftp": "crypto",
+    "jwt": "crypto",
+    "jwcrypto": "crypto",
+    "jks": "crypto",
+    "oauthlib": "crypto",
+    "requests_oauthlib": "crypto",
+    "auth0": "crypto",
+    "hvac": "crypto",
+    "passpy": "crypto",
+    "tgcrypto": "crypto",
+    "zxcvbn": "crypto",
     "cryptography": "crypto",
-
     # templating
-    "jinja2": "templating", "bleach": "templating", "html": "templating",
-    "html5lib": "templating", "string": "templating", "chevron": "templating",
-    "markdown": "templating", "docutils": "templating", "reportlab": "templating",
-    "fpdf": "templating", "webencodings": "templating",
-
+    "jinja2": "templating",
+    "bleach": "templating",
+    "html": "templating",
+    "html5lib": "templating",
+    "string": "templating",
+    "chevron": "templating",
+    "markdown": "templating",
+    "docutils": "templating",
+    "reportlab": "templating",
+    "fpdf": "templating",
+    "webencodings": "templating",
     # web-frameworks
-    "flask": "web-frameworks", "flask_cors": "web-frameworks",
-    "flask_migrate": "web-frameworks", "flask_socketio": "web-frameworks",
-    "django": "web-frameworks", "django_filters": "web-frameworks",
-    "fastapi": "web-frameworks", "starlette": "web-frameworks",
-    "rest_framework": "web-frameworks", "channels": "web-frameworks",
-    "gunicorn": "web-frameworks", "waitress": "web-frameworks",
-    "uwsgi": "web-frameworks", "cgi": "web-frameworks", "cgitb": "web-frameworks",
-    "wsgiref": "web-frameworks", "pydantic": "web-frameworks",
-    "wtforms": "web-frameworks", "jsonschema": "web-frameworks",
-    "celery": "web-frameworks", "grpc": "web-frameworks",
-    "grpc_channelz": "web-frameworks", "grpc_health": "web-frameworks",
-    "grpc_reflection": "web-frameworks", "grpc_status": "web-frameworks",
-    "simple_websocket": "web-frameworks", "gevent": "web-frameworks",
-    "greenlet": "web-frameworks", "fanstatic": "web-frameworks",
+    "flask": "web-frameworks",
+    "flask_cors": "web-frameworks",
+    "flask_migrate": "web-frameworks",
+    "flask_socketio": "web-frameworks",
+    "django": "web-frameworks",
+    "django_filters": "web-frameworks",
+    "fastapi": "web-frameworks",
+    "starlette": "web-frameworks",
+    "rest_framework": "web-frameworks",
+    "channels": "web-frameworks",
+    "gunicorn": "web-frameworks",
+    "waitress": "web-frameworks",
+    "uwsgi": "web-frameworks",
+    "cgi": "web-frameworks",
+    "cgitb": "web-frameworks",
+    "wsgiref": "web-frameworks",
+    "pydantic": "web-frameworks",
+    "wtforms": "web-frameworks",
+    "jsonschema": "web-frameworks",
+    "celery": "web-frameworks",
+    "grpc": "web-frameworks",
+    "grpc_channelz": "web-frameworks",
+    "grpc_health": "web-frameworks",
+    "grpc_reflection": "web-frameworks",
+    "grpc_status": "web-frameworks",
+    "simple_websocket": "web-frameworks",
+    "gevent": "web-frameworks",
+    "greenlet": "web-frameworks",
+    "fanstatic": "web-frameworks",
     "werkzeug": "web-frameworks",
 }
 
 CATEGORY_PATTERNS: list[tuple[str, list[str]]] = [
-    ("language", [
-        "abc", "typing", "types", "dataclasses", "enum", "collections", "contextlib", "contextvars",
-        "functools", "itertools", "operator", "numbers", "decimal", "fractions", "statistics",
-        "math", "cmath", "array", "bisect", "heapq", "graphlib", "weakref", "copy", "copyreg",
-        "gc", "errno", "atexit", "warnings", "traceback", "sys", "platform", "sysconfig",
-        "builtins", "importlib", "imp", "runpy", "site", "compileall", "keyword", "symtable",
-        "token", "tokenize", "linecache", "pkgutil", "pyclbr", "pydoc", "pydoc_data",
-        "rlcompleter", "code", "codeop", "dis", "inspect", "opcode", "py_compile", "tabnanny",
-        "encodings", "codecs", "textwrap", "unicodedata", "stringprep", "readline",
-        "modulefinder", "struct", "faulthandler", "resource", "select", "selectors", "termios",
-        "singledispatch", "six", "decorator", "deprecated", "mypy_extensions", "entrypoints",
-        "toposort", "boltons", "cachetools", "objgraph", "retry", "punq",
-        "watchpoints", "usersettings",
-    ]),
-    ("concurrency", [
-        "asyncio", "asynchat", "asyncore", "threading", "multiprocessing", "queue",
-        "sched", "concurrent",
-    ]),
-    ("testing", [
-        "unittest", "doctest", "atheris", "mock", "assertpy", "behave",
-        "editdistance", "pytest_lazy_fixture",
-    ]),
-    ("datetime", [
-        "datetime", "time", "zoneinfo", "locale", "gettext", "calendar",
-        "dateparser_data", "dateutil", "croniter", "pytz", "python_crontab",
-        "lunardate", "convertdate", "ephem", "icalendar", "workalendar",
-        "pymeeus", "pyluach", "tzdata", "vobject", "rfc3339_validator",
-    ]),
-    ("io", [
-        "io", "filecmp", "difflib", "stat", "pipes", "ossaudiodev", "wave",
-        "sunau", "aifc", "audioop", "chunk", "sndhdr", "imghdr", "uu", "quopri",
-        "base64", "binascii", "xdrlib", "mmap", "datauri", "dirhash",
-        "binaryornot", "str2bool", "unidiff", "whatthepatch", "xmldiff",
-        "untangle", "olefile",
-    ]),
-    ("cli", [
-        "argparse", "getopt", "optparse", "cmd", "shlex", "click",
-        "colorama", "colorful", "consolemenu", "keyboard",
-        "pyautogui", "pyperclip", "pynput", "pyscreeze", "send2trash",
-        "tabulate", "tqdm", "pygments", "capturer", "wurlitzer",
-    ]),
-    ("gui", [
-        "tkinter", "curses", "turtle", "turtledemo", "pyi_splash",
-        "ttkthemes", "Xlib", "jack", "pyaudio",
-    ]),
-    ("data-science", [
-        "tensorflow", "networkx", "geopandas", "shapely", "seaborn",
-        "pycocotools", "hnswlib", "resampy", "openpyxl", "et_xmlfile",
-        "xlrd", "pyfarmhash", "qrcode", "qrbill",
-    ]),
-    ("dev-tools", [
-        "distutils", "ensurepip", "venv", "lib2to3", "idlelib", "bdb", "pdb",
-        "trace", "tracemalloc", "timeit", "cProfile", "profile", "pstats",
-        "flake8", "pyflakes", "pep8_naming", "gdb", "pythonwin", "portpicker",
-        "dockerfile_parse", "jenkins", "jmespath", "fire",
-    ]),
+    (
+        "language",
+        [
+            "abc",
+            "typing",
+            "types",
+            "dataclasses",
+            "enum",
+            "collections",
+            "contextlib",
+            "contextvars",
+            "functools",
+            "itertools",
+            "operator",
+            "numbers",
+            "decimal",
+            "fractions",
+            "statistics",
+            "math",
+            "cmath",
+            "array",
+            "bisect",
+            "heapq",
+            "graphlib",
+            "weakref",
+            "copy",
+            "copyreg",
+            "gc",
+            "errno",
+            "atexit",
+            "warnings",
+            "traceback",
+            "sys",
+            "platform",
+            "sysconfig",
+            "builtins",
+            "importlib",
+            "imp",
+            "runpy",
+            "site",
+            "compileall",
+            "keyword",
+            "symtable",
+            "token",
+            "tokenize",
+            "linecache",
+            "pkgutil",
+            "pyclbr",
+            "pydoc",
+            "pydoc_data",
+            "rlcompleter",
+            "code",
+            "codeop",
+            "dis",
+            "inspect",
+            "opcode",
+            "py_compile",
+            "tabnanny",
+            "encodings",
+            "codecs",
+            "textwrap",
+            "unicodedata",
+            "stringprep",
+            "readline",
+            "modulefinder",
+            "struct",
+            "faulthandler",
+            "resource",
+            "select",
+            "selectors",
+            "termios",
+            "singledispatch",
+            "six",
+            "decorator",
+            "deprecated",
+            "mypy_extensions",
+            "entrypoints",
+            "toposort",
+            "boltons",
+            "cachetools",
+            "objgraph",
+            "retry",
+            "punq",
+            "watchpoints",
+            "usersettings",
+        ],
+    ),
+    (
+        "concurrency",
+        [
+            "asyncio",
+            "asynchat",
+            "asyncore",
+            "threading",
+            "multiprocessing",
+            "queue",
+            "sched",
+            "concurrent",
+        ],
+    ),
+    (
+        "testing",
+        [
+            "unittest",
+            "doctest",
+            "atheris",
+            "mock",
+            "assertpy",
+            "behave",
+            "editdistance",
+            "pytest_lazy_fixture",
+        ],
+    ),
+    (
+        "datetime",
+        [
+            "datetime",
+            "time",
+            "zoneinfo",
+            "locale",
+            "gettext",
+            "calendar",
+            "dateparser_data",
+            "dateutil",
+            "croniter",
+            "pytz",
+            "python_crontab",
+            "lunardate",
+            "convertdate",
+            "ephem",
+            "icalendar",
+            "workalendar",
+            "pymeeus",
+            "pyluach",
+            "tzdata",
+            "vobject",
+            "rfc3339_validator",
+        ],
+    ),
+    (
+        "io",
+        [
+            "io",
+            "filecmp",
+            "difflib",
+            "stat",
+            "pipes",
+            "ossaudiodev",
+            "wave",
+            "sunau",
+            "aifc",
+            "audioop",
+            "chunk",
+            "sndhdr",
+            "imghdr",
+            "uu",
+            "quopri",
+            "base64",
+            "binascii",
+            "xdrlib",
+            "mmap",
+            "datauri",
+            "dirhash",
+            "binaryornot",
+            "str2bool",
+            "unidiff",
+            "whatthepatch",
+            "xmldiff",
+            "untangle",
+            "olefile",
+        ],
+    ),
+    (
+        "cli",
+        [
+            "argparse",
+            "getopt",
+            "optparse",
+            "cmd",
+            "shlex",
+            "click",
+            "colorama",
+            "colorful",
+            "consolemenu",
+            "keyboard",
+            "pyautogui",
+            "pyperclip",
+            "pynput",
+            "pyscreeze",
+            "send2trash",
+            "tabulate",
+            "tqdm",
+            "pygments",
+            "capturer",
+            "wurlitzer",
+        ],
+    ),
+    (
+        "gui",
+        [
+            "tkinter",
+            "curses",
+            "turtle",
+            "turtledemo",
+            "pyi_splash",
+            "ttkthemes",
+            "Xlib",
+            "jack",
+            "pyaudio",
+        ],
+    ),
+    (
+        "data-science",
+        [
+            "tensorflow",
+            "networkx",
+            "geopandas",
+            "shapely",
+            "seaborn",
+            "pycocotools",
+            "hnswlib",
+            "resampy",
+            "openpyxl",
+            "et_xmlfile",
+            "xlrd",
+            "pyfarmhash",
+            "qrcode",
+            "qrbill",
+        ],
+    ),
+    (
+        "dev-tools",
+        [
+            "distutils",
+            "ensurepip",
+            "venv",
+            "lib2to3",
+            "idlelib",
+            "bdb",
+            "pdb",
+            "trace",
+            "tracemalloc",
+            "timeit",
+            "cProfile",
+            "profile",
+            "pstats",
+            "flake8",
+            "pyflakes",
+            "pep8_naming",
+            "gdb",
+            "pythonwin",
+            "portpicker",
+            "dockerfile_parse",
+            "jenkins",
+            "jmespath",
+            "fire",
+        ],
+    ),
 ]
 
 
 def fetch_json(url: str) -> dict:
-    req = urllib.request.Request(url, headers={"User-Agent": "codepathfinder-indexer/1.0"})
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "codepathfinder-indexer/1.0"}
+    )
     with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        data: dict = json.loads(resp.read().decode("utf-8"))
+        return data
 
 
 def to_pascal_case(name: str) -> str:
     """abc -> PyAbc; xml.etree -> PyXmlEtree; http.client -> PyHttpClient."""
     parts = re.split(r"[._-]+", name)
-    return "Py" + "".join(p[:1].upper() + p[1:].lower() if p else "" for p in parts if p)
+    return "Py" + "".join(
+        p[:1].upper() + p[1:].lower() if p else "" for p in parts if p
+    )
 
 
 def categorize(module_name: str) -> str:
@@ -213,14 +513,18 @@ def extract_top_methods(detail: dict, limit: int = 10) -> list[dict]:
             elif isinstance(p, str):
                 param_strs.append(p)
         sig = f"{fn_name}({', '.join(param_strs)})"
-        doc = (fn.get("docstring") or fn.get("description") or "").strip().split("\n")[0][:180] or f"{fn_name} function."
-        methods.append({
-            "name": fn_name,
-            "signature": sig,
-            "description": doc,
-            "role": "neutral",
-            "tracks": [],
-        })
+        doc = (fn.get("docstring") or fn.get("description") or "").strip().split("\n")[
+            0
+        ][:180] or f"{fn_name} function."
+        methods.append(
+            {
+                "name": fn_name,
+                "signature": sig,
+                "description": doc,
+                "role": "neutral",
+                "tracks": [],
+            }
+        )
         if len(methods) >= limit:
             return methods
 
@@ -228,14 +532,18 @@ def extract_top_methods(detail: dict, limit: int = 10) -> list[dict]:
     for cls_name, cls in (detail.get("classes") or {}).items():
         if cls_name.startswith("_"):
             continue
-        doc = (cls.get("docstring") or cls.get("description") or "").strip().split("\n")[0][:180] or f"{cls_name} class."
-        methods.append({
-            "name": cls_name,
-            "signature": f"{cls_name}(...)",
-            "description": doc,
-            "role": "neutral",
-            "tracks": [],
-        })
+        doc = (cls.get("docstring") or cls.get("description") or "").strip().split(
+            "\n"
+        )[0][:180] or f"{cls_name} class."
+        methods.append(
+            {
+                "name": cls_name,
+                "signature": f"{cls_name}(...)",
+                "description": doc,
+                "role": "neutral",
+                "tracks": [],
+            }
+        )
         if len(methods) >= limit:
             return methods
 
@@ -267,7 +575,11 @@ def build_stub(module: dict, source: str, base_url: str, install_hint: str) -> d
         "patterns": [],
         "go_mod": None,
         "pip_snippet": install_hint,
-        "import_stmt": f"import {name}" if "." not in name else f"from {name.rsplit('.', 1)[0]} import {name.rsplit('.', 1)[1]}",
+        "import_stmt": (
+            f"import {name}"
+            if "." not in name
+            else f"from {name.rsplit('.', 1)[0]} import {name.rsplit('.', 1)[1]}"
+        ),
         "methods": methods,
         "example_rule": None,
         "rules_using": [],
@@ -276,22 +588,60 @@ def build_stub(module: dict, source: str, base_url: str, install_hint: str) -> d
 
 
 EXTRA_CATEGORIES = [
-    {"id": "language", "name": "Language Features", "description": "Python language primitives: typing, collections, abc, functools"},
-    {"id": "concurrency", "name": "Concurrency", "description": "asyncio, threading, multiprocessing, queue"},
-    {"id": "datetime", "name": "Date & Time", "description": "datetime, time, zoneinfo, dateutil"},
-    {"id": "io", "name": "I/O & Encoding", "description": "io streams, base64, binascii, plistlib"},
-    {"id": "cli", "name": "CLI & Terminal", "description": "argparse, click, colorama, tqdm"},
+    {
+        "id": "language",
+        "name": "Language Features",
+        "description": "Python language primitives: typing, collections, abc, functools",
+    },
+    {
+        "id": "concurrency",
+        "name": "Concurrency",
+        "description": "asyncio, threading, multiprocessing, queue",
+    },
+    {
+        "id": "datetime",
+        "name": "Date & Time",
+        "description": "datetime, time, zoneinfo, dateutil",
+    },
+    {
+        "id": "io",
+        "name": "I/O & Encoding",
+        "description": "io streams, base64, binascii, plistlib",
+    },
+    {
+        "id": "cli",
+        "name": "CLI & Terminal",
+        "description": "argparse, click, colorama, tqdm",
+    },
     {"id": "gui", "name": "GUI", "description": "tkinter, curses, turtle"},
-    {"id": "testing", "name": "Testing", "description": "unittest, doctest, mock, pytest tooling"},
-    {"id": "dev-tools", "name": "Developer Tools", "description": "distutils, venv, pdb, linters"},
-    {"id": "data-science", "name": "Data Science", "description": "tensorflow, networkx, geopandas, openpyxl"},
-    {"id": "utilities", "name": "Utilities", "description": "Miscellaneous modules without a dedicated category"},
+    {
+        "id": "testing",
+        "name": "Testing",
+        "description": "unittest, doctest, mock, pytest tooling",
+    },
+    {
+        "id": "dev-tools",
+        "name": "Developer Tools",
+        "description": "distutils, venv, pdb, linters",
+    },
+    {
+        "id": "data-science",
+        "name": "Data Science",
+        "description": "tensorflow, networkx, geopandas, openpyxl",
+    },
+    {
+        "id": "utilities",
+        "name": "Utilities",
+        "description": "Miscellaneous modules without a dedicated category",
+    },
 ]
 
 
 def main() -> None:
     if not MANIFEST_PATH.exists():
-        raise SystemExit(f"Manifest not found at {MANIFEST_PATH}. Run generate_sdk_manifest.py first.")
+        raise SystemExit(
+            f"Manifest not found at {MANIFEST_PATH}. Run generate_sdk_manifest.py first."
+        )
 
     manifest = json.loads(MANIFEST_PATH.read_text())
     py = manifest["languages"].setdefault("python", {})
@@ -317,7 +667,9 @@ def main() -> None:
     thirdparty = fetch_json(THIRDPARTY_MANIFEST_URL)
 
     stdlib_base = stdlib.get("base_url", STDLIB_MANIFEST_URL.rsplit("/", 1)[0])
-    thirdparty_base = thirdparty.get("base_url", THIRDPARTY_MANIFEST_URL.rsplit("/", 1)[0])
+    thirdparty_base = thirdparty.get(
+        "base_url", THIRDPARTY_MANIFEST_URL.rsplit("/", 1)[0]
+    )
 
     added = 0
     skipped = 0
@@ -327,7 +679,9 @@ def main() -> None:
         if name in covered_fqns:
             skipped += 1
             continue
-        stub = build_stub(module, "Python stdlib", stdlib_base, "# stdlib — no install required")
+        stub = build_stub(
+            module, "Python stdlib", stdlib_base, "# stdlib — no install required"
+        )
         classes[stub["id"]] = stub
         added += 1
 
@@ -336,7 +690,9 @@ def main() -> None:
         if name in covered_fqns:
             skipped += 1
             continue
-        stub = build_stub(module, "Third-party Python package", thirdparty_base, f"pip install {name}")
+        stub = build_stub(
+            module, "Third-party Python package", thirdparty_base, f"pip install {name}"
+        )
         classes[stub["id"]] = stub
         added += 1
 
@@ -346,7 +702,9 @@ def main() -> None:
         cat = centry.get("category", "utilities")
         if cat not in id_by_cat:
             id_by_cat[cat] = []
-            categories.append({"id": cat, "name": cat.title(), "description": "", "class_ids": []})
+            categories.append(
+                {"id": cat, "name": cat.title(), "description": "", "class_ids": []}
+            )
         id_by_cat[cat].append(cid)
 
     for cat in categories:

--- a/python-sdk/scripts/index_python_from_cdn.py
+++ b/python-sdk/scripts/index_python_from_cdn.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+index_python_from_cdn.py — Merge CDN Python registries into sdk-manifest.json.
+
+This script runs AFTER generate_sdk_manifest.py. It reads the website manifest,
+pulls stdlib + third-party module lists from the CDN, and adds a stub entry for
+every module that the handcrafted python_rule_meta.py doesn't already cover.
+
+Goal: complete discoverability. Rule writers and code-quality reviewers should
+be able to search the SDK reference for any module and find at least a
+canonical FQN and category, even if we haven't annotated source/sink roles yet.
+
+Usage:
+    python scripts/index_python_from_cdn.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).parent
+MANIFEST_PATH = SCRIPT_DIR.parent.parent.parent / "cpf-website" / "public" / "sdk-manifest.json"
+
+STDLIB_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/python3.11/stdlib/v1/manifest.json"
+THIRDPARTY_MANIFEST_URL = "https://assets.codepathfinder.dev/registries/thirdparty/v1/manifest.json"
+
+# Category rules applied in order. First match wins.
+# Modules not matching any rule land in "utilities".
+CATEGORY_EXACT: dict[str, str] = {
+    # command-execution
+    "subprocess": "command-execution", "os": "command-execution", "pty": "command-execution",
+    "pexpect": "command-execution", "docker": "command-execution", "ctypes": "command-execution",
+    "cffi": "command-execution", "fcntl": "command-execution", "signal": "command-execution",
+
+    # deserialization
+    "pickle": "deserialization", "pickletools": "deserialization", "marshal": "deserialization",
+    "json": "deserialization", "simplejson": "deserialization", "yaml": "deserialization",
+    "csv": "deserialization", "xml": "deserialization", "lxml": "deserialization",
+    "defusedxml": "deserialization", "xmltodict": "deserialization", "xmlrpc": "deserialization",
+    "shelve": "deserialization", "dbm": "deserialization", "pyasn1": "deserialization",
+    "toml": "deserialization", "tomllib": "deserialization", "plistlib": "deserialization",
+    "ast": "deserialization", "pyexpat": "deserialization",
+
+    # databases
+    "sqlite3": "databases", "psycopg2": "databases", "pymongo": "databases",
+    "redis": "databases", "sqlalchemy": "databases", "pymysql": "databases",
+    "MySQLdb": "databases", "ldap3": "databases", "hdbcli": "databases",
+    "ibm_db": "databases", "playhouse": "databases", "pony": "databases",
+
+    # http-clients
+    "requests": "http-clients", "urllib": "http-clients", "http": "http-clients",
+    "socket": "http-clients", "ftplib": "http-clients", "telnetlib": "http-clients",
+    "smtplib": "http-clients", "smtpd": "http-clients", "httpx": "http-clients",
+    "httplib2": "http-clients", "aiohttp": "http-clients", "pycurl": "http-clients",
+    "imaplib": "http-clients", "poplib": "http-clients", "nntplib": "http-clients",
+    "email": "http-clients", "ipaddress": "http-clients", "netaddr": "http-clients",
+    "netifaces": "http-clients", "boto3": "http-clients", "aws_xray_sdk": "http-clients",
+    "mailbox": "http-clients", "mailcap": "http-clients", "netrc": "http-clients",
+    "webob": "http-clients", "slumber": "http-clients", "pika": "http-clients",
+    "pysocks": "http-clients",
+
+    # file-system
+    "pathlib": "file-system", "tempfile": "file-system", "shutil": "file-system",
+    "logging": "file-system", "aiofiles": "file-system", "glob": "file-system",
+    "fnmatch": "file-system", "re": "file-system", "regex": "file-system",
+    "configparser": "file-system", "dockerfile_parse": "file-system", "mimetypes": "file-system",
+    "fileinput": "file-system",
+
+    # archives
+    "tarfile": "archives", "zipfile": "archives", "zlib": "archives",
+    "gzip": "archives", "bz2": "archives", "lzma": "archives",
+    "zipapp": "archives", "zipimport": "archives", "zstd": "archives",
+
+    # crypto
+    "hashlib": "crypto", "hmac": "crypto", "secrets": "crypto",
+    "random": "crypto", "ssl": "crypto", "jose": "crypto",
+    "authlib": "crypto", "paramiko": "crypto", "getpass": "crypto",
+    "crypt": "crypto", "pysftp": "crypto", "jwt": "crypto",
+    "jwcrypto": "crypto", "jks": "crypto", "oauthlib": "crypto",
+    "requests_oauthlib": "crypto", "auth0": "crypto", "hvac": "crypto",
+    "passpy": "crypto", "tgcrypto": "crypto", "zxcvbn": "crypto",
+    "cryptography": "crypto",
+
+    # templating
+    "jinja2": "templating", "bleach": "templating", "html": "templating",
+    "html5lib": "templating", "string": "templating", "chevron": "templating",
+    "markdown": "templating", "docutils": "templating", "reportlab": "templating",
+    "fpdf": "templating", "webencodings": "templating",
+
+    # web-frameworks
+    "flask": "web-frameworks", "flask_cors": "web-frameworks",
+    "flask_migrate": "web-frameworks", "flask_socketio": "web-frameworks",
+    "django": "web-frameworks", "django_filters": "web-frameworks",
+    "fastapi": "web-frameworks", "starlette": "web-frameworks",
+    "rest_framework": "web-frameworks", "channels": "web-frameworks",
+    "gunicorn": "web-frameworks", "waitress": "web-frameworks",
+    "uwsgi": "web-frameworks", "cgi": "web-frameworks", "cgitb": "web-frameworks",
+    "wsgiref": "web-frameworks", "pydantic": "web-frameworks",
+    "wtforms": "web-frameworks", "jsonschema": "web-frameworks",
+    "celery": "web-frameworks", "grpc": "web-frameworks",
+    "grpc_channelz": "web-frameworks", "grpc_health": "web-frameworks",
+    "grpc_reflection": "web-frameworks", "grpc_status": "web-frameworks",
+    "simple_websocket": "web-frameworks", "gevent": "web-frameworks",
+    "greenlet": "web-frameworks", "fanstatic": "web-frameworks",
+    "werkzeug": "web-frameworks",
+}
+
+CATEGORY_PATTERNS: list[tuple[str, list[str]]] = [
+    ("language", [
+        "abc", "typing", "types", "dataclasses", "enum", "collections", "contextlib", "contextvars",
+        "functools", "itertools", "operator", "numbers", "decimal", "fractions", "statistics",
+        "math", "cmath", "array", "bisect", "heapq", "graphlib", "weakref", "copy", "copyreg",
+        "gc", "errno", "atexit", "warnings", "traceback", "sys", "platform", "sysconfig",
+        "builtins", "importlib", "imp", "runpy", "site", "compileall", "keyword", "symtable",
+        "token", "tokenize", "linecache", "pkgutil", "pyclbr", "pydoc", "pydoc_data",
+        "rlcompleter", "code", "codeop", "dis", "inspect", "opcode", "py_compile", "tabnanny",
+        "encodings", "codecs", "textwrap", "unicodedata", "stringprep", "readline",
+        "modulefinder", "struct", "faulthandler", "resource", "select", "selectors", "termios",
+        "singledispatch", "six", "decorator", "deprecated", "mypy_extensions", "entrypoints",
+        "toposort", "boltons", "cachetools", "objgraph", "retry", "punq",
+        "watchpoints", "usersettings",
+    ]),
+    ("concurrency", [
+        "asyncio", "asynchat", "asyncore", "threading", "multiprocessing", "queue",
+        "sched", "concurrent",
+    ]),
+    ("testing", [
+        "unittest", "doctest", "atheris", "mock", "assertpy", "behave",
+        "editdistance", "pytest_lazy_fixture",
+    ]),
+    ("datetime", [
+        "datetime", "time", "zoneinfo", "locale", "gettext", "calendar",
+        "dateparser_data", "dateutil", "croniter", "pytz", "python_crontab",
+        "lunardate", "convertdate", "ephem", "icalendar", "workalendar",
+        "pymeeus", "pyluach", "tzdata", "vobject", "rfc3339_validator",
+    ]),
+    ("io", [
+        "io", "filecmp", "difflib", "stat", "pipes", "ossaudiodev", "wave",
+        "sunau", "aifc", "audioop", "chunk", "sndhdr", "imghdr", "uu", "quopri",
+        "base64", "binascii", "xdrlib", "mmap", "datauri", "dirhash",
+        "binaryornot", "str2bool", "unidiff", "whatthepatch", "xmldiff",
+        "untangle", "olefile",
+    ]),
+    ("cli", [
+        "argparse", "getopt", "optparse", "cmd", "shlex", "click",
+        "colorama", "colorful", "consolemenu", "keyboard",
+        "pyautogui", "pyperclip", "pynput", "pyscreeze", "send2trash",
+        "tabulate", "tqdm", "pygments", "capturer", "wurlitzer",
+    ]),
+    ("gui", [
+        "tkinter", "curses", "turtle", "turtledemo", "pyi_splash",
+        "ttkthemes", "Xlib", "jack", "pyaudio",
+    ]),
+    ("data-science", [
+        "tensorflow", "networkx", "geopandas", "shapely", "seaborn",
+        "pycocotools", "hnswlib", "resampy", "openpyxl", "et_xmlfile",
+        "xlrd", "pyfarmhash", "qrcode", "qrbill",
+    ]),
+    ("dev-tools", [
+        "distutils", "ensurepip", "venv", "lib2to3", "idlelib", "bdb", "pdb",
+        "trace", "tracemalloc", "timeit", "cProfile", "profile", "pstats",
+        "flake8", "pyflakes", "pep8_naming", "gdb", "pythonwin", "portpicker",
+        "dockerfile_parse", "jenkins", "jmespath", "fire",
+    ]),
+]
+
+
+def fetch_json(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": "codepathfinder-indexer/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def to_pascal_case(name: str) -> str:
+    """abc -> PyAbc; xml.etree -> PyXmlEtree; http.client -> PyHttpClient."""
+    parts = re.split(r"[._-]+", name)
+    return "Py" + "".join(p[:1].upper() + p[1:].lower() if p else "" for p in parts if p)
+
+
+def categorize(module_name: str) -> str:
+    # Try exact first, then prefix matching
+    if module_name in CATEGORY_EXACT:
+        return CATEGORY_EXACT[module_name]
+    head = module_name.split(".", 1)[0]
+    if head in CATEGORY_EXACT:
+        return CATEGORY_EXACT[head]
+    for category, names in CATEGORY_PATTERNS:
+        if module_name in names or head in names:
+            return category
+    return "utilities"
+
+
+def extract_top_methods(detail: dict, limit: int = 10) -> list[dict]:
+    """Pull a handful of public functions/classes from a per-module CDN detail JSON."""
+    methods = []
+
+    # Module-level functions
+    for fn_name, fn in (detail.get("functions") or {}).items():
+        if fn_name.startswith("_"):
+            continue
+        params = fn.get("parameters") or fn.get("params") or []
+        param_strs: list[str] = []
+        for p in params:
+            if isinstance(p, dict):
+                n = p.get("name", "")
+                if n:
+                    param_strs.append(n)
+            elif isinstance(p, str):
+                param_strs.append(p)
+        sig = f"{fn_name}({', '.join(param_strs)})"
+        doc = (fn.get("docstring") or fn.get("description") or "").strip().split("\n")[0][:180] or f"{fn_name} function."
+        methods.append({
+            "name": fn_name,
+            "signature": sig,
+            "description": doc,
+            "role": "neutral",
+            "tracks": [],
+        })
+        if len(methods) >= limit:
+            return methods
+
+    # Classes (flatten to class name only)
+    for cls_name, cls in (detail.get("classes") or {}).items():
+        if cls_name.startswith("_"):
+            continue
+        doc = (cls.get("docstring") or cls.get("description") or "").strip().split("\n")[0][:180] or f"{cls_name} class."
+        methods.append({
+            "name": cls_name,
+            "signature": f"{cls_name}(...)",
+            "description": doc,
+            "role": "neutral",
+            "tracks": [],
+        })
+        if len(methods) >= limit:
+            return methods
+
+    return methods
+
+
+def try_fetch_detail(base_url: str, filename: str) -> dict | None:
+    try:
+        return fetch_json(f"{base_url}/{filename}")
+    except Exception as e:
+        print(f"  [skip] {filename}: {e}", file=sys.stderr)
+        return None
+
+
+def build_stub(module: dict, source: str, base_url: str, install_hint: str) -> dict:
+    name = module["name"]
+    filename = module["file"]
+    detail = try_fetch_detail(base_url, filename) or {}
+    methods = extract_top_methods(detail, limit=10)
+    return {
+        "id": to_pascal_case(name),
+        "name": to_pascal_case(name),
+        "description": (
+            f"{source} module — {name}. Auto-indexed from CDN. "
+            "Method-level security roles have not been annotated; rule writers should inspect the source before use."
+        ),
+        "category": categorize(name),
+        "fqns": [name],
+        "patterns": [],
+        "go_mod": None,
+        "pip_snippet": install_hint,
+        "import_stmt": f"import {name}" if "." not in name else f"from {name.rsplit('.', 1)[0]} import {name.rsplit('.', 1)[1]}",
+        "methods": methods,
+        "example_rule": None,
+        "rules_using": [],
+        "usage_count": 0,
+    }
+
+
+EXTRA_CATEGORIES = [
+    {"id": "language", "name": "Language Features", "description": "Python language primitives: typing, collections, abc, functools"},
+    {"id": "concurrency", "name": "Concurrency", "description": "asyncio, threading, multiprocessing, queue"},
+    {"id": "datetime", "name": "Date & Time", "description": "datetime, time, zoneinfo, dateutil"},
+    {"id": "io", "name": "I/O & Encoding", "description": "io streams, base64, binascii, plistlib"},
+    {"id": "cli", "name": "CLI & Terminal", "description": "argparse, click, colorama, tqdm"},
+    {"id": "gui", "name": "GUI", "description": "tkinter, curses, turtle"},
+    {"id": "testing", "name": "Testing", "description": "unittest, doctest, mock, pytest tooling"},
+    {"id": "dev-tools", "name": "Developer Tools", "description": "distutils, venv, pdb, linters"},
+    {"id": "data-science", "name": "Data Science", "description": "tensorflow, networkx, geopandas, openpyxl"},
+    {"id": "utilities", "name": "Utilities", "description": "Miscellaneous modules without a dedicated category"},
+]
+
+
+def main() -> None:
+    if not MANIFEST_PATH.exists():
+        raise SystemExit(f"Manifest not found at {MANIFEST_PATH}. Run generate_sdk_manifest.py first.")
+
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    py = manifest["languages"].setdefault("python", {})
+    classes: dict[str, Any] = py.setdefault("classes", {})
+    categories = py.setdefault("categories", [])
+
+    # Reverse lookup: module name -> class id (if already handcrafted)
+    covered_fqns: set[str] = set()
+    for cid, centry in classes.items():
+        for fq in centry.get("fqns", []) or []:
+            covered_fqns.add(fq.split(".")[0])
+            covered_fqns.add(fq)
+
+    # Add new categories if missing
+    existing_cat_ids = {c["id"] for c in categories}
+    for extra in EXTRA_CATEGORIES:
+        if extra["id"] not in existing_cat_ids:
+            categories.append({**extra, "class_ids": []})
+
+    # Fetch CDN manifests
+    print("Fetching CDN manifests...")
+    stdlib = fetch_json(STDLIB_MANIFEST_URL)
+    thirdparty = fetch_json(THIRDPARTY_MANIFEST_URL)
+
+    stdlib_base = stdlib.get("base_url", STDLIB_MANIFEST_URL.rsplit("/", 1)[0])
+    thirdparty_base = thirdparty.get("base_url", THIRDPARTY_MANIFEST_URL.rsplit("/", 1)[0])
+
+    added = 0
+    skipped = 0
+
+    for module in stdlib.get("modules", []):
+        name = module["name"]
+        if name in covered_fqns:
+            skipped += 1
+            continue
+        stub = build_stub(module, "Python stdlib", stdlib_base, "# stdlib — no install required")
+        classes[stub["id"]] = stub
+        added += 1
+
+    for module in thirdparty.get("modules", []):
+        name = module["name"]
+        if name in covered_fqns:
+            skipped += 1
+            continue
+        stub = build_stub(module, "Third-party Python package", thirdparty_base, f"pip install {name}")
+        classes[stub["id"]] = stub
+        added += 1
+
+    # Rebuild category class_ids lists
+    id_by_cat: dict[str, list[str]] = {c["id"]: [] for c in categories}
+    for cid, centry in classes.items():
+        cat = centry.get("category", "utilities")
+        if cat not in id_by_cat:
+            id_by_cat[cat] = []
+            categories.append({"id": cat, "name": cat.title(), "description": "", "class_ids": []})
+        id_by_cat[cat].append(cid)
+
+    for cat in categories:
+        cat["class_ids"] = sorted(id_by_cat.get(cat["id"], []))
+
+    py["total_classes"] = len(classes)
+    py["total_methods"] = sum(len(c["methods"]) for c in classes.values())
+
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2))
+    print(f"Added {added} stubs, skipped {skipped} already-covered modules.")
+    print(f"Python total: {py['total_classes']} classes, {py['total_methods']} methods")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the handcrafted SDK metadata and CDN indexers that drive the new `/sdk/` documentation on codepathfinder.dev.

- **`codepathfinder/go_rule_meta.py`** — 72 Go classes, 221 methods (Gin, Echo, Fiber, Chi, Gorilla Mux, GORM, sqlx, pgx, Mongo, Redis, JWT, Viper, YAML, gRPC, Resty + stdlib).
- **`codepathfinder/python_rule_meta.py`** — 100 Python class entries, 302 methods across 9 categories (web frameworks, command exec, databases, deserialization, HTTP clients, filesystem, archives, crypto, templating).
- **`scripts/generate_sdk_manifest.py`** — Reads each `*_rule_meta.py` and emits `sdk-manifest.json` consumed by the website. Chains the two indexers below automatically; `--skip-cdn-index` opts out.
- **`scripts/index_python_from_cdn.py`** — Fills stubs for every Python module in the `assets.codepathfinder.dev` CDN registries that isn't already covered by hand.
- **`scripts/index_go_from_cdn.py`** — Same pattern for Go stdlib and third-party CDN entries.

## Coverage in the published manifest

| Language | Handcrafted | CDN stubs | Total classes | Total methods |
|---|---|---|---|---|
| Go | 72 | 132 | **204** | **1,132** |
| Python | 100 | 329 | **429** | **2,781** |

100% of 167 Go stdlib + 25 Go third-party + 211 Python stdlib + 208 Python third-party modules from the CDN are indexed. Stubs carry `role: neutral` with a clear banner so readers don't mistake auto-indexed metadata for verified security annotations.

## Lint status

Matches the canonical `lintPython` task in `sast-engine/build.gradle`:

- `black --check codepathfinder/go_rule_meta.py codepathfinder/python_rule_meta.py scripts/` — all files left unchanged
- `ruff check codepathfinder/ scripts/` — all checks passed
- `mypy` on the 5 new/modified files — no issues found

Pre-existing formatting drift in `python_ir.py`, `go_rule.py`, and `tests/test_go_thirdparty_querytypes.py` is out of scope and left untouched.

## Test plan

- [x] `cd python-sdk && python3 scripts/generate_sdk_manifest.py` runs end-to-end and regenerates `sdk-manifest.json` without raising (ignored output path requires cpf-website checkout adjacent).
- [x] `cd python-sdk && black --check codepathfinder/go_rule_meta.py codepathfinder/python_rule_meta.py scripts/` passes.
- [x] `cd python-sdk && ruff check codepathfinder/go_rule_meta.py codepathfinder/python_rule_meta.py scripts/` passes.
- [x] `cd python-sdk && mypy codepathfinder/go_rule_meta.py codepathfinder/python_rule_meta.py scripts/generate_sdk_manifest.py scripts/index_go_from_cdn.py scripts/index_python_from_cdn.py` passes.
- [x] Confirm generated Go manifest totals: 204 classes / 1,132 methods.
- [x] Confirm generated Python manifest totals: 429 classes / 2,781 methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)