### PR TITLE
feat(engine): persisted FQN index schema foundation (PR-01)

### DIFF
--- a/sast-engine/cmd/scan.go
+++ b/sast-engine/cmd/scan.go
@@ -281,11 +281,19 @@ Examples:
 				enableDBCache, _ := cmd.Flags().GetBool("enable-db-cache")
 				var analysisCache *builder.AnalysisCache
 				if enableDBCache {
+					indexPath, _ := cmd.Flags().GetString("index-path")
+					rebuildIndex, _ := cmd.Flags().GetBool("rebuild-index")
 					var cacheErr error
-					analysisCache, cacheErr = builder.OpenAnalysisCache(projectPath)
+					analysisCache, cacheErr = builder.OpenAnalysisCacheWithOptions(builder.CacheOptions{
+						ProjectRoot:   projectPath,
+						IndexPath:     indexPath,
+						EngineVersion: Version,
+						ForceRebuild:  rebuildIndex,
+					})
 					if cacheErr != nil {
-						logger.Warning("Could not open analysis cache: %v — running full analysis", cacheErr)
+						logger.Warning("Could not open analysis cache: %v. Running full analysis instead.", cacheErr)
 					} else {
+						logger.Debug("Analysis index: %s", analysisCache.DBPath())
 						defer analysisCache.Close()
 					}
 				}
@@ -1180,5 +1188,7 @@ func init() {
 	scanCmd.Flags().String("base", "", "Base git ref for diff-aware scanning (required with --diff-aware)")
 	scanCmd.Flags().String("head", "HEAD", "Head git ref for diff-aware scanning")
 	scanCmd.Flags().Bool("enable-db-cache", false, "Enable SQLite-backed incremental analysis cache (experimental)")
+	scanCmd.Flags().String("index-path", "", "Override the analysis index location (default $HOME/.codepathfinder/<project-hash>.sqlite; also reads CODEPATHFINDER_INDEX_PATH)")
+	scanCmd.Flags().Bool("rebuild-index", false, "Drop and rebuild the analysis index before scanning")
 	scanCmd.MarkFlagRequired("project")
 }

--- a/sast-engine/graph/callgraph/builder/analysis_cache.go
+++ b/sast-engine/graph/callgraph/builder/analysis_cache.go
@@ -6,10 +6,10 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -30,10 +30,23 @@ import (
 // At worst, an affected table is wiped and rebuilt from a single full analysis
 // run; unaffected tables stay warm.
 const (
-	fileCacheVersion    = "1"
+	fileCacheVersion     = "1"
 	functionIndexVersion = "1"
-	pass4Version        = "1"
+	pass4Version         = "1"
+	fqnIndexVersion      = "1"
+	callSitesVersion     = "1"
 )
+
+// currentSchemaVersion is the global on-disk schema version. It is written into
+// every fqn_index / call_sites row and stamped in meta at open time.
+//
+// Bump it when a change makes previously-cached analysis data invalid in a way
+// the per-table version constants above do not capture (for example, a change
+// in how FQNs are computed). On a bump, a database stamped with an older
+// non-empty version is fully rebuilt at open time (see reconcileVersions). A database
+// with no stamp at all (one written before this field existed) is NOT wiped: it
+// is simply stamped, so existing warm Go caches survive the first upgrade.
+const currentSchemaVersion = "2"
 
 // CachedCallSite is the minimal data needed to reconstruct a CallSiteInternal.
 type CachedCallSite struct {
@@ -107,8 +120,8 @@ type CachedPass4Edge struct {
 
 // CachedPass4Result holds the cached Pass 4 output for one source file.
 type CachedPass4Result struct {
-	ContentHash     string            `json:"contentHash"`
-	Edges           []CachedPass4Edge `json:"edges"`
+	ContentHash string            `json:"contentHash"`
+	Edges       []CachedPass4Edge `json:"edges"`
 	// UnresolvedNames are the FunctionName values of unresolved call sites in this
 	// file.  They are stored so that, when new functions are added to the index,
 	// we can detect that a previously-failing call site might now resolve and mark
@@ -124,25 +137,44 @@ type CachedPass4Result struct {
 // Thread-safety: the DB connection serialises writes; parallel goroutines should
 // only call Get* (reads) and flush with Put* sequentially afterwards.
 type AnalysisCache struct {
-	db *sql.DB
+	db   *sql.DB
+	path string
+}
+
+// CacheOptions configures where the index lives and how aggressively it is
+// rebuilt. ProjectRoot is required; the rest default to the zero value.
+type CacheOptions struct {
+	// ProjectRoot is the absolute or relative path to the project being scanned.
+	// It seeds the default index location and the project-root invalidation key.
+	ProjectRoot string
+	// IndexPath overrides the index location (the --index-path flag). Empty means
+	// fall back to the env var, then the default $HOME location.
+	IndexPath string
+	// EngineVersion is the running binary's version. A mismatch with the stored
+	// version triggers a full rebuild. Empty means "unknown": the stored stamp is
+	// left untouched and never compared, so callers that do not know the version
+	// (tests, auxiliary commands) cannot clobber another command's stamp.
+	EngineVersion string
+	// ForceRebuild drops all cached data on open, as --rebuild-index requests.
+	ForceRebuild bool
 }
 
 // OpenAnalysisCache opens (or creates) the SQLite cache for the given project
-// root. The database lives at ~/.cache/pathfinder/<hex(sha256(projectRoot))[:16]>.db.
+// root at the default location, with no engine-version stamp and no forced
+// rebuild. It is the convenience form for callers that only need the default
+// behaviour; richer callers use OpenAnalysisCacheWithOptions.
 func OpenAnalysisCache(projectRoot string) (*AnalysisCache, error) {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		cacheDir = os.TempDir()
-	}
-	pfDir := filepath.Join(cacheDir, "pathfinder")
-	if err := os.MkdirAll(pfDir, 0o755); err != nil {
-		return nil, fmt.Errorf("analysis cache: cannot create cache dir %s: %w", pfDir, err)
-	}
+	return OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: projectRoot})
+}
 
-	// Derive a short, stable identifier from the project root path.
-	h := sha256.Sum256([]byte(projectRoot))
-	dbName := hex.EncodeToString(h[:])[:16] + ".db"
-	dbPath := filepath.Join(pfDir, dbName)
+// OpenAnalysisCacheWithOptions opens (or creates) the SQLite index per opts.
+// The index lives at $HOME/.codepathfinder/<hash>.sqlite unless overridden by
+// opts.IndexPath or the CODEPATHFINDER_INDEX_PATH env var.
+func OpenAnalysisCacheWithOptions(opts CacheOptions) (*AnalysisCache, error) {
+	dbPath, err := ResolveIndexPath(opts.ProjectRoot, opts.IndexPath, os.Getenv(IndexEnvVar))
+	if err != nil {
+		return nil, err
+	}
 
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
@@ -155,105 +187,184 @@ func OpenAnalysisCache(projectRoot string) (*AnalysisCache, error) {
 		return nil, fmt.Errorf("analysis cache: set WAL mode: %w", err)
 	}
 
-	if err := initSchema(db, projectRoot); err != nil {
+	if err := applySchema(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if err := reconcileVersions(db, opts); err != nil {
 		db.Close()
 		return nil, err
 	}
 
-	return &AnalysisCache{db: db}, nil
+	return &AnalysisCache{db: db, path: dbPath}, nil
 }
 
 // DBPath returns the filesystem path of the SQLite database file, for diagnostics.
 func (c *AnalysisCache) DBPath() string {
-	// Query sqlite_master for the database filename via the pragma.
-	var path string
-	_ = c.db.QueryRowContext(context.Background(), `PRAGMA database_list`).Scan(nil, nil, &path)
-	return path
+	return c.path
 }
 
-// initSchema creates tables and runs per-table version checks.
-// Only tables whose stored version differs from the current version are wiped;
-// unchanged tables keep their warm data.
-func initSchema(db *sql.DB, projectRoot string) error {
-	createStmts := []string{
-		`CREATE TABLE IF NOT EXISTS meta (
-			key   TEXT PRIMARY KEY,
-			value TEXT NOT NULL
-		)`,
-		`CREATE TABLE IF NOT EXISTS file_cache (
-			file_path        TEXT    PRIMARY KEY,
-			content_hash     TEXT    NOT NULL,
-			updated_at       INTEGER NOT NULL,
-			call_sites_json  TEXT    NOT NULL,
-			scope_json       TEXT    NOT NULL
-		)`,
-		// Pass 1 function index snapshot — one row per (file, fqn) pair.
-		`CREATE TABLE IF NOT EXISTS function_index (
-			file_path TEXT NOT NULL,
-			fqn       TEXT NOT NULL,
-			PRIMARY KEY (file_path, fqn)
-		)`,
-		// Pass 4 resolved-edge cache — one row per source file.
-		`CREATE TABLE IF NOT EXISTS pass4_results (
-			file_path       TEXT    PRIMARY KEY,
-			content_hash    TEXT    NOT NULL,
-			updated_at      INTEGER NOT NULL,
-			edges_json      TEXT    NOT NULL,
-			unresolved_json TEXT    NOT NULL
-		)`,
-	}
-	for _, stmt := range createStmts {
-		if _, err := db.ExecContext(context.Background(), stmt); err != nil {
-			return fmt.Errorf("analysis cache: create schema: %w", err)
-		}
+// tableVersion ties a per-table version constant to its meta key and table.
+// When the stored version differs from the constant, only that table is wiped;
+// every other table keeps its warm data.
+type tableVersion struct {
+	metaKey string
+	current string
+	table   string
+}
+
+var tableVersions = []tableVersion{
+	{"file_cache_version", fileCacheVersion, "file_cache"},
+	{"function_index_version", functionIndexVersion, "function_index"},
+	{"pass4_version", pass4Version, "pass4_results"},
+	{"fqn_index_version", fqnIndexVersion, "fqn_index"},
+	{"call_sites_version", callSitesVersion, "call_sites"},
+}
+
+// reconcileVersions decides how much cached data to discard, assuming the
+// schema has already been applied (see applySchema).
+//
+// A full rebuild (all data tables emptied) happens on, in priority order:
+//   - opts.ForceRebuild (the --rebuild-index flag),
+//   - a global schema_version mismatch,
+//   - an engine_version mismatch (when both versions are known),
+//   - a project_root change.
+//
+// In each case a stored value that is absent is treated as "fresh, leave it":
+// a database written by an older binary is stamped on first open rather than
+// wiped, so existing warm caches survive an upgrade. When no full rebuild is
+// needed, the cheaper per-table version check runs: only tables whose version
+// constant changed are wiped. Finally every version stamp is refreshed.
+func reconcileVersions(db *sql.DB, opts CacheOptions) error {
+	fullRebuild, reason, err := needsFullRebuild(db, opts)
+	if err != nil {
+		return err
 	}
 
-	// Always upsert project_root so a moved project gets its own DB.
-	var storedRoot string
-	_ = db.QueryRowContext(context.Background(), `SELECT value FROM meta WHERE key='project_root'`).Scan(&storedRoot)
-	if storedRoot != "" && storedRoot != projectRoot {
-		// Project root changed — wipe everything; this is a different project.
-		for _, tbl := range []string{"file_cache", "function_index", "pass4_results"} {
-			if _, err := db.ExecContext(context.Background(), `DELETE FROM `+tbl); err != nil {
-				return fmt.Errorf("analysis cache: wipe table %s on project root change: %w", tbl, err)
-			}
+	if fullRebuild {
+		fmt.Fprintf(os.Stderr, "[cache] rebuilding index: %s\n", reason)
+		if err := wipeDataTables(db); err != nil {
+			return err
 		}
+	} else if err := wipeStaleTables(db); err != nil {
+		return err
 	}
 
-	// Per-table version check: only wipe tables whose version changed.
-	tableVersions := []struct {
-		metaKey string
-		current string
-		table   string
-	}{
-		{"file_cache_version", fileCacheVersion, "file_cache"},
-		{"function_index_version", functionIndexVersion, "function_index"},
-		{"pass4_version", pass4Version, "pass4_results"},
+	return stampMeta(db, opts)
+}
+
+// needsFullRebuild reports whether every data table must be discarded, and a
+// human-readable reason for the one-line log. An absent stored value never
+// triggers a rebuild (see reconcileVersions).
+func needsFullRebuild(db *sql.DB, opts CacheOptions) (bool, string, error) {
+	if opts.ForceRebuild {
+		return true, "rebuild requested", nil
 	}
+
+	// Read the three invalidation stamps in one query so there is a single
+	// error path. An absent stamp reads as "" and never triggers a rebuild.
+	s, err := readRebuildStamps(db)
+	if err != nil {
+		return false, "", err
+	}
+
+	switch {
+	case s.schema != "" && s.schema != currentSchemaVersion:
+		return true, fmt.Sprintf("schema v%s -> v%s", s.schema, currentSchemaVersion), nil
+	case opts.EngineVersion != "" && s.engine != "" && s.engine != opts.EngineVersion:
+		return true, fmt.Sprintf("engine %s -> %s", s.engine, opts.EngineVersion), nil
+	case s.projectRoot != "" && s.projectRoot != opts.ProjectRoot:
+		return true, "project root changed", nil
+	default:
+		return false, "", nil
+	}
+}
+
+// rebuildStamps holds the meta values that gate a full rebuild.
+type rebuildStamps struct {
+	schema      string
+	engine      string
+	projectRoot string
+}
+
+// readRebuildStamps reads the schema, engine, and project-root stamps in a
+// single query. Missing rows leave their fields "".
+func readRebuildStamps(db *sql.DB) (rebuildStamps, error) {
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT key, value FROM meta WHERE key IN (?,?,?)`,
+		metaSchemaVersion, metaEngineVersion, metaProjectRoot)
+	if err != nil {
+		return rebuildStamps{}, fmt.Errorf("analysis cache: read rebuild stamps: %w", err)
+	}
+	defer rows.Close()
+
+	var s rebuildStamps
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return rebuildStamps{}, fmt.Errorf("analysis cache: scan rebuild stamp: %w", err)
+		}
+		switch key {
+		case metaSchemaVersion:
+			s.schema = value
+		case metaEngineVersion:
+			s.engine = value
+		case metaProjectRoot:
+			s.projectRoot = value
+		}
+	}
+	return s, rows.Err()
+}
+
+// readOptionalMeta returns the stored value for key, or "" when the key is
+// absent. A real SQL error is propagated; a missing key is not an error.
+func readOptionalMeta(db *sql.DB, key string) (string, error) {
+	value, err := getMetaValue(db, key)
+	if errors.Is(err, errMetaKeyMissing) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+// wipeStaleTables wipes only the tables whose version constant differs from the
+// stored stamp. Tables that are up to date keep their warm data.
+func wipeStaleTables(db *sql.DB) error {
 	for _, tv := range tableVersions {
-		var stored string
-		_ = db.QueryRowContext(context.Background(),
-			`SELECT value FROM meta WHERE key=?`, tv.metaKey,
-		).Scan(&stored)
+		stored, err := readOptionalMeta(db, tv.metaKey)
+		if err != nil {
+			return err
+		}
 		if stored != tv.current {
 			if _, err := db.ExecContext(context.Background(), `DELETE FROM `+tv.table); err != nil {
 				return fmt.Errorf("analysis cache: wipe %s on version change: %w", tv.table, err)
 			}
 		}
 	}
+	return nil
+}
 
-	// Upsert all metadata.
-	upserts := []struct{ k, v string }{
-		{"project_root", projectRoot},
-		{"file_cache_version", fileCacheVersion},
-		{"function_index_version", functionIndexVersion},
-		{"pass4_version", pass4Version},
+// stampMeta refreshes every version stamp and the project root. The engine
+// version is only written when known, so an auxiliary command that does not
+// pass its version leaves another command's stamp intact.
+func stampMeta(db *sql.DB, opts CacheOptions) error {
+	stamps := map[string]string{
+		metaProjectRoot:          opts.ProjectRoot,
+		metaSchemaVersion:        currentSchemaVersion,
+		"file_cache_version":     fileCacheVersion,
+		"function_index_version": functionIndexVersion,
+		"pass4_version":          pass4Version,
+		"fqn_index_version":      fqnIndexVersion,
+		"call_sites_version":     callSitesVersion,
 	}
-	for _, kv := range upserts {
-		if _, err := db.ExecContext(context.Background(),
-			`INSERT OR REPLACE INTO meta(key,value) VALUES(?,?)`, kv.k, kv.v,
-		); err != nil {
-			return fmt.Errorf("analysis cache: upsert meta %q: %w", kv.k, err)
+	if opts.EngineVersion != "" {
+		stamps[metaEngineVersion] = opts.EngineVersion
+	}
+	for k, v := range stamps {
+		if err := setMetaValue(db, k, v); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/sast-engine/graph/callgraph/builder/analysis_cache_test.go
+++ b/sast-engine/graph/callgraph/builder/analysis_cache_test.go
@@ -4,11 +4,28 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMain points default-location index resolution at a throwaway directory so
+// the package's tests never write SQLite files into the developer's real
+// $HOME/.codepathfinder. It deliberately does not touch $HOME itself: other
+// resolvers in this package read $HOME to locate GOMODCACHE.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "cpf-index-tests")
+	if err != nil {
+		panic(err)
+	}
+	indexParentDirOverride = dir
+	code := m.Run()
+	indexParentDirOverride = ""
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 // ---- helpers ----
 
@@ -38,17 +55,19 @@ func TestAnalysisCache_OpenClose(t *testing.T) {
 	require.NoError(t, cache.Close())
 }
 
-// TestAnalysisCache_OpenClose_InvalidDir verifies that a truly unwritable path
-// returns an error instead of panicking.
+// TestAnalysisCache_OpenClose_InvalidDir verifies that an index path whose
+// parent cannot be created returns an error instead of panicking. A regular
+// file is planted where the index directory would go, so os.MkdirAll fails.
 func TestAnalysisCache_OpenClose_InvalidDir(t *testing.T) {
-	// Use a path under a non-existent root that os.MkdirAll should fail on.
-	// On Linux, writing under /proc is not permitted.
-	_, err := OpenAnalysisCache("/proc/nonexistent_cpf_test/project")
-	// We expect either an error from MkdirAll or from sql.Open — either way not nil.
-	// If the test machine somehow allows it we just skip.
-	if err == nil {
-		t.Skip("unexpected success — running as root or unusual kernel config")
-	}
+	tmp := t.TempDir()
+	blocker := filepath.Join(tmp, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	// IndexPath points inside the blocking file, so MkdirAll on its parent fails.
+	_, err := OpenAnalysisCacheWithOptions(CacheOptions{
+		ProjectRoot: tmp,
+		IndexPath:   filepath.Join(blocker, "sub", "index.sqlite"),
+	})
 	assert.Error(t, err)
 }
 
@@ -56,9 +75,11 @@ func TestAnalysisCache_OpenClose_InvalidDir(t *testing.T) {
 
 func TestAnalysisCache_DBPath(t *testing.T) {
 	cache := openTempCache(t)
-	// DBPath uses PRAGMA database_list; the returned path may be empty on in-memory
-	// DBs or non-empty for file-backed ones. Either way it should not panic.
-	_ = cache.DBPath()
+	// DBPath returns the resolved index file. With the test override active it
+	// lives under the isolated temp dir and ends in .sqlite.
+	path := cache.DBPath()
+	assert.Equal(t, indexParentDirOverride, filepath.Dir(path))
+	assert.True(t, strings.HasSuffix(path, ".sqlite"), "got %q", path)
 }
 
 // ---- Per-table version wipe tests ----
@@ -561,7 +582,7 @@ func TestGetFileCached_CorruptCallSitesJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	// Insert row with correct hash but invalid call_sites_json.
-	_, err = cache.db.ExecContext(context.Background(), 
+	_, err = cache.db.ExecContext(context.Background(),
 		`INSERT OR REPLACE INTO file_cache(file_path, content_hash, updated_at, call_sites_json, scope_json)
 		 VALUES(?,?,?,?,?)`,
 		goFile, hash, 1, "NOT_VALID_JSON", `{"function_scopes":{}}`,
@@ -582,7 +603,7 @@ func TestGetFileCached_CorruptScopeJSON(t *testing.T) {
 	hash, err := hashFile(goFile)
 	require.NoError(t, err)
 
-	_, err = cache.db.ExecContext(context.Background(), 
+	_, err = cache.db.ExecContext(context.Background(),
 		`INSERT OR REPLACE INTO file_cache(file_path, content_hash, updated_at, call_sites_json, scope_json)
 		 VALUES(?,?,?,?,?)`,
 		goFile, hash, 1, `[]`, `NOT_VALID_JSON`,
@@ -601,7 +622,7 @@ func TestLoadPass4Results_CorruptEdgesJSON(t *testing.T) {
 	goFile := writeTempGoFile(t, dir, "corrupt_edges.go", "package main\n")
 
 	hash, _ := hashFile(goFile)
-	_, err := cache.db.ExecContext(context.Background(), 
+	_, err := cache.db.ExecContext(context.Background(),
 		`INSERT OR REPLACE INTO pass4_results(file_path, content_hash, updated_at, edges_json, unresolved_json)
 		 VALUES(?,?,?,?,?)`,
 		goFile, hash, 1, "NOT_VALID_JSON", `[]`,
@@ -619,7 +640,7 @@ func TestLoadPass4Results_CorruptUnresolvedJSON(t *testing.T) {
 	goFile := writeTempGoFile(t, dir, "corrupt_unresolved.go", "package main\n")
 
 	hash, _ := hashFile(goFile)
-	_, err := cache.db.ExecContext(context.Background(), 
+	_, err := cache.db.ExecContext(context.Background(),
 		`INSERT OR REPLACE INTO pass4_results(file_path, content_hash, updated_at, edges_json, unresolved_json)
 		 VALUES(?,?,?,?,?)`,
 		goFile, hash, 1, `[]`, `NOT_VALID_JSON`,
@@ -667,52 +688,6 @@ func TestLoadFunctionIndex_ClosedDB(t *testing.T) {
 	// Should return empty map, not panic, on closed DB.
 	idx := cache.LoadFunctionIndex()
 	assert.Empty(t, idx)
-}
-
-// TestOpenAnalysisCache_UserCacheDirFallback verifies that OpenAnalysisCache
-// gracefully falls back to os.TempDir() when os.UserCacheDir() cannot determine
-// the home directory. This covers the fallback branch in OpenAnalysisCache.
-func TestOpenAnalysisCache_UserCacheDirFallback(t *testing.T) {
-	// Force os.UserCacheDir() to fail by clearing both HOME and XDG_CACHE_HOME.
-	// Go's UserCacheDir on Linux returns an error when neither is set.
-	t.Setenv("HOME", "")
-	t.Setenv("XDG_CACHE_HOME", "")
-
-	// Set TMPDIR to an isolated fresh directory so os.TempDir() → fresh dir/pathfinder,
-	// avoiding collisions with pre-existing /tmp/pathfinder entries on the test host.
-	t.Setenv("TMPDIR", t.TempDir())
-
-	// OpenAnalysisCache should still succeed using os.TempDir() as the fallback.
-	cache, err := OpenAnalysisCache(t.TempDir())
-	if err != nil {
-		// If HOME="" breaks more than just UserCacheDir (e.g. sqlite temp files),
-		// that's acceptable to skip — the important thing is it doesn't panic.
-		t.Skipf("env-cleared run produced error (acceptable): %v", err)
-	}
-	require.NoError(t, cache.Close())
-}
-
-// TestOpenAnalysisCache_MkdirError verifies that OpenAnalysisCache returns an
-// error when it cannot create the cache directory (e.g., because a file already
-// exists at the target path).
-func TestOpenAnalysisCache_MkdirError(t *testing.T) {
-	tmp := t.TempDir()
-
-	// Redirect os.UserCacheDir() into our temp dir on every platform:
-	// linux/freebsd honour XDG_CACHE_HOME; darwin uses $HOME/Library/Caches.
-	t.Setenv("HOME", tmp)
-	t.Setenv("XDG_CACHE_HOME", tmp)
-
-	// Resolve where OpenAnalysisCache will try to create the "pathfinder" subdir
-	// and plant a regular file there so os.MkdirAll fails.
-	cacheDir, err := os.UserCacheDir()
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
-	blockingFile := filepath.Join(cacheDir, "pathfinder")
-	require.NoError(t, os.WriteFile(blockingFile, []byte("block"), 0o444))
-
-	_, err = OpenAnalysisCache(t.TempDir())
-	assert.Error(t, err, "os.MkdirAll should fail when a file blocks the cache dir")
 }
 
 // TestSaveFunctionIndex_TableDropped verifies that SaveFunctionIndex returns an
@@ -817,4 +792,188 @@ func TestOpenAnalysisCache_VersionMismatch_OnlyWipesAffectedTable(t *testing.T) 
 	// file_cache should still be warm.
 	_, hit := cache2.GetFileCached(goFile)
 	assert.True(t, hit, "file_cache should survive a pass4_version bump")
+}
+
+// ---- Global schema / engine version + rebuild (PR-01) ----
+
+// seedFqnRow inserts one row directly into fqn_index (no writer exists yet).
+func seedFqnRow(t *testing.T, cache *AnalysisCache) {
+	t.Helper()
+	_, err := cache.db.ExecContext(context.Background(),
+		`INSERT INTO fqn_index(fqn, language, kind, source, schema_version) VALUES(?,?,?,?,?)`,
+		"pkg.Fn", "python", "function", "project", currentSchemaVersion)
+	require.NoError(t, err)
+}
+
+func countFqnRows(t *testing.T, cache *AnalysisCache) int {
+	t.Helper()
+	var n int
+	require.NoError(t, cache.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM fqn_index`).Scan(&n))
+	return n
+}
+
+func TestInitSchema_FreshDB_StampsVersions(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir, EngineVersion: "9.9.9"})
+	require.NoError(t, err)
+	defer cache.Close()
+
+	for key, want := range map[string]string{
+		metaSchemaVersion:        currentSchemaVersion,
+		metaEngineVersion:        "9.9.9",
+		"fqn_index_version":      fqnIndexVersion,
+		"call_sites_version":     callSitesVersion,
+		"file_cache_version":     fileCacheVersion,
+		"pass4_version":          pass4Version,
+		"function_index_version": functionIndexVersion,
+	} {
+		got, err := getMetaValue(cache.db, key)
+		require.NoError(t, err, "meta key %s should be stamped", key)
+		assert.Equal(t, want, got, "meta key %s", key)
+	}
+}
+
+func TestInitSchema_NewTablesQueryable(t *testing.T) {
+	cache := openTempCache(t)
+	// Both new tables should accept a query without error.
+	assert.Zero(t, countFqnRows(t, cache))
+	var cs int
+	require.NoError(t, cache.db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM call_sites`).Scan(&cs))
+	assert.Zero(t, cs)
+}
+
+func TestInitSchema_SchemaVersionMismatch_FullRebuild(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+
+	goFile := writeTempGoFile(t, dir, "schema_bump.go", "package main\n")
+	cs := []CachedCallSite{{CallerFQN: "pkg.Fn", FunctionName: "f", CallerFile: goFile, CallLine: 1}}
+	require.NoError(t, cache.PutFileCached(goFile, cs, &CachedScope{FunctionScopes: map[string]CachedFunctionScope{}}))
+	seedFqnRow(t, cache)
+
+	// Stamp an older schema version to trigger the open-time full rebuild.
+	require.NoError(t, setMetaValue(cache.db, metaSchemaVersion, "1"))
+	require.NoError(t, cache.Close())
+
+	cache2, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	defer cache2.Close()
+
+	_, hit := cache2.GetFileCached(goFile)
+	assert.False(t, hit, "file_cache should be wiped on schema version mismatch")
+	assert.Zero(t, countFqnRows(t, cache2), "fqn_index should be wiped on schema version mismatch")
+
+	got, err := getMetaValue(cache2.db, metaSchemaVersion)
+	require.NoError(t, err)
+	assert.Equal(t, currentSchemaVersion, got, "schema version should be re-stamped after rebuild")
+}
+
+func TestInitSchema_EngineVersionMismatch_FullRebuild(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir, EngineVersion: "2.1.0"})
+	require.NoError(t, err)
+	seedFqnRow(t, cache)
+	require.NoError(t, cache.Close())
+
+	cache2, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir, EngineVersion: "2.2.0"})
+	require.NoError(t, err)
+	defer cache2.Close()
+
+	assert.Zero(t, countFqnRows(t, cache2), "fqn_index should be wiped on engine version mismatch")
+	got, err := getMetaValue(cache2.db, metaEngineVersion)
+	require.NoError(t, err)
+	assert.Equal(t, "2.2.0", got)
+}
+
+// TestInitSchema_EngineVersionUnknown_DoesNotWipeOrClobber verifies that a
+// command that does not know its version (EngineVersion == "") neither wipes the
+// cache nor overwrites the stamp a versioned command wrote.
+func TestInitSchema_EngineVersionUnknown_DoesNotWipeOrClobber(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir, EngineVersion: "2.1.0"})
+	require.NoError(t, err)
+	seedFqnRow(t, cache)
+	require.NoError(t, cache.Close())
+
+	// Reopen with no engine version (e.g. an auxiliary command or a test).
+	cache2, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir})
+	require.NoError(t, err)
+	defer cache2.Close()
+
+	assert.Equal(t, 1, countFqnRows(t, cache2), "unknown engine version must not wipe the cache")
+	got, err := getMetaValue(cache2.db, metaEngineVersion)
+	require.NoError(t, err)
+	assert.Equal(t, "2.1.0", got, "unknown engine version must not clobber the existing stamp")
+}
+
+// TestInitSchema_LegacyDBNoSchemaStamp_Survives simulates a database written by
+// a binary that predates the schema_version stamp: it must be upgraded in place
+// (new tables added, stamp written) without wiping the warm data.
+func TestInitSchema_LegacyDBNoSchemaStamp_Survives(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+
+	goFile := writeTempGoFile(t, dir, "legacy.go", "package main\n")
+	cs := []CachedCallSite{{CallerFQN: "pkg.Fn", FunctionName: "f", CallerFile: goFile, CallLine: 1}}
+	require.NoError(t, cache.PutFileCached(goFile, cs, &CachedScope{FunctionScopes: map[string]CachedFunctionScope{}}))
+
+	// Remove the schema_version stamp to look like a pre-stamp database.
+	_, err = cache.db.ExecContext(context.Background(), `DELETE FROM meta WHERE key=?`, metaSchemaVersion)
+	require.NoError(t, err)
+	require.NoError(t, cache.Close())
+
+	cache2, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	defer cache2.Close()
+
+	_, hit := cache2.GetFileCached(goFile)
+	assert.True(t, hit, "a legacy DB without a schema stamp must not be wiped on upgrade")
+	got, err := getMetaValue(cache2.db, metaSchemaVersion)
+	require.NoError(t, err)
+	assert.Equal(t, currentSchemaVersion, got, "schema version should be stamped on upgrade")
+}
+
+func TestInitSchema_ForceRebuild_WipesAll(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+
+	goFile := writeTempGoFile(t, dir, "force.go", "package main\n")
+	cs := []CachedCallSite{{CallerFQN: "pkg.Fn", FunctionName: "f", CallerFile: goFile, CallLine: 1}}
+	require.NoError(t, cache.PutFileCached(goFile, cs, &CachedScope{FunctionScopes: map[string]CachedFunctionScope{}}))
+	seedFqnRow(t, cache)
+	require.NoError(t, cache.Close())
+
+	cache2, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir, ForceRebuild: true})
+	require.NoError(t, err)
+	defer cache2.Close()
+
+	_, hit := cache2.GetFileCached(goFile)
+	assert.False(t, hit, "--rebuild-index should wipe file_cache")
+	assert.Zero(t, countFqnRows(t, cache2), "--rebuild-index should wipe fqn_index")
+}
+
+func TestInitSchema_FqnIndexVersionBump_WipesOnlyFqnIndex(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+
+	goFile := writeTempGoFile(t, dir, "fqn_bump.go", "package main\n")
+	cs := []CachedCallSite{{CallerFQN: "pkg.Fn", FunctionName: "f", CallerFile: goFile, CallLine: 1}}
+	require.NoError(t, cache.PutFileCached(goFile, cs, &CachedScope{FunctionScopes: map[string]CachedFunctionScope{}}))
+	seedFqnRow(t, cache)
+
+	// Bump only the fqn_index per-table version.
+	require.NoError(t, setMetaValue(cache.db, "fqn_index_version", "999"))
+	require.NoError(t, cache.Close())
+
+	cache2, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	defer cache2.Close()
+
+	assert.Zero(t, countFqnRows(t, cache2), "fqn_index should be wiped on its own version bump")
+	_, hit := cache2.GetFileCached(goFile)
+	assert.True(t, hit, "file_cache should survive an fqn_index_version bump")
 }

--- a/sast-engine/graph/callgraph/builder/index_path.go
+++ b/sast-engine/graph/callgraph/builder/index_path.go
@@ -1,0 +1,81 @@
+package builder
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// IndexEnvVar is the environment variable that overrides the default index
+// location. A non-empty value is used verbatim when no explicit override flag
+// is passed. The precedence is: override flag > env var > default location.
+const IndexEnvVar = "CODEPATHFINDER_INDEX_PATH"
+
+// indexDirName is the per-user directory under $HOME that holds one SQLite
+// index file per project root. It lives outside the project tree so there is
+// nothing to .gitignore and nothing to commit by accident.
+const indexDirName = ".codepathfinder"
+
+// indexParentDirOverride, when non-empty, replaces $HOME/.codepathfinder as the
+// directory that holds default-location index files. It is a test-isolation
+// seam: the package test binary points it at a temp directory so tests never
+// write into the developer's real home directory and never depend on $HOME
+// (other resolvers in this package read $HOME for GOMODCACHE). It is never set
+// in production.
+var indexParentDirOverride string
+
+// ResolveIndexPath computes the on-disk location of a project's FQN index.
+//
+// Precedence:
+//  1. override (the --index-path flag) when non-empty.
+//  2. envVar (CODEPATHFINDER_INDEX_PATH) when non-empty.
+//  3. $HOME/.codepathfinder/<hash>.sqlite, where <hash> is the first 16 hex
+//     chars of SHA-256 over the cleaned absolute project root. Two checkouts at
+//     different absolute paths get distinct files; the same path always maps to
+//     the same file regardless of the working directory a command runs from.
+//
+// The parent directory of the resolved path is created with 0700 perms
+// (user-only) on first use, whether the path comes from an override, the env
+// var, or the default location, so callers never hit a cryptic open error on a
+// fresh path.
+func ResolveIndexPath(projectRoot, override, envVar string) (string, error) {
+	path, err := resolveIndexFile(projectRoot, override, envVar)
+	if err != nil {
+		return "", err
+	}
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o700); err != nil {
+		return "", fmt.Errorf("resolve index path: create %s: %w", parent, err)
+	}
+	return path, nil
+}
+
+// resolveIndexFile computes the index file path without touching the filesystem.
+func resolveIndexFile(projectRoot, override, envVar string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	if envVar != "" {
+		return envVar, nil
+	}
+
+	abs, err := filepath.Abs(filepath.Clean(projectRoot))
+	if err != nil {
+		return "", fmt.Errorf("resolve index path: absolute path for %q: %w", projectRoot, err)
+	}
+
+	dir := indexParentDirOverride
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve index path: locate home directory: %w", err)
+		}
+		dir = filepath.Join(home, indexDirName)
+	}
+
+	sum := sha256.Sum256([]byte(abs))
+	name := hex.EncodeToString(sum[:8]) + ".sqlite" // 8 bytes -> 16 hex chars
+	return filepath.Join(dir, name), nil
+}

--- a/sast-engine/graph/callgraph/builder/index_path_test.go
+++ b/sast-engine/graph/callgraph/builder/index_path_test.go
@@ -1,0 +1,138 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveIndexPath_OverrideWins(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "custom", "idx.sqlite")
+	got, err := ResolveIndexPath("/some/project", want, "/env/path.sqlite")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	// Parent is created so a fresh override path opens cleanly.
+	assert.DirExists(t, filepath.Dir(want))
+}
+
+func TestResolveIndexPath_EnvVarUsedWhenNoOverride(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "env", "idx.sqlite")
+	got, err := ResolveIndexPath("/some/project", "", want)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.DirExists(t, filepath.Dir(want))
+}
+
+func TestResolveIndexPath_OverrideBeatsEnvVar(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "override.sqlite")
+	got, err := ResolveIndexPath("/some/project", override, filepath.Join(t.TempDir(), "env.sqlite"))
+	require.NoError(t, err)
+	assert.Equal(t, override, got)
+}
+
+func TestResolveIndexPath_DefaultLocation(t *testing.T) {
+	// TestMain points indexParentDirOverride at a temp dir, so the default
+	// location resolves under it rather than the real $HOME.
+	got, err := ResolveIndexPath("/some/project", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, indexParentDirOverride, filepath.Dir(got))
+	assert.True(t, strings.HasSuffix(got, ".sqlite"), "index file should end with .sqlite, got %q", got)
+	// 16 hex chars + ".sqlite".
+	assert.Len(t, filepath.Base(got), 16+len(".sqlite"))
+}
+
+func TestResolveIndexPath_DeterministicForSameRoot(t *testing.T) {
+	a, err := ResolveIndexPath("/some/project", "", "")
+	require.NoError(t, err)
+	b, err := ResolveIndexPath("/some/project", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, a, b, "same project root must map to the same index file")
+}
+
+func TestResolveIndexPath_RelativeAndAbsoluteRootMatch(t *testing.T) {
+	// A relative path and its absolute form should hash to the same file.
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	rel := "somedir"
+	abs := filepath.Join(cwd, rel)
+
+	fromRel, err := ResolveIndexPath(rel, "", "")
+	require.NoError(t, err)
+	fromAbs, err := ResolveIndexPath(abs, "", "")
+	require.NoError(t, err)
+	assert.Equal(t, fromAbs, fromRel, "relative and absolute forms of the same root must match")
+}
+
+func TestResolveIndexPath_DistinctRootsDistinctFiles(t *testing.T) {
+	a, err := ResolveIndexPath("/project/one", "", "")
+	require.NoError(t, err)
+	b, err := ResolveIndexPath("/project/two", "", "")
+	require.NoError(t, err)
+	assert.NotEqual(t, a, b, "distinct project roots must map to distinct index files")
+}
+
+func TestResolveIndexPath_MkdirParentFails(t *testing.T) {
+	// Plant a regular file, then ask for an index path nested under it. The
+	// override path is honoured, but creating its parent directory must fail.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	_, err := ResolveIndexPath("/some/project", filepath.Join(blocker, "nested", "idx.sqlite"), "")
+	assert.Error(t, err)
+}
+
+func TestResolveIndexFile_DefaultUnderHome(t *testing.T) {
+	// With the test override cleared and a real HOME, the default location is
+	// $HOME/.codepathfinder/<hash>.sqlite. This exercises the production
+	// home-resolution branch that TestMain's override otherwise bypasses.
+	saved := indexParentDirOverride
+	indexParentDirOverride = ""
+	t.Cleanup(func() { indexParentDirOverride = saved })
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := resolveIndexFile("/some/project", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".codepathfinder"), filepath.Dir(got))
+	assert.True(t, strings.HasSuffix(got, ".sqlite"), "got %q", got)
+}
+
+func TestResolveIndexPath_PropagatesResolveError(t *testing.T) {
+	// ResolveIndexPath must surface an error from the inner resolver (here, an
+	// unresolvable home) rather than proceeding to MkdirAll.
+	saved := indexParentDirOverride
+	indexParentDirOverride = ""
+	t.Cleanup(func() { indexParentDirOverride = saved })
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("home", "")
+
+	_, err := ResolveIndexPath("/some/project", "", "")
+	if err == nil {
+		t.Skip("platform resolved a home directory despite cleared env; nothing to assert")
+	}
+	assert.Error(t, err)
+}
+
+func TestResolveIndexFile_NoHomeNoOverride(t *testing.T) {
+	// Clear the test override and HOME so os.UserHomeDir fails and the default
+	// branch surfaces an actionable error rather than panicking. resolveIndexFile
+	// is exercised directly (no filesystem side effects) for a deterministic hit
+	// on the home-lookup error path.
+	saved := indexParentDirOverride
+	indexParentDirOverride = ""
+	t.Cleanup(func() { indexParentDirOverride = saved })
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "") // windows
+	t.Setenv("home", "")        // plan9
+
+	_, err := resolveIndexFile("/some/project", "", "")
+	if err == nil {
+		t.Skip("platform resolved a home directory despite cleared env; nothing to assert")
+	}
+	assert.Contains(t, err.Error(), "home directory")
+}

--- a/sast-engine/graph/callgraph/builder/metadata.go
+++ b/sast-engine/graph/callgraph/builder/metadata.go
@@ -1,0 +1,48 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Reserved meta keys. The meta table is a flat key/value store; these are the
+// keys reconcileVersions reads and writes at open time.
+const (
+	metaProjectRoot   = "project_root"
+	metaSchemaVersion = "schema_version"
+	metaEngineVersion = "engine_version"
+)
+
+// errMetaKeyMissing is returned by getMetaValue when a key is absent. Callers
+// that treat "absent" as "fresh database" check for it with errors.Is.
+var errMetaKeyMissing = errors.New("analysis cache: meta key not found")
+
+// getMetaValue reads a single meta key. It returns errMetaKeyMissing when the
+// key is absent (distinct from a present-but-empty value or a SQL error) so the
+// open-time check can tell a brand-new database apart from one stamped by an
+// older binary.
+func getMetaValue(db *sql.DB, key string) (string, error) {
+	var value string
+	err := db.QueryRowContext(context.Background(),
+		`SELECT value FROM meta WHERE key=?`, key,
+	).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", errMetaKeyMissing
+	}
+	if err != nil {
+		return "", fmt.Errorf("analysis cache: read meta %q: %w", key, err)
+	}
+	return value, nil
+}
+
+// setMetaValue upserts a single meta key.
+func setMetaValue(db *sql.DB, key, value string) error {
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT OR REPLACE INTO meta(key,value) VALUES(?,?)`, key, value,
+	); err != nil {
+		return fmt.Errorf("analysis cache: write meta %q: %w", key, err)
+	}
+	return nil
+}

--- a/sast-engine/graph/callgraph/builder/metadata_test.go
+++ b/sast-engine/graph/callgraph/builder/metadata_test.go
@@ -1,0 +1,186 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaValue_RoundTrip(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	require.NoError(t, setMetaValue(db, metaSchemaVersion, "2"))
+	got, err := getMetaValue(db, metaSchemaVersion)
+	require.NoError(t, err)
+	assert.Equal(t, "2", got)
+}
+
+func TestMetaValue_Upsert(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	require.NoError(t, setMetaValue(db, metaEngineVersion, "2.1.0"))
+	require.NoError(t, setMetaValue(db, metaEngineVersion, "2.2.0"))
+	got, err := getMetaValue(db, metaEngineVersion)
+	require.NoError(t, err)
+	assert.Equal(t, "2.2.0", got, "second write should overwrite the first")
+}
+
+func TestMetaValue_MissingKey(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	_, err := getMetaValue(db, "never-written")
+	assert.True(t, errors.Is(err, errMetaKeyMissing), "absent key should return errMetaKeyMissing, got %v", err)
+}
+
+func TestMetaValue_EmptyStringIsNotMissing(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	require.NoError(t, setMetaValue(db, "present-but-empty", ""))
+	got, err := getMetaValue(db, "present-but-empty")
+	require.NoError(t, err, "a present empty value is not a missing key")
+	assert.Equal(t, "", got)
+}
+
+func TestGetMetaValue_SQLErrorPropagates(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close()) // force a real SQL error, distinct from "missing"
+
+	_, err := getMetaValue(db, metaSchemaVersion)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errMetaKeyMissing), "a closed-DB error must not masquerade as a missing key")
+}
+
+func TestReadOptionalMeta_MissingReturnsEmpty(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	got, err := readOptionalMeta(db, "absent")
+	require.NoError(t, err)
+	assert.Equal(t, "", got)
+}
+
+func TestReadOptionalMeta_SQLErrorPropagates(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+
+	_, err := readOptionalMeta(db, metaSchemaVersion)
+	assert.Error(t, err, "a real SQL error must not be swallowed as empty")
+}
+
+func TestSetMetaValue_ClosedDBErrors(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+
+	assert.Error(t, setMetaValue(db, metaSchemaVersion, "2"))
+}
+
+// ---- init helpers error injection (closed DB) ----
+
+func TestNeedsFullRebuild_SQLErrorPropagates(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+
+	_, _, err := needsFullRebuild(db, CacheOptions{ProjectRoot: "/p"})
+	assert.Error(t, err)
+}
+
+func TestWipeStaleTables_SQLErrorPropagates(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+
+	assert.Error(t, wipeStaleTables(db))
+}
+
+func TestStampMeta_SQLErrorPropagates(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+
+	assert.Error(t, stampMeta(db, CacheOptions{ProjectRoot: "/p", EngineVersion: "1.0.0"}))
+}
+
+func TestReadRebuildStamps_ClosedDBErrors(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+
+	_, err := readRebuildStamps(db)
+	assert.Error(t, err)
+}
+
+func TestReconcileVersions_NeedsRebuildErrorOnClosedDB(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, db.Close())
+
+	assert.Error(t, reconcileVersions(db, CacheOptions{ProjectRoot: "/p"}))
+}
+
+func TestReconcileVersions_WipeDataErrorOnForceRebuild(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	// Drop a data table, then force a full rebuild so wipeDataTables hits it.
+	_, err := db.ExecContext(context.Background(), `DROP TABLE fqn_index`)
+	require.NoError(t, err)
+
+	assert.Error(t, reconcileVersions(db, CacheOptions{ProjectRoot: "/p", ForceRebuild: true}))
+}
+
+func TestReconcileVersions_WipeStaleErrorOnDroppedTable(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	// No version stamps yet, so the per-table check will try to DELETE every
+	// table; dropping one makes that DELETE fail (no full rebuild triggered).
+	_, err := db.ExecContext(context.Background(), `DROP TABLE file_cache`)
+	require.NoError(t, err)
+
+	assert.Error(t, reconcileVersions(db, CacheOptions{ProjectRoot: "/p"}))
+}
+
+func TestWipeStaleTables_DeleteErrorOnDroppedTable(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	// file_cache_version is unstamped (""), so wipeStaleTables will try to DELETE
+	// file_cache; dropping the table makes that DELETE fail.
+	_, err := db.ExecContext(context.Background(), `DROP TABLE file_cache`)
+	require.NoError(t, err)
+
+	assert.Error(t, wipeStaleTables(db))
+}
+
+// TestOpenAnalysisCacheWithOptions_WALErrorOnDirectory points the index path at
+// an existing directory: sql.Open is lazy, so the failure surfaces at the WAL
+// pragma rather than at open, exercising that error path.
+func TestOpenAnalysisCacheWithOptions_WALErrorOnDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: dir, IndexPath: dir})
+	assert.Error(t, err)
+}
+
+// TestOpenAnalysisCacheWithOptions_ApplySchemaError seeds a valid database with
+// an object whose name collides with an index applySchema creates, so the open
+// path fails at schema application (after a clean WAL pragma).
+func TestOpenAnalysisCacheWithOptions_ApplySchemaError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "seeded.sqlite")
+	seed, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	_, err = seed.ExecContext(context.Background(), `CREATE TABLE idx_fqn_exact (x INTEGER)`)
+	require.NoError(t, err)
+	require.NoError(t, seed.Close())
+
+	_, err = OpenAnalysisCacheWithOptions(CacheOptions{ProjectRoot: t.TempDir(), IndexPath: path})
+	assert.Error(t, err, "a name collision must surface during schema application")
+}

--- a/sast-engine/graph/callgraph/builder/schema.go
+++ b/sast-engine/graph/callgraph/builder/schema.go
@@ -1,0 +1,142 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Table DDL for the persisted analysis index.
+//
+// All statements use CREATE TABLE/INDEX IF NOT EXISTS so applySchema is
+// idempotent: running it against an up-to-date database is a no-op, and adding
+// a brand-new table to an existing database needs no version bump (the new
+// table is simply created empty for downstream PRs to populate).
+//
+// The first three tables (meta, file_cache, function_index, pass4_results)
+// predate this index generalisation and back the Go callgraph cache. The
+// fqn_index and call_sites tables are the language-agnostic FQN surface added
+// here; PR-02 populates fqn_index, PR-03 populates call_sites.
+const (
+	ddlMeta = `CREATE TABLE IF NOT EXISTS meta (
+		key   TEXT PRIMARY KEY,
+		value TEXT NOT NULL
+	)`
+
+	ddlFileCache = `CREATE TABLE IF NOT EXISTS file_cache (
+		file_path        TEXT    PRIMARY KEY,
+		content_hash     TEXT    NOT NULL,
+		updated_at       INTEGER NOT NULL,
+		call_sites_json  TEXT    NOT NULL,
+		scope_json       TEXT    NOT NULL
+	)`
+
+	ddlFunctionIndex = `CREATE TABLE IF NOT EXISTS function_index (
+		file_path TEXT NOT NULL,
+		fqn       TEXT NOT NULL,
+		PRIMARY KEY (file_path, fqn)
+	)`
+
+	ddlPass4Results = `CREATE TABLE IF NOT EXISTS pass4_results (
+		file_path       TEXT    PRIMARY KEY,
+		content_hash    TEXT    NOT NULL,
+		updated_at      INTEGER NOT NULL,
+		edges_json      TEXT    NOT NULL,
+		unresolved_json TEXT    NOT NULL
+	)`
+
+	// fqn_index: every FQN the engine knows about, with its definition site if
+	// any. file/start_*/end_* are NULL for synthetic stdlib entries.
+	ddlFqnIndex = `CREATE TABLE IF NOT EXISTS fqn_index (
+		fqn             TEXT    NOT NULL,
+		language        TEXT    NOT NULL,
+		kind            TEXT    NOT NULL,
+		source          TEXT    NOT NULL,
+		file            TEXT,
+		start_line      INTEGER,
+		start_col       INTEGER,
+		end_line        INTEGER,
+		end_col         INTEGER,
+		parent_fqn      TEXT,
+		signature       TEXT,
+		schema_version  INTEGER NOT NULL
+	)`
+
+	// call_sites: every call site, resolved or not, with enough breadcrumbs to
+	// explain failures. diagnostics holds a JSON array of frames, populated only
+	// when resolved=0.
+	ddlCallSites = `CREATE TABLE IF NOT EXISTS call_sites (
+		file            TEXT    NOT NULL,
+		line            INTEGER NOT NULL,
+		col             INTEGER NOT NULL,
+		function_fqn    TEXT,
+		target_name     TEXT    NOT NULL,
+		target_fqn      TEXT,
+		resolved        INTEGER NOT NULL,
+		diagnostics     TEXT,
+		schema_version  INTEGER NOT NULL
+	)`
+)
+
+// schemaStmts is the ordered list of DDL applied at open time. Tables first,
+// then their indices.
+var schemaStmts = []string{
+	ddlMeta,
+	ddlFileCache,
+	ddlFunctionIndex,
+	ddlPass4Results,
+	ddlFqnIndex,
+	ddlCallSites,
+	`CREATE INDEX IF NOT EXISTS idx_fqn_exact    ON fqn_index(fqn)`,
+	`CREATE INDEX IF NOT EXISTS idx_fqn_prefix   ON fqn_index(fqn COLLATE NOCASE)`,
+	`CREATE INDEX IF NOT EXISTS idx_location     ON fqn_index(file, start_line)`,
+	`CREATE INDEX IF NOT EXISTS idx_parent_fqn   ON fqn_index(parent_fqn)`,
+	`CREATE INDEX IF NOT EXISTS idx_callsite_loc ON call_sites(file, line, col)`,
+	`CREATE INDEX IF NOT EXISTS idx_callsite_fqn ON call_sites(target_fqn)`,
+}
+
+// dataTables are every table holding cached analysis output (everything except
+// meta). A full rebuild (schema/engine version mismatch, or --rebuild-index)
+// empties these while leaving meta to carry the new version stamps.
+var dataTables = []string{
+	"file_cache",
+	"function_index",
+	"pass4_results",
+	"fqn_index",
+	"call_sites",
+}
+
+// applySchema creates every table and index if absent. It is wrapped in a
+// single transaction so a partial DDL failure rolls back and never leaves a
+// half-applied schema on disk.
+func applySchema(db *sql.DB) error {
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("analysis cache: begin schema tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, stmt := range schemaStmts {
+		if _, err := tx.ExecContext(context.Background(), stmt); err != nil {
+			return fmt.Errorf("analysis cache: apply schema: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// wipeDataTables empties every data table in a single transaction, leaving meta
+// intact. Used by the full-rebuild paths.
+func wipeDataTables(db *sql.DB) error {
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		return fmt.Errorf("analysis cache: begin wipe tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, tbl := range dataTables {
+		if _, err := tx.ExecContext(context.Background(), `DELETE FROM `+tbl); err != nil {
+			return fmt.Errorf("analysis cache: wipe %s: %w", tbl, err)
+		}
+	}
+	return tx.Commit()
+}

--- a/sast-engine/graph/callgraph/builder/schema_test.go
+++ b/sast-engine/graph/callgraph/builder/schema_test.go
@@ -1,0 +1,126 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openRawDB opens a file-backed SQLite database with no schema applied, for
+// exercising schema.go in isolation.
+func openRawDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "raw.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func tableExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var got string
+	err := db.QueryRowContext(context.Background(),
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, name,
+	).Scan(&got)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	require.NoError(t, err)
+	return got == name
+}
+
+func indexExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var got string
+	err := db.QueryRowContext(context.Background(),
+		`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, name,
+	).Scan(&got)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	require.NoError(t, err)
+	return got == name
+}
+
+func TestApplySchema_CreatesAllTablesAndIndices(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	for _, tbl := range []string{"meta", "file_cache", "function_index", "pass4_results", "fqn_index", "call_sites"} {
+		assert.True(t, tableExists(t, db, tbl), "table %s should exist", tbl)
+	}
+	for _, idx := range []string{
+		"idx_fqn_exact", "idx_fqn_prefix", "idx_location", "idx_parent_fqn",
+		"idx_callsite_loc", "idx_callsite_fqn",
+	} {
+		assert.True(t, indexExists(t, db, idx), "index %s should exist", idx)
+	}
+}
+
+func TestApplySchema_Idempotent(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	// A second apply against an up-to-date schema is a no-op, not an error.
+	require.NoError(t, applySchema(db))
+	assert.True(t, tableExists(t, db, "fqn_index"))
+}
+
+func TestWipeDataTables_EmptiesDataKeepsMeta(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+
+	// Seed one row in a data table and one meta row.
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO fqn_index(fqn, language, kind, source, schema_version) VALUES('pkg.Fn','python','function','project',2)`)
+	require.NoError(t, err)
+	require.NoError(t, setMetaValue(db, "sentinel", "keep"))
+
+	require.NoError(t, wipeDataTables(db))
+
+	var fqnCount int
+	require.NoError(t, db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM fqn_index`).Scan(&fqnCount))
+	assert.Zero(t, fqnCount, "fqn_index should be emptied")
+
+	got, err := getMetaValue(db, "sentinel")
+	require.NoError(t, err)
+	assert.Equal(t, "keep", got, "meta must survive a data wipe")
+}
+
+func TestApplySchema_RollsBackOnError(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, db.Close()) // a closed DB makes BeginTx fail
+	assert.Error(t, applySchema(db))
+}
+
+func TestWipeDataTables_ErrorsOnClosedDB(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	require.NoError(t, db.Close())
+	assert.Error(t, wipeDataTables(db))
+}
+
+// TestWipeDataTables_ErrorsOnMissingTable covers the in-loop DELETE failure:
+// the DB is open but one data table has been dropped.
+func TestWipeDataTables_ErrorsOnMissingTable(t *testing.T) {
+	db := openRawDB(t)
+	require.NoError(t, applySchema(db))
+	_, err := db.ExecContext(context.Background(), `DROP TABLE fqn_index`)
+	require.NoError(t, err)
+
+	assert.Error(t, wipeDataTables(db))
+}
+
+// TestApplySchema_ErrorsOnNameCollision covers the in-loop DDL failure: an
+// object already exists under a name applySchema needs for an index, so the
+// CREATE INDEX cannot be satisfied even with IF NOT EXISTS.
+func TestApplySchema_ErrorsOnNameCollision(t *testing.T) {
+	db := openRawDB(t)
+	_, err := db.ExecContext(context.Background(), `CREATE TABLE idx_fqn_exact (x INTEGER)`)
+	require.NoError(t, err)
+
+	assert.Error(t, applySchema(db))
+}


### PR DESCRIPTION
**Stack**: PR-01 of 14 (Rule Authoring Toolchain, Phase 0). First PR in the stack; nothing depends on it yet upstream.

## What

Generalise the experimental Go-only SQLite analysis cache into a language-agnostic, persisted FQN index that later PRs populate (`fqn_index` in PR-02, `call_sites` in PR-03) and query (`pathfinder fqn` in PR-04). No new user-facing query surface ships here; this is the schema + location + versioning foundation.

## Changes

- **`schema.go`** (new): `fqn_index` and `call_sites` tables plus their indices (per tech-spec Section 2.1), created idempotently alongside the existing Go cache tables. `applySchema` / `wipeDataTables` helpers.
- **`metadata.go`** (new): `meta` key/value accessors with a real "missing key" sentinel kept distinct from SQL errors, so an absent stamp is never confused with a backend failure.
- **`index_path.go`** (new): default location moves out of the project tree to `$HOME/.codepathfinder/<project-hash>.sqlite` (16 hex chars of SHA-256 over the cleaned absolute root, so branches share one index). `--index-path` override and `CODEPATHFINDER_INDEX_PATH` env var; the parent directory is created for every resolved path.
- **`analysis_cache.go`**: options-based constructor (`OpenAnalysisCacheWithOptions`), global `schema_version` + `engine_version` stamps, and open-time auto-rebuild on mismatch or `--rebuild-index`. An **absent** stamp (a DB written by an older binary) is upgraded in place rather than wiped, so existing warm Go caches survive the first upgrade. Engine version is only compared when known, so an auxiliary command cannot clobber another command's stamp.
- **`scan.go`**: `--index-path` and `--rebuild-index` flags; the resolved index path is logged at debug verbosity.

`OpenAnalysisCache(projectRoot)` is retained as a thin wrapper so every existing caller and test keeps compiling. The per-table version mechanism, Go callgraph cache tables, and scan output are unchanged.

## Reconciliations vs the spec's illustrative code

- Reused the existing `meta` table instead of introducing a separate `metadata` table (renaming would orphan existing DBs for no benefit).
- Rebuild guard skips when the stored stamp is **absent** (vs the spec's literal `!= current`), so existing caches upgrade gracefully instead of being wiped on the first run of the new binary.

## Verification

- `gradle buildGo` clean; `go test ./...` green; `golangci-lint run` reports `0 issues`.
- New code unit-tested incl. SQL-error injection; `schema.go` and `metadata.go` at 100% line coverage.
- End-to-end on a Go project: fresh run creates all tables with correct meta stamps; second run reuses the warm cache (no rebuild); `--rebuild-index` rebuilds; an engine-version bump triggers `[cache] rebuilding index: engine 1.0.0 -> 2.1.1` and re-stamps.

Note: the repo `lintGo` gradle task chains `lintPython`, which is red on `main` due to pre-existing black formatting in three `python-sdk/` files. This PR touches zero Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)