### PR TITLE
chore: sync server.json docker tag to v2.1.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -35,7 +35,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/shivasurya/code-pathfinder:v2.0.2",
+      "identifier": "docker.io/shivasurya/code-pathfinder:v2.1.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Bump `packages[1].identifier` in `server.json` from `v2.0.2` to `v2.1.0` so the committed manifest matches the published release.
- MCP registry entry `dev.codepathfinder/pathfinder@2.1.0` is already live — this PR just syncs the repo to what's published.

## Test plan
- [x] `mcp-publisher validate` passes
- [x] Registry lookup shows `2.1.0` with docker tag `v2.1.0`
- [x] Docker image `shivasurya/code-pathfinder:v2.1.0` exists on Docker Hub