### PR TITLE
chore(deps): scope Dependabot to real manifests, ignore vulnerable test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,154 @@
+# Dependabot version-update configuration.
+#
+# Why this file exists:
+# Without an explicit allowlist, Dependabot's auto-discovery walks every
+# manifest in the repo, including the 70+ go.mod files we keep under
+# rules/**/tests/ and sast-engine/test-fixtures/. Those are intentionally
+# vulnerable fixtures used to self-test pathfinder's rules; the deps they
+# pin are deliberately old (e.g. dgrijalva/jwt-go@v3.2.0 for GO-JWT-002,
+# vulnerable gorm releases for GO-GORM-SQLI-*). Letting Dependabot file
+# version-update PRs against them would break the very thing they exist
+# to test.
+#
+# This config explicitly enumerates the SEVEN real manifest locations.
+# Anything not listed here is left untouched. Test-fixture go.mods stay
+# at their pinned vulnerable versions.
+#
+# Note: this file controls version-update PRs only. Dependabot ALERTS
+# (the Security tab) are built off the dependency graph and have no
+# repo-file mechanism to exclude paths. For those, use
+# Settings -> Security -> Dependabot -> Auto-triage rules in the GitHub
+# UI to auto-dismiss alerts whose manifest path matches
+# rules/** or sast-engine/test-fixtures/** with reason
+# "tolerable_risk" or "not_used".
+
+version: 2
+
+updates:
+  # --- Go ---
+
+  - package-ecosystem: "gomod"
+    directory: "/sast-engine"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gomod"
+    directory: "/sast-engine/tools/validate_go_resolution"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # --- Java (Gradle) ---
+
+  - package-ecosystem: "gradle"
+    directory: "/sast-engine"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # --- Python ---
+
+  - package-ecosystem: "pip"
+    directory: "/python-sdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/sast-engine/tools/typeshed-converter"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # --- npm (VS Code extension monorepo) ---
+
+  - package-ecosystem: "npm"
+    directory: "/extension/secureflow"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/extension/secureflow/packages/secureflow-cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # --- GitHub Actions ---
+  # Tracks SHA-pinned action references across .github/workflows/*.yml.
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github_actions"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      gh-actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Dependabot's auto-discovery walks every manifest in the repo. Without an explicit allowlist it picks up:

- ~70 `go.mod` files under `rules/**/tests/{positive,negative,}` (per-rule self-test modules)
- ~5 `go.mod` files under `sast-engine/test-fixtures/golang/`

These pin **deliberately vulnerable** dependency versions used to self-test pathfinder's rules (`dgrijalva/jwt-go@v3.2.0` for `GO-JWT-002`, vulnerable `gorm` releases for `GO-GORM-SQLI-*`, etc.). Letting Dependabot file version-update PRs against them would break the very rules they exist to test.

This adds `.github/dependabot.yml` that explicitly lists the seven real manifest locations. Everything not listed is left untouched.

## What gets tracked

| Ecosystem | Path | Why |
| --- | --- | --- |
| gomod | `/sast-engine` | The actual SAST engine |
| gomod | `/sast-engine/tools/validate_go_resolution` | Real internal tool |
| gradle | `/sast-engine` | Java build deps |
| pip | `/python-sdk` | Public Python SDK |
| pip | `/sast-engine/tools/typeshed-converter` | Real internal tool |
| npm | `/extension/secureflow` | VS Code extension root |
| npm | `/extension/secureflow/packages/secureflow-cli` | CLI subpackage |
| github-actions | `/` | All 15 workflow files |

Minor/patch updates are grouped into one weekly PR per ecosystem to reduce noise; major updates remain individual for review. `chore(deps)` prefix matches the repo's commit convention.

## Scope this does NOT cover

**Dependabot alerts (Security tab) are not controlled by this file.** Alerts come from the auto-built dependency graph, and there is no repo-file mechanism to path-exclude. To stop alert noise from the fixture manifests:

1. Go to **Settings → Security → Dependabot → Auto-triage rules**.
2. Add a rule with: paths matching `rules/**` or `sast-engine/test-fixtures/**`, action = "Auto-dismiss alert", reason = `tolerable_risk` (or `not_used`).

The header comment in `dependabot.yml` documents this.

A second follow-up is the **self-scan workflow** (`code-pathfinder-scan.yml`), which runs pathfinder on this repo: it doesn't pass `--exclude rules --exclude sast-engine/test-fixtures` yet. That needs an `exclude` input added to `action.yml` first, which is a separate PR.

## Test plan

- [x] YAML syntax valid (parses cleanly).
- [x] Every listed `directory:` resolves to a real manifest file in this repo.
- [x] No listed path overlaps with `rules/` or `sast-engine/test-fixtures/`.
- [ ] Once merged: confirm via [the Dependabot tab](https://github.com/shivasurya/code-pathfinder/network/updates) that only the 8 listed update configs appear (no auto-discovered entries from fixture manifests).