### PR TITLE
feat(cli): add --exclude flag to skip paths from scan and ci

### DIFF
--- a/sast-engine/cmd/ci.go
+++ b/sast-engine/cmd/ci.go
@@ -70,6 +70,7 @@ Examples:
 		debug, _ := cmd.Flags().GetBool("debug")
 		failOnStr, _ := cmd.Flags().GetString("fail-on")
 		skipTests, _ := cmd.Flags().GetBool("skip-tests")
+		rawExcludes, _ := cmd.Flags().GetStringArray("exclude")
 		baseRef, _ := cmd.Flags().GetString("base")
 		headRef, _ := cmd.Flags().GetString("head")
 		noDiff, _ := cmd.Flags().GetBool("no-diff")
@@ -130,6 +131,11 @@ Examples:
 				"phase":      "initialization",
 			})
 			return fmt.Errorf("--project flag is required")
+		}
+
+		excludes, err := validateExcludePatterns(rawExcludes)
+		if err != nil {
+			return err
 		}
 
 		if outputFormat != "sarif" && outputFormat != "json" && outputFormat != "csv" {
@@ -211,6 +217,7 @@ Examples:
 			OnProgress: func() {
 				logger.UpdateProgress(1)
 			},
+			ExcludePatterns: excludes,
 		})
 		logger.FinishProgress()
 		if len(codeGraph.Nodes) == 0 {
@@ -514,6 +521,7 @@ func init() {
 	ciCmd.Flags().Bool("debug", false, "Show detailed debug diagnostics with file-level progress and timestamps")
 	ciCmd.Flags().String("fail-on", "", "Fail with exit code 1 if findings match severities (e.g., critical,high)")
 	ciCmd.Flags().Bool("skip-tests", true, "Skip test files (test_*.py, *_test.py, conftest.py, etc.)")
+	ciCmd.Flags().StringArray("exclude", nil, "Exclude files or directories from the scan. Repo-relative path prefix; repeatable. e.g. --exclude rules/ --exclude sast-engine/test-fixtures")
 	ciCmd.Flags().String("base", "", "Base git ref for diff-aware scanning (auto-detected in CI)")
 	ciCmd.Flags().String("head", "HEAD", "Head git ref for diff-aware scanning")
 	ciCmd.Flags().Bool("no-diff", false, "Disable diff-aware scanning (scan all files)")

--- a/sast-engine/cmd/ci_test.go
+++ b/sast-engine/cmd/ci_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -447,4 +449,76 @@ func TestCICmdEnableDBCacheOpenError(t *testing.T) {
 	// Should warn about cache failure but continue without error.
 	err := ciCmd.RunE(ciCmd, []string{})
 	require.NoError(t, err)
+}
+
+// setCIExcludeFlag replaces (not appends) the StringArray exclude flag on ciCmd.
+// pflag's StringArray.Set appends after the first call; Replace resets cleanly.
+func setCIExcludeFlag(cmd *cobra.Command, values []string) {
+	flag := cmd.Flags().Lookup("exclude")
+	if sv, ok := flag.Value.(pflag.SliceValue); ok {
+		sv.Replace(values)
+		flag.Changed = len(values) > 0
+	}
+}
+
+// TestCICmdExcludeFlag verifies --exclude flag registration and validation.
+func TestCICmdExcludeFlag(t *testing.T) {
+	t.Run("flag is registered", func(t *testing.T) {
+		flag := ciCmd.Flags().Lookup("exclude")
+		require.NotNil(t, flag, "exclude flag should be registered on ci command")
+	})
+
+	// resetForExclude puts the command in a state where RunE reaches validateExcludePatterns.
+	resetForExclude := func(t *testing.T) {
+		t.Helper()
+		ciCmd.Flags().Set("rules", "/tmp/fake-rules.py")
+		ciCmd.Flags().Set("project", "/tmp/fake-project")
+		ciCmd.Flags().Set("output", "sarif")
+		ciCmd.Flags().Set("output-file", "")
+		ciCmd.Flags().Set("verbose", "false")
+		ciCmd.Flags().Set("debug", "false")
+		ciCmd.Flags().Set("fail-on", "")
+		ciCmd.Flags().Set("skip-tests", "true")
+		ciCmd.Flags().Set("no-diff", "true")
+		ciCmd.Flags().Set("base", "")
+		ciCmd.Flags().Set("head", "HEAD")
+		ciCmd.Flags().Set("ruleset", "")
+		ciCmd.Flags().Set("github-token", "")
+		ciCmd.Flags().Set("github-repo", "")
+		ciCmd.Flags().Set("github-pr", "0")
+		ciCmd.Flags().Set("pr-comment", "false")
+		ciCmd.Flags().Set("pr-inline", "false")
+		ciCmd.Flags().Set("enable-db-cache", "false")
+		setCIExcludeFlag(ciCmd, nil) // clear exclude before each test
+	}
+
+	t.Run("absolute pattern rejected", func(t *testing.T) {
+		resetForExclude(t)
+		setCIExcludeFlag(ciCmd, []string{"/etc/passwd"})
+		defer setCIExcludeFlag(ciCmd, nil)
+
+		err := ciCmd.RunE(ciCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no leading slash")
+	})
+
+	t.Run("traversal pattern rejected", func(t *testing.T) {
+		resetForExclude(t)
+		setCIExcludeFlag(ciCmd, []string{"../outside"})
+		defer setCIExcludeFlag(ciCmd, nil)
+
+		err := ciCmd.RunE(ciCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "..")
+	})
+
+	t.Run("backslash pattern rejected", func(t *testing.T) {
+		resetForExclude(t)
+		setCIExcludeFlag(ciCmd, []string{"foo\\bar"})
+		defer setCIExcludeFlag(ciCmd, nil)
+
+		err := ciCmd.RunE(ciCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backslash")
+	})
 }

--- a/sast-engine/cmd/exclude.go
+++ b/sast-engine/cmd/exclude.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// validateExcludePatterns normalizes and validates a list of repo-relative path prefixes.
+// It returns the cleaned slice on success, or an error listing the offending pattern.
+//
+// A pattern is rejected if it:
+//   - is absolute (starts with "/")
+//   - contains ".." as a path component
+//   - contains a null byte
+//   - contains a backslash (only forward slashes are allowed)
+//   - exceeds 512 characters
+//
+// Valid patterns are normalized: leading slashes stripped, trailing slashes stripped.
+func validateExcludePatterns(patterns []string) ([]string, error) {
+	cleaned := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		if len(p) > 512 {
+			return nil, fmt.Errorf("--exclude pattern too long (>512 chars): %q", p)
+		}
+		if strings.HasPrefix(p, "/") {
+			return nil, fmt.Errorf("--exclude pattern must be repo-relative (no leading slash): %q", p)
+		}
+		if strings.Contains(p, "\\") {
+			return nil, fmt.Errorf("--exclude pattern must use forward slashes, not backslashes: %q", p)
+		}
+		if strings.ContainsRune(p, 0) {
+			return nil, fmt.Errorf("--exclude pattern contains null byte: %q", p)
+		}
+		// Check every path component for ".."
+		norm := filepath.ToSlash(strings.Trim(p, "/"))
+		for _, seg := range strings.Split(norm, "/") {
+			if seg == ".." {
+				return nil, fmt.Errorf("--exclude pattern must not contain '..': %q", p)
+			}
+		}
+		cleaned = append(cleaned, norm)
+	}
+	return cleaned, nil
+}
+
+// isExcluded reports whether relPath (forward-slash, repo-relative) is covered by
+// any of the given patterns. A file is covered when its path starts with
+// "<pattern>/", ensuring "rules" matches "rules/foo.py" but not "rulesx/foo.py".
+// An exact match (relPath == pattern) is also considered covered.
+func isExcluded(relPath string, patterns []string) bool {
+	rel := filepath.ToSlash(relPath)
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		// Exact match or prefix match with a separator boundary.
+		if rel == p || strings.HasPrefix(rel, p+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/sast-engine/cmd/exclude.go
+++ b/sast-engine/cmd/exclude.go
@@ -16,9 +16,12 @@ import (
 //   - contains a backslash (only forward slashes are allowed)
 //   - exceeds 512 characters
 //
-// Valid patterns are normalized: leading slashes stripped, trailing slashes stripped.
+// Valid patterns are normalized: leading slashes stripped, trailing slashes
+// stripped. Exact duplicates (after normalization) are dropped silently so the
+// caller can repeat --exclude flags without bloating the per-file check loop.
 func validateExcludePatterns(patterns []string) ([]string, error) {
 	cleaned := make([]string, 0, len(patterns))
+	seen := make(map[string]struct{}, len(patterns))
 	for _, p := range patterns {
 		if len(p) > 512 {
 			return nil, fmt.Errorf("--exclude pattern too long (>512 chars): %q", p)
@@ -39,6 +42,10 @@ func validateExcludePatterns(patterns []string) ([]string, error) {
 				return nil, fmt.Errorf("--exclude pattern must not contain '..': %q", p)
 			}
 		}
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
 		cleaned = append(cleaned, norm)
 	}
 	return cleaned, nil

--- a/sast-engine/cmd/exclude_test.go
+++ b/sast-engine/cmd/exclude_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- validateExcludePatterns ---
+
+func TestValidateExcludePatterns_EmptyList(t *testing.T) {
+	got, err := validateExcludePatterns(nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	got, err = validateExcludePatterns([]string{})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestValidateExcludePatterns_SingleValid(t *testing.T) {
+	got, err := validateExcludePatterns([]string{"rules/"})
+	require.NoError(t, err)
+	// Trailing slash must be stripped.
+	assert.Equal(t, []string{"rules"}, got)
+}
+
+func TestValidateExcludePatterns_MultipleValid(t *testing.T) {
+	got, err := validateExcludePatterns([]string{"rules/", "sast-engine/test-fixtures"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rules", "sast-engine/test-fixtures"}, got)
+}
+
+func TestValidateExcludePatterns_TrailingSlashStripped(t *testing.T) {
+	got, err := validateExcludePatterns([]string{"foo/bar/"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"foo/bar"}, got)
+}
+
+func TestValidateExcludePatterns_AbsoluteRejected(t *testing.T) {
+	_, err := validateExcludePatterns([]string{"/etc/passwd"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no leading slash")
+}
+
+func TestValidateExcludePatterns_TraversalRejected(t *testing.T) {
+	cases := []string{
+		"../secret",
+		"foo/../bar",
+		"foo/..",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			_, err := validateExcludePatterns([]string{p})
+			require.Error(t, err, "pattern %q should be rejected", p)
+			assert.Contains(t, err.Error(), "..")
+		})
+	}
+}
+
+func TestValidateExcludePatterns_BackslashRejected(t *testing.T) {
+	_, err := validateExcludePatterns([]string{"foo\\bar"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backslash")
+}
+
+func TestValidateExcludePatterns_NullByteRejected(t *testing.T) {
+	_, err := validateExcludePatterns([]string{"foo\x00bar"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "null byte")
+}
+
+func TestValidateExcludePatterns_TooLongRejected(t *testing.T) {
+	long := strings.Repeat("a", 513)
+	_, err := validateExcludePatterns([]string{long})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too long")
+}
+
+func TestValidateExcludePatterns_ExactlyMaxLengthAllowed(t *testing.T) {
+	maxLen := strings.Repeat("a", 512)
+	got, err := validateExcludePatterns([]string{maxLen})
+	require.NoError(t, err)
+	assert.Equal(t, []string{maxLen}, got)
+}
+
+func TestValidateExcludePatterns_UnicodeAllowed(t *testing.T) {
+	got, err := validateExcludePatterns([]string{"src/testi18n/世界"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"src/testi18n/世界"}, got)
+}
+
+// --- isExcluded ---
+
+func TestIsExcluded_EmptyPatterns(t *testing.T) {
+	assert.False(t, isExcluded("rules/foo.py", nil))
+	assert.False(t, isExcluded("rules/foo.py", []string{}))
+}
+
+func TestIsExcluded_SinglePrefixMatch(t *testing.T) {
+	assert.True(t, isExcluded("rules/foo.py", []string{"rules"}))
+}
+
+func TestIsExcluded_SinglePrefixNoMatch(t *testing.T) {
+	// "rules" must NOT match "rulesx/foo.py" (no separator boundary).
+	assert.False(t, isExcluded("rulesx/foo.py", []string{"rules"}))
+}
+
+func TestIsExcluded_ExactDirMatch(t *testing.T) {
+	// Exact match of the directory name itself is excluded.
+	assert.True(t, isExcluded("rules", []string{"rules"}))
+}
+
+func TestIsExcluded_NestedPrefix(t *testing.T) {
+	assert.True(t, isExcluded("sast-engine/test-fixtures/java/Main.java", []string{"sast-engine/test-fixtures"}))
+}
+
+func TestIsExcluded_MultiplePatterns(t *testing.T) {
+	patterns := []string{"rules", "sast-engine/test-fixtures"}
+	assert.True(t, isExcluded("rules/owasp.py", patterns))
+	assert.True(t, isExcluded("sast-engine/test-fixtures/x.java", patterns))
+	assert.False(t, isExcluded("sast-engine/cmd/scan.go", patterns))
+}
+
+func TestIsExcluded_EmptyPattern(t *testing.T) {
+	// An empty string in the pattern list must be a no-op, not a wildcard.
+	assert.False(t, isExcluded("anything.py", []string{""}))
+}
+
+func TestIsExcluded_CaseSensitive(t *testing.T) {
+	// Patterns are case-sensitive on Linux; verify no lowercasing occurs.
+	assert.False(t, isExcluded("Rules/foo.py", []string{"rules"}))
+	assert.True(t, isExcluded("Rules/foo.py", []string{"Rules"}))
+}
+
+func TestIsExcluded_WindowsPathNormalized(t *testing.T) {
+	// Even if relPath uses OS separator, forward-slash comparison must work.
+	// filepath.ToSlash is applied inside isExcluded.
+	assert.True(t, isExcluded("rules/foo.py", []string{"rules"}))
+}

--- a/sast-engine/cmd/exclude_test.go
+++ b/sast-engine/cmd/exclude_test.go
@@ -92,6 +92,26 @@ func TestValidateExcludePatterns_UnicodeAllowed(t *testing.T) {
 	assert.Equal(t, []string{"src/testi18n/世界"}, got)
 }
 
+func TestValidateExcludePatterns_ExactDuplicatesDropped(t *testing.T) {
+	got, err := validateExcludePatterns([]string{"rules", "vendor", "rules"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rules", "vendor"}, got)
+}
+
+func TestValidateExcludePatterns_DuplicatesAfterNormalization(t *testing.T) {
+	// "rules/" and "rules" both normalize to "rules"; only one survives.
+	// "/vendor/" and "vendor" both normalize to "vendor".
+	got, err := validateExcludePatterns([]string{"rules/", "rules", "vendor", "vendor/"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rules", "vendor"}, got)
+}
+
+func TestValidateExcludePatterns_DedupPreservesFirstOccurrenceOrder(t *testing.T) {
+	got, err := validateExcludePatterns([]string{"c", "a", "b", "a", "c"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c", "a", "b"}, got)
+}
+
 // --- isExcluded ---
 
 func TestIsExcluded_EmptyPatterns(t *testing.T) {

--- a/sast-engine/cmd/scan.go
+++ b/sast-engine/cmd/scan.go
@@ -68,6 +68,7 @@ Examples:
 		outputFormat, _ := cmd.Flags().GetString("output")
 		outputFile, _ := cmd.Flags().GetString("output-file")
 		skipTests, _ := cmd.Flags().GetBool("skip-tests")
+		rawExcludes, _ := cmd.Flags().GetStringArray("exclude")
 		diffAware, _ := cmd.Flags().GetBool("diff-aware")
 		baseRef, _ := cmd.Flags().GetString("base")
 		headRef, _ := cmd.Flags().GetString("head")
@@ -96,6 +97,11 @@ Examples:
 				"phase":      "initialization",
 			})
 			return fmt.Errorf("--project flag is required")
+		}
+
+		excludes, err := validateExcludePatterns(rawExcludes)
+		if err != nil {
+			return err
 		}
 
 		// Setup logger with appropriate verbosity
@@ -183,6 +189,7 @@ Examples:
 			OnProgress: func() {
 				logger.UpdateProgress(1)
 			},
+			ExcludePatterns: excludes,
 		})
 		logger.FinishProgress()
 		if len(codeGraph.Nodes) == 0 {
@@ -1132,6 +1139,7 @@ func init() {
 	scanCmd.Flags().Bool("debug", false, "Show detailed debug diagnostics with file-level progress and timestamps")
 	scanCmd.Flags().String("fail-on", "", "Fail with exit code 1 if findings match severities (e.g., critical,high)")
 	scanCmd.Flags().Bool("skip-tests", true, "Skip test files (test_*.py, *_test.py, conftest.py, etc.)")
+	scanCmd.Flags().StringArray("exclude", nil, "Exclude files or directories from the scan. Repo-relative path prefix; repeatable. e.g. --exclude rules/ --exclude sast-engine/test-fixtures")
 	scanCmd.Flags().Bool("diff-aware", false, "Enable diff-aware scanning (only report findings in changed files)")
 	scanCmd.Flags().String("base", "", "Base git ref for diff-aware scanning (required with --diff-aware)")
 	scanCmd.Flags().String("head", "HEAD", "Head git ref for diff-aware scanning")

--- a/sast-engine/cmd/scan_test.go
+++ b/sast-engine/cmd/scan_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/shivasurya/code-pathfinder/sast-engine/graph/callgraph/core"
 	"github.com/shivasurya/code-pathfinder/sast-engine/output"
 	"github.com/shivasurya/code-pathfinder/sast-engine/ruleset"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -936,4 +938,73 @@ func TestScanCmdEnableDBCacheOpenError(t *testing.T) {
 		assert.Contains(t, err.Error(), "rule",
 			"unexpected error: %v", err)
 	}
+}
+
+// setExcludeFlag replaces (not appends) the StringArray exclude flag with the
+// given values, working around pflag's append-after-first-Set behaviour by
+// using the SliceValue.Replace interface.
+func setExcludeFlag(cmd *cobra.Command, values []string) {
+	flag := cmd.Flags().Lookup("exclude")
+	if sv, ok := flag.Value.(pflag.SliceValue); ok {
+		sv.Replace(values)
+		flag.Changed = len(values) > 0
+	}
+}
+
+// TestScanCmdExcludeFlag verifies --exclude flag registration and validation.
+func TestScanCmdExcludeFlag(t *testing.T) {
+	t.Run("flag is registered", func(t *testing.T) {
+		flag := scanCmd.Flags().Lookup("exclude")
+		require.NotNil(t, flag, "exclude flag should be registered on scan command")
+	})
+
+	// resetForExclude puts the command in a known good state so RunE reaches
+	// validateExcludePatterns before hitting any other early-exit error.
+	resetForExclude := func(t *testing.T) {
+		t.Helper()
+		scanCmd.Flags().Set("rules", "/tmp/fake-rules.py")
+		scanCmd.Flags().Set("project", "/tmp/fake-project")
+		scanCmd.Flags().Set("output", "text")
+		scanCmd.Flags().Set("output-file", "")
+		scanCmd.Flags().Set("verbose", "false")
+		scanCmd.Flags().Set("debug", "false")
+		scanCmd.Flags().Set("fail-on", "")
+		scanCmd.Flags().Set("skip-tests", "true")
+		scanCmd.Flags().Set("diff-aware", "false")
+		scanCmd.Flags().Set("base", "")
+		scanCmd.Flags().Set("head", "HEAD")
+		scanCmd.Flags().Set("ruleset", "")
+		scanCmd.Flags().Set("enable-db-cache", "false")
+		setExcludeFlag(scanCmd, nil) // clear exclude before each test
+	}
+
+	t.Run("absolute pattern rejected", func(t *testing.T) {
+		resetForExclude(t)
+		setExcludeFlag(scanCmd, []string{"/etc/passwd"})
+		defer setExcludeFlag(scanCmd, nil)
+
+		err := scanCmd.RunE(scanCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no leading slash")
+	})
+
+	t.Run("traversal pattern rejected", func(t *testing.T) {
+		resetForExclude(t)
+		setExcludeFlag(scanCmd, []string{"../outside"})
+		defer setExcludeFlag(scanCmd, nil)
+
+		err := scanCmd.RunE(scanCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "..")
+	})
+
+	t.Run("backslash pattern rejected", func(t *testing.T) {
+		resetForExclude(t)
+		setExcludeFlag(scanCmd, []string{"foo\\bar"})
+		defer setExcludeFlag(scanCmd, nil)
+
+		err := scanCmd.RunE(scanCmd, []string{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backslash")
+	})
 }

--- a/sast-engine/graph/graph_test.go
+++ b/sast-engine/graph/graph_test.go
@@ -226,7 +226,7 @@ func TestGetFiles(t *testing.T) {
 	}
 
 	// Run getFiles
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -258,7 +258,7 @@ func TestGetFilesEmptyDirectory(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestGetFilesEmptyDirectory(t *testing.T) {
 
 func TestGetFilesNonExistentDirectory(t *testing.T) {
 	nonExistentDir := "/path/to/non/existent/directory"
-	_, err := getFiles(nonExistentDir)
+	_, err := getFiles(nonExistentDir, nil)
 	if err == nil {
 		t.Error("Expected an error for non-existent directory, but got nil")
 	}
@@ -297,7 +297,7 @@ func TestGetFilesWithSymlinks(t *testing.T) {
 		t.Fatalf("Failed to create symlink: %v", err)
 	}
 
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -992,7 +992,7 @@ func TestGetFilesMixedLanguages(t *testing.T) {
 	}
 
 	// Run getFiles
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -1412,7 +1412,7 @@ func TestGetFilesIncludesGo(t *testing.T) {
 		}
 	}
 
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -1468,7 +1468,7 @@ func TestGetFilesSkipsVendor(t *testing.T) {
 		t.Fatalf("Failed to create vendor file: %v", err)
 	}
 
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -1499,7 +1499,7 @@ func TestGetFilesSkipsTestdata(t *testing.T) {
 		t.Fatalf("Failed to create testdata file: %v", err)
 	}
 
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}
@@ -1530,7 +1530,7 @@ func TestGetFilesSkipsUnderscoreDirs(t *testing.T) {
 		t.Fatalf("Failed to create underscore dir file: %v", err)
 	}
 
-	files, err := getFiles(tempDir)
+	files, err := getFiles(tempDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles returned an error: %v", err)
 	}

--- a/sast-engine/graph/initialize.go
+++ b/sast-engine/graph/initialize.go
@@ -22,6 +22,10 @@ type ProgressCallbacks struct {
 	OnStart func(totalFiles int)
 	// OnProgress is called after each file is processed (successfully or with error).
 	OnProgress func()
+	// ExcludePatterns holds validated, normalized repo-relative path prefixes.
+	// A file is skipped during the walk if its repo-relative path starts with any prefix.
+	// Use validateExcludePatterns in the cmd package to produce this slice.
+	ExcludePatterns []string
 }
 
 // Initialize initializes the code graph by parsing all source files in a directory.
@@ -30,7 +34,11 @@ func Initialize(directory string, callbacks *ProgressCallbacks) *CodeGraph {
 	codeGraph := NewCodeGraph()
 	start := time.Now()
 
-	files, err := getFiles(directory)
+	var excludePatterns []string
+	if callbacks != nil {
+		excludePatterns = callbacks.ExcludePatterns
+	}
+	files, err := getFiles(directory, excludePatterns)
 	if err != nil {
 		//nolint:all
 		Log("Directory not found:", err)

--- a/sast-engine/graph/utils.go
+++ b/sast-engine/graph/utils.go
@@ -254,13 +254,32 @@ func extractMethodName(node *sitter.Node, sourceCode []byte, filepath string) (s
 
 // getFiles walks through a directory and returns all source files (Java, Python, Go, C/C++, Dockerfile, docker-compose).
 // It skips vendor/, testdata/, node_modules/, .git/, common C/C++ build artifact directories,
-// and directories starting with "_".
-func getFiles(directory string) ([]string, error) {
+// directories starting with "_", and any path covered by excludePatterns.
+//
+// excludePatterns is a list of normalized, repo-relative path prefixes (no leading or trailing slash).
+// A path is skipped when its repo-relative form starts with "<prefix>/", or equals the prefix exactly.
+func getFiles(directory string, excludePatterns []string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
+
+		// Compute repo-relative path once so both directory and file checks can use it.
+		relPath, relErr := filepath.Rel(directory, path)
+		if relErr != nil {
+			relPath = path
+		}
+		relSlash := filepath.ToSlash(relPath)
+
+		// Apply user-specified exclude patterns before any other check.
+		if len(excludePatterns) > 0 && isExcludedPath(relSlash, excludePatterns) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		// Skip directories that should never be scanned
 		if info.IsDir() {
 			name := info.Name()
@@ -298,6 +317,22 @@ func getFiles(directory string) ([]string, error) {
 		return nil
 	})
 	return files, err
+}
+
+// isExcludedPath reports whether relPath (forward-slash, repo-relative) is covered
+// by any of the given prefix patterns. A match requires that relPath equals the
+// pattern exactly, or that relPath begins with "<pattern>/", so that "rules" covers
+// "rules/foo.py" but not "rulesx/foo.py".
+func isExcludedPath(relPath string, patterns []string) bool {
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		if relPath == p || strings.HasPrefix(relPath, p+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // readFile reads the contents of a file.

--- a/sast-engine/graph/utils.go
+++ b/sast-engine/graph/utils.go
@@ -265,11 +265,10 @@ func getFiles(directory string, excludePatterns []string) ([]string, error) {
 			return err
 		}
 
-		// Compute repo-relative path once so both directory and file checks can use it.
-		relPath, relErr := filepath.Rel(directory, path)
-		if relErr != nil {
-			relPath = path
-		}
+		// Compute repo-relative path once so both directory and file checks can
+		// use it. filepath.Walk guarantees `path` is rooted at `directory`, so
+		// filepath.Rel cannot fail here in practice; we ignore its error.
+		relPath, _ := filepath.Rel(directory, path)
 		relSlash := filepath.ToSlash(relPath)
 
 		// Apply user-specified exclude patterns before any other check.

--- a/sast-engine/graph/utils_test.go
+++ b/sast-engine/graph/utils_test.go
@@ -791,6 +791,47 @@ func TestGetFilesWithExcludePatterns(t *testing.T) {
 	}
 }
 
+// TestGetFilesExcludeIndividualFile exercises the file-level (non-directory)
+// exclude branch in getFiles: the excluded pattern targets a single file, not
+// a directory subtree.
+func TestGetFilesExcludeIndividualFile(t *testing.T) {
+	dir, err := os.MkdirTemp("", "getfiles_exclude_file")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	layout := []string{
+		"src/keep.py",
+		"src/skip_me.py",
+	}
+	for _, f := range layout {
+		full := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte("# stub\n"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	got, err := getFiles(dir, []string{"src/skip_me.py"})
+	if err != nil {
+		t.Fatalf("getFiles: %v", err)
+	}
+	gotSet := make(map[string]bool, len(got))
+	for _, p := range got {
+		rel, _ := filepath.Rel(dir, p)
+		gotSet[filepath.ToSlash(rel)] = true
+	}
+	if gotSet["src/skip_me.py"] {
+		t.Error("src/skip_me.py should have been excluded but was returned")
+	}
+	if !gotSet["src/keep.py"] {
+		t.Error("src/keep.py should be included")
+	}
+}
+
 func BenchmarkGenerateMethodID(b *testing.B) {
 	params := []string{"int", "String", "Object"}
 	for i := 0; i < b.N; i++ {

--- a/sast-engine/graph/utils_test.go
+++ b/sast-engine/graph/utils_test.go
@@ -233,7 +233,7 @@ func TestGetFilesComprehensive(t *testing.T) {
 	}
 
 	// Test getFiles
-	files, err := getFiles(tmpDir)
+	files, err := getFiles(tmpDir, nil)
 	if err != nil {
 		t.Fatalf("getFiles failed: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestGetFilesIncludesCAndCpp(t *testing.T) {
 		}
 	}
 
-	got, err := getFiles(dir)
+	got, err := getFiles(dir, nil)
 	if err != nil {
 		t.Fatalf("getFiles: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestGetFilesErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			files, err := getFiles(tt.directory)
+			files, err := getFiles(tt.directory, nil)
 
 			if tt.wantError && err == nil {
 				t.Error("Expected error but got none")
@@ -713,6 +713,81 @@ func TestIsGitHubActionsComprehensive(t *testing.T) {
 				t.Errorf("Expected %v, got %v (env=%q)", tt.expected, result, tt.envValue)
 			}
 		})
+	}
+}
+
+// TestIsExcludedPath covers the graph-internal prefix-match helper.
+func TestIsExcludedPath(t *testing.T) {
+	cases := []struct {
+		rel      string
+		patterns []string
+		want     bool
+	}{
+		{"rules/foo.py", []string{"rules"}, true},
+		{"rulesx/foo.py", []string{"rules"}, false},        // no separator boundary
+		{"rules", []string{"rules"}, true},                 // exact match
+		{"sast-engine/cmd/scan.go", []string{"rules"}, false},
+		{"a/b/c.py", []string{"a/b"}, true},
+		{"a/b/c.py", []string{"a"}, true},
+		{"a/b/c.py", []string{"x"}, false},
+		{"any.py", []string{""}, false},                    // empty pattern is no-op
+		{"any.py", nil, false},
+	}
+	for _, c := range cases {
+		got := isExcludedPath(c.rel, c.patterns)
+		if got != c.want {
+			t.Errorf("isExcludedPath(%q, %v) = %v, want %v", c.rel, c.patterns, got, c.want)
+		}
+	}
+}
+
+// TestGetFilesWithExcludePatterns verifies that getFiles skips files whose
+// repo-relative path starts with an excluded prefix.
+func TestGetFilesWithExcludePatterns(t *testing.T) {
+	dir, err := os.MkdirTemp("", "getfiles_exclude")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Create a small project layout:
+	//   src/main.py      (include)
+	//   rules/rule.py    (exclude via "rules")
+	//   rulesx/other.py  (include, must NOT be caught by "rules" prefix)
+	layout := []string{
+		"src/main.py",
+		"rules/rule.py",
+		"rulesx/other.py",
+	}
+	for _, f := range layout {
+		full := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte("# stub\n"), 0644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	got, err := getFiles(dir, []string{"rules"})
+	if err != nil {
+		t.Fatalf("getFiles: %v", err)
+	}
+
+	gotSet := make(map[string]bool, len(got))
+	for _, p := range got {
+		rel, _ := filepath.Rel(dir, p)
+		gotSet[filepath.ToSlash(rel)] = true
+	}
+
+	if gotSet["rules/rule.py"] {
+		t.Error("rules/rule.py should have been excluded but was returned")
+	}
+	if !gotSet["src/main.py"] {
+		t.Error("src/main.py should be included but was missing")
+	}
+	if !gotSet["rulesx/other.py"] {
+		t.Error("rulesx/other.py should be included (prefix 'rules' must not match 'rulesx')")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `--exclude` (repeatable `StringArray`) flag to both `pathfinder scan` and `pathfinder ci`. Each value is a repo-relative path prefix; files whose path starts with any prefix are skipped at the file-walk layer, so they are never parsed or counted.
- Introduces `sast-engine/cmd/exclude.go` with `validateExcludePatterns` (normalize + reject dangerous inputs) and `isExcluded` (prefix-boundary match with `rules` matching `rules/foo` but not `rulesx/foo`).
- Threads `ExcludePatterns` through `graph.ProgressCallbacks` into `graph.Initialize`/`getFiles`, so exclusion happens before any I/O or AST work begins.

## Test plan

- [x] 36 new tests in `exclude_test.go`, `scan_test.go`, `ci_test.go`, `utils_test.go` covering: empty list, single prefix, multiple, nested prefix, exact dir match, boundary semantics (`rules` vs `rulesx`), trailing slash normalization, case sensitivity, unicode.
- [x] Security validation: absolute paths, `..` traversal, backslashes, null bytes, length > 512 all return a clear error.
- [x] `go test ./... -count=1` passes on all 30 packages (2113 tests total).
- [x] `go vet ./...` clean.
- [x] `golangci-lint run ./...` clean (v2.9.0).

## Security notes

Validation rules applied by `validateExcludePatterns` before any filesystem access:

| Rule | Rationale |
|---|---|
| No leading `/` | Absolute paths could reference files outside the project root |
| No `..` path component | Prevents traversal to parent directories |
| No backslash | Rejects Windows-style paths that would silently misbehave on Linux |
| No null byte | Null bytes terminate C strings and bypass naive checks |
| Length <= 512 | Guards against pathological inputs |

Go does not shell-expand these patterns (no `glob`, no `os/exec`), but inputs are rejected anyway to enforce a clean repo-relative contract and prevent confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)