### PR TITLE
feat(engine): persist Python definitions into fqn_index (PR-02)

### DIFF
--- a/sast-engine/cmd/ci.go
+++ b/sast-engine/cmd/ci.go
@@ -267,9 +267,32 @@ Examples:
 			logger.Debug("Skipping test files (use --skip-tests=false to include)")
 		}
 
+		// Open the analysis index (shared by the Python and Go builders), then
+		// build the call graph. The index persists the Python FQN surface as a
+		// side effect; opening it is best-effort and never blocks the scan.
+		var analysisCache *builder.AnalysisCache
+		if enableDBCache, _ := cmd.Flags().GetBool("enable-db-cache"); enableDBCache {
+			indexPath, _ := cmd.Flags().GetString("index-path")
+			rebuildIndex, _ := cmd.Flags().GetBool("rebuild-index")
+			var cacheErr error
+			analysisCache, cacheErr = builder.OpenAnalysisCacheWithOptions(builder.CacheOptions{
+				ProjectRoot:   projectPath,
+				IndexPath:     indexPath,
+				EngineVersion: Version,
+				ForceRebuild:  rebuildIndex,
+			})
+			if cacheErr != nil {
+				logger.Warning("Could not open analysis cache: %v. Running full analysis instead.", cacheErr)
+				analysisCache = nil
+			} else {
+				logger.Debug("Analysis index: %s", analysisCache.DBPath())
+				defer analysisCache.Close()
+			}
+		}
+
 		// Build callgraph
 		logger.StartProgress("Building callgraph", -1)
-		cg, err := builder.BuildCallGraph(codeGraph, moduleRegistry, projectPath, logger)
+		cg, err := builder.BuildCallGraphWithCache(codeGraph, moduleRegistry, projectPath, logger, analysisCache)
 		logger.FinishProgress()
 		if err != nil {
 			analytics.ReportEventWithProperties(analytics.CIFailed, map[string]any{
@@ -294,18 +317,7 @@ Examples:
 				builder.InitGoStdlibLoader(goRegistry, projectPath, logger)
 				goTypeEngine := resolution.NewGoTypeInferenceEngine(goRegistry)
 
-				enableDBCache, _ := cmd.Flags().GetBool("enable-db-cache")
-				var analysisCache *builder.AnalysisCache
-				if enableDBCache {
-					var cacheErr error
-					analysisCache, cacheErr = builder.OpenAnalysisCache(projectPath)
-					if cacheErr != nil {
-						logger.Warning("Could not open analysis cache: %v — running full analysis", cacheErr)
-					} else {
-						defer analysisCache.Close()
-					}
-				}
-
+				// Reuses the analysis cache opened above for the call-graph build.
 				goCG, err := builder.BuildGoCallGraph(codeGraph, goRegistry, goTypeEngine, logger, analysisCache)
 				if err != nil {
 					logger.Warning("Failed to build Go call graph: %v", err)
@@ -560,5 +572,7 @@ func init() {
 	ciCmd.Flags().Bool("pr-comment", false, "Post summary comment on the pull request")
 	ciCmd.Flags().Bool("pr-inline", false, "Post inline review comments for critical/high findings")
 	ciCmd.Flags().Bool("enable-db-cache", false, "Enable SQLite-backed incremental analysis cache (experimental)")
+	ciCmd.Flags().String("index-path", "", "Override the analysis index location (default $HOME/.codepathfinder/<project-hash>.sqlite; also reads CODEPATHFINDER_INDEX_PATH)")
+	ciCmd.Flags().Bool("rebuild-index", false, "Drop and rebuild the analysis index before scanning")
 	ciCmd.MarkFlagRequired("project")
 }

--- a/sast-engine/cmd/scan.go
+++ b/sast-engine/cmd/scan.go
@@ -246,9 +246,31 @@ Examples:
 			logger.Debug("Skipping test files (use --skip-tests=false to include)")
 		}
 
-		// Step 3: Build callgraph
+		// Step 3: Open the analysis index (shared by the Python and Go builders),
+		// then build the call graph. The index persists the Python FQN surface as
+		// a side effect; opening it is best-effort and never blocks the scan.
+		var analysisCache *builder.AnalysisCache
+		if enableDBCache, _ := cmd.Flags().GetBool("enable-db-cache"); enableDBCache {
+			indexPath, _ := cmd.Flags().GetString("index-path")
+			rebuildIndex, _ := cmd.Flags().GetBool("rebuild-index")
+			var cacheErr error
+			analysisCache, cacheErr = builder.OpenAnalysisCacheWithOptions(builder.CacheOptions{
+				ProjectRoot:   projectPath,
+				IndexPath:     indexPath,
+				EngineVersion: Version,
+				ForceRebuild:  rebuildIndex,
+			})
+			if cacheErr != nil {
+				logger.Warning("Could not open analysis cache: %v. Running full analysis instead.", cacheErr)
+				analysisCache = nil
+			} else {
+				logger.Debug("Analysis index: %s", analysisCache.DBPath())
+				defer analysisCache.Close()
+			}
+		}
+
 		logger.StartProgress("Building callgraph", -1)
-		cg, err := builder.BuildCallGraph(codeGraph, moduleRegistry, projectPath, logger)
+		cg, err := builder.BuildCallGraphWithCache(codeGraph, moduleRegistry, projectPath, logger, analysisCache)
 		logger.FinishProgress()
 		if err != nil {
 			analytics.ReportEventWithProperties(analytics.ScanFailed, map[string]any{
@@ -278,26 +300,7 @@ Examples:
 
 				goTypeEngine := resolution.NewGoTypeInferenceEngine(goRegistry)
 
-				enableDBCache, _ := cmd.Flags().GetBool("enable-db-cache")
-				var analysisCache *builder.AnalysisCache
-				if enableDBCache {
-					indexPath, _ := cmd.Flags().GetString("index-path")
-					rebuildIndex, _ := cmd.Flags().GetBool("rebuild-index")
-					var cacheErr error
-					analysisCache, cacheErr = builder.OpenAnalysisCacheWithOptions(builder.CacheOptions{
-						ProjectRoot:   projectPath,
-						IndexPath:     indexPath,
-						EngineVersion: Version,
-						ForceRebuild:  rebuildIndex,
-					})
-					if cacheErr != nil {
-						logger.Warning("Could not open analysis cache: %v. Running full analysis instead.", cacheErr)
-					} else {
-						logger.Debug("Analysis index: %s", analysisCache.DBPath())
-						defer analysisCache.Close()
-					}
-				}
-
+				// Reuses the analysis cache opened above for the call-graph build.
 				goCG, err := builder.BuildGoCallGraph(codeGraph, goRegistry, goTypeEngine, logger, analysisCache)
 				if err != nil {
 					logger.Warning("Failed to build Go call graph: %v", err)

--- a/sast-engine/graph/callgraph/builder/analysis_cache.go
+++ b/sast-engine/graph/callgraph/builder/analysis_cache.go
@@ -35,6 +35,7 @@ const (
 	pass4Version         = "1"
 	fqnIndexVersion      = "1"
 	callSitesVersion     = "1"
+	indexedFilesVersion  = "1"
 )
 
 // currentSchemaVersion is the global on-disk schema version. It is written into
@@ -219,6 +220,7 @@ var tableVersions = []tableVersion{
 	{"pass4_version", pass4Version, "pass4_results"},
 	{"fqn_index_version", fqnIndexVersion, "fqn_index"},
 	{"call_sites_version", callSitesVersion, "call_sites"},
+	{"indexed_files_version", indexedFilesVersion, "indexed_files"},
 }
 
 // reconcileVersions decides how much cached data to discard, assuming the
@@ -358,6 +360,7 @@ func stampMeta(db *sql.DB, opts CacheOptions) error {
 		"pass4_version":          pass4Version,
 		"fqn_index_version":      fqnIndexVersion,
 		"call_sites_version":     callSitesVersion,
+		"indexed_files_version":  indexedFilesVersion,
 	}
 	if opts.EngineVersion != "" {
 		stamps[metaEngineVersion] = opts.EngineVersion

--- a/sast-engine/graph/callgraph/builder/builder.go
+++ b/sast-engine/graph/callgraph/builder/builder.go
@@ -97,7 +97,18 @@ func getOptimalWorkerCount() int {
 //	  edges: {"myapp.views.get_user": ["myapp.utils.sanitize"]}
 //	  reverseEdges: {"myapp.utils.sanitize": ["myapp.views.get_user"]}
 //	  callSites: {"myapp.views.get_user": [CallSite{Target: "sanitize", ...}]}
+// BuildCallGraph builds the call graph without persisting an FQN index. It is
+// the form callers that do not opt into the analysis cache use (serve, the
+// integration wrappers, tests).
 func BuildCallGraph(codeGraph *graph.CodeGraph, registry *core.ModuleRegistry, projectRoot string, logger *output.Logger) (*core.CallGraph, error) {
+	return BuildCallGraphWithCache(codeGraph, registry, projectRoot, logger, nil)
+}
+
+// BuildCallGraphWithCache builds the call graph and, when cache is non-nil,
+// writes every discovered Python definition into the persisted fqn_index as a
+// side effect of the same analysis. The in-memory call graph it returns is
+// identical whether or not a cache is supplied.
+func BuildCallGraphWithCache(codeGraph *graph.CodeGraph, registry *core.ModuleRegistry, projectRoot string, logger *output.Logger, cache *AnalysisCache) (*core.CallGraph, error) {
 	callGraph := core.NewCallGraph()
 
 	// Initialize import map cache for performance
@@ -472,6 +483,18 @@ func BuildCallGraph(codeGraph *graph.CodeGraph, registry *core.ModuleRegistry, p
 	// Store registries for inheritance-aware matching in rule executors
 	callGraph.ThirdPartyRemote = typeEngine.ThirdPartyRemote
 	callGraph.StdlibRemote = typeEngine.StdlibRemote
+
+	// Persist the Python FQN index as a side effect of the same analysis. This
+	// is best-effort: a write failure is logged but never fails the scan, since
+	// the in-memory call graph is already complete and correct.
+	if cache != nil {
+		entries, files := collectPythonFqnEntries(callGraph, codeGraph, registry)
+		if err := cache.ReplacePythonFqnIndex(entries, files); err != nil {
+			logger.Warning("Failed to persist Python FQN index: %v", err)
+		} else {
+			logger.Debug("Persisted %d Python FQN entries across %d files", len(entries), len(files))
+		}
+	}
 
 	return callGraph, nil
 }

--- a/sast-engine/graph/callgraph/builder/file_mtime.go
+++ b/sast-engine/graph/callgraph/builder/file_mtime.go
@@ -1,0 +1,56 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// IndexedFile records that a file's definitions were written into fqn_index at a
+// known modification time. ModTimeUnix is the file's mtime at index time, used
+// to detect staleness on a later query.
+type IndexedFile struct {
+	Path        string
+	ModTimeUnix int64
+}
+
+// GetIndexedFileMtime returns the stored index-time mtime for a file. The bool
+// is false when the file has never been indexed (no row), which is distinct
+// from a SQL error.
+func (c *AnalysisCache) GetIndexedFileMtime(path string) (int64, bool, error) {
+	var mtime int64
+	err := c.db.QueryRowContext(context.Background(),
+		`SELECT indexed_at_mtime FROM indexed_files WHERE file_path=?`, path,
+	).Scan(&mtime)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("analysis cache: read indexed mtime for %s: %w", path, err)
+	}
+	return mtime, true, nil
+}
+
+// IsStale reports whether a file must be re-indexed before a query trusts its
+// fqn_index rows. A file is stale when it has never been indexed or when its
+// current mtime is newer than the indexed mtime.
+//
+// When os.Stat fails (the file was deleted or is unreadable) IsStale returns
+// (true, err): the stored rows can no longer be trusted, but the caller decides
+// whether to re-parse (it cannot, for a deleted file) or drop the rows.
+func (c *AnalysisCache) IsStale(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return true, fmt.Errorf("analysis cache: stat %s: %w", path, err)
+	}
+	indexedMtime, exists, err := c.GetIndexedFileMtime(path)
+	if err != nil {
+		return true, err
+	}
+	if !exists {
+		return true, nil
+	}
+	return info.ModTime().Unix() > indexedMtime, nil
+}

--- a/sast-engine/graph/callgraph/builder/file_mtime_test.go
+++ b/sast-engine/graph/callgraph/builder/file_mtime_test.go
@@ -1,0 +1,83 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetIndexedFileMtime_NeverIndexed(t *testing.T) {
+	cache := openTempCache(t)
+	_, ok, err := cache.GetIndexedFileMtime("/never/seen.py")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestIsStale_NeverIndexed(t *testing.T) {
+	cache := openTempCache(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "fresh.py")
+	require.NoError(t, os.WriteFile(f, []byte("x = 1\n"), 0o644))
+
+	stale, err := cache.IsStale(f)
+	require.NoError(t, err)
+	assert.True(t, stale, "a file never indexed is stale")
+}
+
+func TestIsStale_FreshThenTouched(t *testing.T) {
+	cache := openTempCache(t)
+	dir := t.TempDir()
+	f := filepath.Join(dir, "m.py")
+	require.NoError(t, os.WriteFile(f, []byte("x = 1\n"), 0o644))
+
+	info, err := os.Stat(f)
+	require.NoError(t, err)
+	require.NoError(t, cache.ReplacePythonFqnIndex(nil, []IndexedFile{{Path: f, ModTimeUnix: info.ModTime().Unix()}}))
+
+	stale, err := cache.IsStale(f)
+	require.NoError(t, err)
+	assert.False(t, stale, "a file indexed at its current mtime is fresh")
+
+	// Advance mtime past the stamp.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(f, future, future))
+
+	stale, err = cache.IsStale(f)
+	require.NoError(t, err)
+	assert.True(t, stale, "a file touched after indexing is stale")
+}
+
+func TestIsStale_DeletedFile(t *testing.T) {
+	cache := openTempCache(t)
+	stale, err := cache.IsStale("/proj/deleted.py")
+	assert.True(t, stale, "a missing file is reported stale")
+	assert.Error(t, err, "stat failure is surfaced so the caller can drop the rows")
+}
+
+func TestGetIndexedFileMtime_ClosedDBErrors(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	require.NoError(t, cache.Close())
+
+	_, _, err = cache.GetIndexedFileMtime("/a.py")
+	assert.Error(t, err)
+}
+
+func TestIsStale_DBErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+
+	f := filepath.Join(dir, "live.py")
+	require.NoError(t, os.WriteFile(f, []byte("x = 1\n"), 0o644))
+	require.NoError(t, cache.Close()) // close so the mtime lookup errors, but stat still succeeds
+
+	stale, err := cache.IsStale(f)
+	assert.True(t, stale)
+	assert.Error(t, err, "a DB error during staleness check must surface, defaulting to stale")
+}

--- a/sast-engine/graph/callgraph/builder/fqn_collect.go
+++ b/sast-engine/graph/callgraph/builder/fqn_collect.go
@@ -1,0 +1,133 @@
+package builder
+
+import (
+	"os"
+	"strings"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/graph"
+	"github.com/shivasurya/code-pathfinder/sast-engine/graph/callgraph/core"
+)
+
+// pythonNodeKind maps a tree-sitter Python definition node type to the kind
+// stored in fqn_index. The empty string means "not a Python definition we index
+// here" (PR-02 indexes callables and classes; module-level variables and import
+// aliases are a follow-up).
+func pythonNodeKind(nodeType string) string {
+	switch nodeType {
+	case "function_definition":
+		return "function"
+	case "method", "constructor", "property", "special_method":
+		return "method"
+	case "class_definition", "dataclass":
+		return "class"
+	default:
+		return ""
+	}
+}
+
+// isPythonFile reports whether a path is a Python source file.
+func isPythonFile(path string) bool {
+	return strings.HasSuffix(path, ".py")
+}
+
+// parentFqn returns the enclosing module/class FQN by dropping the last
+// dot-segment. "app.models.User.save" -> "app.models.User"; "app.models.User"
+// -> "app.models"; a name with no dot -> "".
+func parentFqn(fqn string) string {
+	if i := strings.LastIndex(fqn, "."); i >= 0 {
+		return fqn[:i]
+	}
+	return ""
+}
+
+// pythonSignature renders a callable's signature from its typed parameters and
+// return annotation, e.g. "(user: User, force: bool) -> None". Classes and
+// nodes without parameters or a return type yield "".
+func pythonSignature(node *graph.Node) string {
+	if len(node.MethodArgumentsType) == 0 && node.ReturnType == "" {
+		return ""
+	}
+	sig := "(" + strings.Join(node.MethodArgumentsType, ", ") + ")"
+	if node.ReturnType != "" {
+		sig += " -> " + node.ReturnType
+	}
+	return sig
+}
+
+// collectPythonFqnEntries enumerates every Python function, method, and class
+// the build discovered and returns them as fqn_index rows plus the set of
+// Python source files to stamp in indexed_files.
+//
+// Every entry is source="project": these are definitions written in the
+// scanned project's own files. Stdlib/thirdparty symbols are resolution
+// targets, not project definitions, and are out of scope here.
+func collectPythonFqnEntries(
+	callGraph *core.CallGraph,
+	codeGraph *graph.CodeGraph,
+	registry *core.ModuleRegistry,
+) ([]FqnEntry, []IndexedFile) {
+	entries := make([]FqnEntry, 0, len(callGraph.Functions))
+	seen := make(map[string]bool, len(callGraph.Functions))
+
+	add := func(fqn string, node *graph.Node, kind, signature string) {
+		if seen[fqn] {
+			return
+		}
+		seen[fqn] = true
+		entries = append(entries, FqnEntry{
+			Fqn:       fqn,
+			Language:  "python",
+			Kind:      kind,
+			Source:    "project",
+			File:      nullStr(node.File),
+			StartLine: nullInt(int(node.LineNumber)),
+			ParentFqn: nullStr(parentFqn(fqn)),
+			Signature: nullStr(signature),
+		})
+	}
+
+	// Functions and methods are keyed by FQN in the call graph.
+	for fqn, node := range callGraph.Functions {
+		if node == nil || !isPythonFile(node.File) {
+			continue
+		}
+		kind := pythonNodeKind(node.Type)
+		if kind == "" {
+			continue
+		}
+		add(fqn, node, kind, pythonSignature(node))
+	}
+
+	// Classes are not call-graph functions; enumerate them from the code graph.
+	for _, node := range codeGraph.Nodes {
+		if node == nil || !isPythonFile(node.File) || pythonNodeKind(node.Type) != "class" {
+			continue
+		}
+		modulePath, ok := registry.FileToModule[node.File]
+		if !ok {
+			continue
+		}
+		add(modulePath+"."+node.Name, node, "class", "")
+	}
+
+	return entries, collectPythonIndexedFiles(registry)
+}
+
+// collectPythonIndexedFiles returns every Python source file the build knows
+// about, with its current mtime, so each is stamped in indexed_files. Files
+// that cannot be stat'd (race with a delete) are skipped: a missing stamp just
+// makes the file look stale to a later query, which is the safe default.
+func collectPythonIndexedFiles(registry *core.ModuleRegistry) []IndexedFile {
+	files := make([]IndexedFile, 0, len(registry.FileToModule))
+	for file := range registry.FileToModule {
+		if !isPythonFile(file) {
+			continue
+		}
+		info, err := os.Stat(file)
+		if err != nil {
+			continue
+		}
+		files = append(files, IndexedFile{Path: file, ModTimeUnix: info.ModTime().Unix()})
+	}
+	return files
+}

--- a/sast-engine/graph/callgraph/builder/fqn_collect_test.go
+++ b/sast-engine/graph/callgraph/builder/fqn_collect_test.go
@@ -1,0 +1,165 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/graph"
+	"github.com/shivasurya/code-pathfinder/sast-engine/graph/callgraph/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPythonNodeKind(t *testing.T) {
+	cases := map[string]string{
+		"function_definition": "function",
+		"method":              "method",
+		"constructor":         "method",
+		"property":            "method",
+		"special_method":      "method",
+		"class_definition":    "class",
+		"dataclass":           "class",
+		"method_declaration":  "", // Java; not indexed here
+		"call":                "",
+	}
+	for nodeType, want := range cases {
+		assert.Equal(t, want, pythonNodeKind(nodeType), "kind for %q", nodeType)
+	}
+}
+
+func TestIsPythonFile(t *testing.T) {
+	assert.True(t, isPythonFile("/a/b/models.py"))
+	assert.False(t, isPythonFile("/a/b/main.go"))
+	assert.False(t, isPythonFile("/a/b/py"))
+}
+
+func TestParentFqn(t *testing.T) {
+	assert.Equal(t, "app.models.User", parentFqn("app.models.User.save"))
+	assert.Equal(t, "app.models", parentFqn("app.models.User"))
+	assert.Equal(t, "app", parentFqn("app.helper"))
+	assert.Equal(t, "", parentFqn("toplevel"))
+}
+
+func TestPythonSignature(t *testing.T) {
+	assert.Equal(t, "(user: User, force: bool) -> None",
+		pythonSignature(&graph.Node{MethodArgumentsType: []string{"user: User", "force: bool"}, ReturnType: "None"}))
+	assert.Equal(t, "(x: int)",
+		pythonSignature(&graph.Node{MethodArgumentsType: []string{"x: int"}}))
+	assert.Equal(t, "() -> str",
+		pythonSignature(&graph.Node{ReturnType: "str"}))
+	assert.Equal(t, "", pythonSignature(&graph.Node{}), "no args and no return type yields no signature")
+}
+
+func TestCollectPythonFqnEntries(t *testing.T) {
+	pyFile := "/proj/app/models.py"
+	goFile := "/proj/main.go"
+
+	fn := &graph.Node{Type: "function_definition", Name: "sanitize", File: pyFile, LineNumber: 10, MethodArgumentsType: []string{"s: str"}, ReturnType: "str"}
+	method := &graph.Node{Type: "method", Name: "save", File: pyFile, LineNumber: 20}
+	goFn := &graph.Node{Type: "function_definition", Name: "Main", File: goFile, LineNumber: 3}
+
+	cg := core.NewCallGraph()
+	cg.Functions["app.models.sanitize"] = fn
+	cg.Functions["app.models.User.save"] = method
+	cg.Functions["main.Main"] = goFn // non-python: must be skipped
+
+	classNode := &graph.Node{Type: "class_definition", Name: "User", File: pyFile, LineNumber: 15}
+	codeGraph := &graph.CodeGraph{Nodes: map[string]*graph.Node{"c1": classNode}}
+
+	registry := core.NewModuleRegistry()
+	registry.FileToModule[pyFile] = "app.models"
+	registry.FileToModule[goFile] = "main"
+
+	entries, files := collectPythonFqnEntries(cg, codeGraph, registry)
+
+	byFqn := make(map[string]FqnEntry, len(entries))
+	for _, e := range entries {
+		byFqn[e.Fqn] = e
+		assert.Equal(t, "python", e.Language)
+		assert.Equal(t, "project", e.Source)
+	}
+
+	require.Contains(t, byFqn, "app.models.sanitize")
+	require.Contains(t, byFqn, "app.models.User.save")
+	require.Contains(t, byFqn, "app.models.User")
+	assert.NotContains(t, byFqn, "main.Main", "Go functions must not be indexed as python")
+	assert.Len(t, entries, 3)
+
+	fnEntry := byFqn["app.models.sanitize"]
+	assert.Equal(t, "function", fnEntry.Kind)
+	assert.Equal(t, "app.models", fnEntry.ParentFqn.String)
+	assert.Equal(t, "(s: str) -> str", fnEntry.Signature.String)
+	assert.Equal(t, int64(10), fnEntry.StartLine.Int64)
+	assert.Equal(t, pyFile, fnEntry.File.String)
+
+	methodEntry := byFqn["app.models.User.save"]
+	assert.Equal(t, "method", methodEntry.Kind)
+	assert.Equal(t, "app.models.User", methodEntry.ParentFqn.String)
+	assert.False(t, methodEntry.Signature.Valid, "no args/return -> NULL signature")
+
+	classEntry := byFqn["app.models.User"]
+	assert.Equal(t, "class", classEntry.Kind)
+	assert.Equal(t, "app.models", classEntry.ParentFqn.String)
+
+	// Only the python file is stamped for staleness; the .go file is excluded.
+	require.Len(t, files, 0, "files with no on-disk presence are skipped by stat; none exist in this unit test")
+	_ = files
+}
+
+// TestCollectPythonFqnEntries_NilAndUnknownNodes ensures defensive skips:
+// a nil node, a node in a non-registered file, and an unindexed node type.
+func TestCollectPythonFqnEntries_SkipsNonDefinitions(t *testing.T) {
+	pyFile := "/proj/app/x.py"
+	cg := core.NewCallGraph()
+	cg.Functions["app.x.fn"] = &graph.Node{Type: "function_definition", Name: "fn", File: pyFile, LineNumber: 1}
+	cg.Functions["app.x.nilnode"] = nil
+	cg.Functions["app.x.var"] = &graph.Node{Type: "assignment", Name: "var", File: pyFile, LineNumber: 2} // not a def
+
+	// A class node whose file is not in the registry must be skipped.
+	codeGraph := &graph.CodeGraph{Nodes: map[string]*graph.Node{
+		"c1": {Type: "class_definition", Name: "Orphan", File: "/unregistered.py", LineNumber: 3},
+		"c2": nil,
+	}}
+
+	registry := core.NewModuleRegistry()
+	registry.FileToModule[pyFile] = "app.x"
+
+	entries, _ := collectPythonFqnEntries(cg, codeGraph, registry)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "app.x.fn", entries[0].Fqn)
+}
+
+// TestCollectPythonFqnEntries_DedupesRepeatedClassNodes verifies the seen-set:
+// two class nodes resolving to the same FQN produce a single entry.
+func TestCollectPythonFqnEntries_DedupesRepeatedClassNodes(t *testing.T) {
+	pyFile := "/proj/app/d.py"
+	codeGraph := &graph.CodeGraph{Nodes: map[string]*graph.Node{
+		"c1": {Type: "class_definition", Name: "Dup", File: pyFile, LineNumber: 1},
+		"c2": {Type: "class_definition", Name: "Dup", File: pyFile, LineNumber: 1},
+	}}
+	registry := core.NewModuleRegistry()
+	registry.FileToModule[pyFile] = "app.d"
+
+	entries, _ := collectPythonFqnEntries(core.NewCallGraph(), codeGraph, registry)
+	require.Len(t, entries, 1, "the same class FQN must be indexed once")
+	assert.Equal(t, "app.d.Dup", entries[0].Fqn)
+}
+
+// TestCollectPythonIndexedFiles_StampsRealFilesSkipsMissing verifies that an
+// on-disk python file is stamped while a registered-but-missing path is skipped.
+func TestCollectPythonIndexedFiles_StampsRealFilesSkipsMissing(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "real.py")
+	require.NoError(t, os.WriteFile(present, []byte("x = 1\n"), 0o644))
+
+	registry := core.NewModuleRegistry()
+	registry.FileToModule[present] = "real"
+	registry.FileToModule["/does/not/exist.py"] = "ghost"
+	registry.FileToModule[filepath.Join(dir, "main.go")] = "main" // non-python, skipped
+
+	files := collectPythonIndexedFiles(registry)
+	require.Len(t, files, 1, "only the existing python file is stamped")
+	assert.Equal(t, present, files[0].Path)
+	assert.Positive(t, files[0].ModTimeUnix)
+}

--- a/sast-engine/graph/callgraph/builder/fqn_integration_test.go
+++ b/sast-engine/graph/callgraph/builder/fqn_integration_test.go
@@ -1,0 +1,102 @@
+package builder
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shivasurya/code-pathfinder/sast-engine/graph"
+	"github.com/shivasurya/code-pathfinder/sast-engine/graph/callgraph/registry"
+	"github.com/shivasurya/code-pathfinder/sast-engine/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countPythonFqns returns how many python rows fqn_index holds.
+func countPythonFqns(t *testing.T, cache *AnalysisCache) int {
+	t.Helper()
+	var n int
+	require.NoError(t, cache.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM fqn_index WHERE language='python'`).Scan(&n))
+	return n
+}
+
+// TestBuildCallGraphWithCache_PersistsPythonFqnIndex drives the whole PR-02 path
+// in-process: parse a real Python project, build the call graph with a cache,
+// and assert the discovered definitions landed in fqn_index with their files
+// stamped for staleness.
+func TestBuildCallGraphWithCache_PersistsPythonFqnIndex(t *testing.T) {
+	dir := t.TempDir()
+	src := `GLOBAL = "x"
+
+def sanitize(value):
+    return value.strip()
+
+class User:
+    def __init__(self, name):
+        self.name = name
+
+    def save(self):
+        return sanitize(self.name)
+`
+	modelsPy := filepath.Join(dir, "models.py")
+	require.NoError(t, os.WriteFile(modelsPy, []byte(src), 0o644))
+
+	codeGraph := graph.Initialize(dir, nil)
+	require.NotNil(t, codeGraph)
+	moduleRegistry, err := registry.BuildModuleRegistry(dir, false)
+	require.NoError(t, err)
+
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	defer cache.Close()
+
+	logger := output.NewLogger(output.VerbosityDefault)
+	cg, err := BuildCallGraphWithCache(codeGraph, moduleRegistry, dir, logger, cache)
+	require.NoError(t, err)
+	require.NotNil(t, cg)
+
+	// The function, the class, and both methods should be indexed.
+	assert.GreaterOrEqual(t, countPythonFqns(t, cache), 4, "function + class + two methods expected")
+
+	for _, fqn := range []string{"models.sanitize", "models.User", "models.User.save", "models.User.__init__"} {
+		var got string
+		err := cache.db.QueryRowContext(context.Background(),
+			`SELECT fqn FROM fqn_index WHERE fqn=? AND language='python'`, fqn).Scan(&got)
+		require.NoError(t, err, "expected %s in fqn_index", fqn)
+	}
+
+	// Every indexed entry is project source.
+	var nonProject int
+	require.NoError(t, cache.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM fqn_index WHERE language='python' AND source<>'project'`).Scan(&nonProject))
+	assert.Zero(t, nonProject)
+
+	// models.py is stamped for staleness, and a fresh check sees it as current.
+	stale, err := cache.IsStale(modelsPy)
+	require.NoError(t, err)
+	assert.False(t, stale, "the file just indexed should not be stale")
+}
+
+// TestBuildCallGraph_NilCacheWritesNothing verifies the cache-disabled branch:
+// the no-cache wrapper builds an identical graph and persists nothing.
+func TestBuildCallGraph_NilCacheWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "m.py"), []byte("def f():\n    return 1\n"), 0o644))
+
+	codeGraph := graph.Initialize(dir, nil)
+	moduleRegistry, err := registry.BuildModuleRegistry(dir, false)
+	require.NoError(t, err)
+
+	logger := output.NewLogger(output.VerbosityDefault)
+	cg, err := BuildCallGraph(codeGraph, moduleRegistry, dir, logger)
+	require.NoError(t, err)
+	assert.NotEmpty(t, cg.Functions, "the graph is still built without a cache")
+
+	// A separately opened cache for the same project has no python rows.
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	defer cache.Close()
+	assert.Zero(t, countPythonFqns(t, cache), "no cache passed -> nothing persisted")
+}

--- a/sast-engine/graph/callgraph/builder/fqn_writer.go
+++ b/sast-engine/graph/callgraph/builder/fqn_writer.go
@@ -1,0 +1,112 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// FqnEntry is one row of the fqn_index table: a single definition the engine
+// discovered, with its location and classification. Nullable columns use
+// sql.Null* so "absent" (a synthetic entry with no file, a variable with no
+// signature) is distinct from an empty string or a zero line.
+type FqnEntry struct {
+	Fqn       string
+	Language  string
+	Kind      string // function | class | method | module | variable | import_alias
+	Source    string // project | stdlib | thirdparty
+	File      sql.NullString
+	StartLine sql.NullInt64
+	StartCol  sql.NullInt64
+	EndLine   sql.NullInt64
+	EndCol    sql.NullInt64
+	ParentFqn sql.NullString
+	Signature sql.NullString
+}
+
+// nullStr returns a valid sql.NullString only for a non-empty value.
+func nullStr(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+// nullInt returns a valid sql.NullInt64 only for a positive value. Lines and
+// columns are 1-indexed in the engine, so 0 means "unknown".
+func nullInt(v int) sql.NullInt64 {
+	return sql.NullInt64{Int64: int64(v), Valid: v > 0}
+}
+
+// ReplacePythonFqnIndex atomically refreshes the Python slice of the index:
+// it deletes every existing python row in fqn_index, inserts the supplied
+// entries, and stamps each file's mtime in indexed_files, all in one
+// transaction. A full BuildCallGraph run rediscovers every Python definition,
+// so replacing the whole python slice keeps the index free of rows for deleted
+// or renamed symbols without a per-file diff.
+//
+// Only python rows are touched; Go's function_index/pass4 caches are unaffected.
+func (c *AnalysisCache) ReplacePythonFqnIndex(entries []FqnEntry, files []IndexedFile) error {
+	ctx := context.Background()
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("analysis cache: begin fqn tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM fqn_index WHERE language='python'`); err != nil {
+		return fmt.Errorf("analysis cache: clear python fqn_index: %w", err)
+	}
+
+	insert, err := tx.PrepareContext(ctx, `INSERT INTO fqn_index
+		(fqn, language, kind, source, file, start_line, start_col, end_line, end_col, parent_fqn, signature, schema_version)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`)
+	if err != nil {
+		return fmt.Errorf("analysis cache: prepare fqn insert: %w", err)
+	}
+	defer insert.Close()
+
+	for _, e := range entries {
+		if _, err := insert.ExecContext(ctx,
+			e.Fqn, e.Language, e.Kind, e.Source, e.File,
+			e.StartLine, e.StartCol, e.EndLine, e.EndCol,
+			e.ParentFqn, e.Signature, currentSchemaVersion,
+		); err != nil {
+			return fmt.Errorf("analysis cache: insert fqn %q: %w", e.Fqn, err)
+		}
+	}
+
+	mark, err := tx.PrepareContext(ctx,
+		`INSERT OR REPLACE INTO indexed_files(file_path, indexed_at_mtime, indexed_at) VALUES(?,?,?)`)
+	if err != nil {
+		return fmt.Errorf("analysis cache: prepare indexed_files insert: %w", err)
+	}
+	defer mark.Close()
+
+	now := time.Now().Unix()
+	for _, f := range files {
+		if _, err := mark.ExecContext(ctx, f.Path, f.ModTimeUnix, now); err != nil {
+			return fmt.Errorf("analysis cache: mark indexed %s: %w", f.Path, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// LookupFqn returns the indexed definition whose recorded start location is the
+// given file and line. The bool is false when no definition starts there. It is
+// the reader PR-04's `pathfinder fqn` CLI consumes; col is accepted for forward
+// compatibility but definition rows currently index on (file, start_line).
+func (c *AnalysisCache) LookupFqn(file string, line, _ int) (FqnEntry, bool, error) {
+	var e FqnEntry
+	err := c.db.QueryRowContext(context.Background(),
+		`SELECT fqn, language, kind, source, file, start_line, start_col, end_line, end_col, parent_fqn, signature
+		 FROM fqn_index WHERE file=? AND start_line=? LIMIT 1`, file, line,
+	).Scan(&e.Fqn, &e.Language, &e.Kind, &e.Source, &e.File,
+		&e.StartLine, &e.StartCol, &e.EndLine, &e.EndCol, &e.ParentFqn, &e.Signature)
+	if err == sql.ErrNoRows {
+		return FqnEntry{}, false, nil
+	}
+	if err != nil {
+		return FqnEntry{}, false, fmt.Errorf("analysis cache: lookup fqn at %s:%d: %w", file, line, err)
+	}
+	return e, true, nil
+}

--- a/sast-engine/graph/callgraph/builder/fqn_writer_test.go
+++ b/sast-engine/graph/callgraph/builder/fqn_writer_test.go
@@ -1,0 +1,208 @@
+package builder
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func pyEntry(fqn, kind, file string, line int) FqnEntry {
+	return FqnEntry{
+		Fqn:       fqn,
+		Language:  "python",
+		Kind:      kind,
+		Source:    "project",
+		File:      nullStr(file),
+		StartLine: nullInt(line),
+		ParentFqn: nullStr(parentFqn(fqn)),
+	}
+}
+
+func TestReplacePythonFqnIndex_WriteAndLookup(t *testing.T) {
+	cache := openTempCache(t)
+	entries := []FqnEntry{
+		pyEntry("app.models.sanitize", "function", "/proj/app/models.py", 10),
+		pyEntry("app.models.User", "class", "/proj/app/models.py", 15),
+	}
+	require.NoError(t, cache.ReplacePythonFqnIndex(entries, nil))
+
+	got, ok, err := cache.LookupFqn("/proj/app/models.py", 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "app.models.sanitize", got.Fqn)
+	assert.Equal(t, "function", got.Kind)
+	assert.Equal(t, "project", got.Source)
+	assert.Equal(t, "app.models", got.ParentFqn.String)
+}
+
+func TestLookupFqn_Miss(t *testing.T) {
+	cache := openTempCache(t)
+	_, ok, err := cache.LookupFqn("/nope.py", 1, 0)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestReplacePythonFqnIndex_ReplacesPreviousPythonRows(t *testing.T) {
+	cache := openTempCache(t)
+	require.NoError(t, cache.ReplacePythonFqnIndex([]FqnEntry{
+		pyEntry("app.old.gone", "function", "/proj/old.py", 1),
+	}, nil))
+	require.NoError(t, cache.ReplacePythonFqnIndex([]FqnEntry{
+		pyEntry("app.new.fresh", "function", "/proj/new.py", 1),
+	}, nil))
+
+	_, ok, err := cache.LookupFqn("/proj/old.py", 1, 0)
+	require.NoError(t, err)
+	assert.False(t, ok, "the previous python slice must be gone after a replace")
+
+	_, ok, err = cache.LookupFqn("/proj/new.py", 1, 0)
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestReplacePythonFqnIndex_LeavesNonPythonRowsIntact(t *testing.T) {
+	cache := openTempCache(t)
+	// Seed a non-python row directly.
+	_, err := cache.db.ExecContext(context.Background(),
+		`INSERT INTO fqn_index(fqn, language, kind, source, file, start_line, schema_version)
+		 VALUES('pkg.GoFn','go','function','project','/proj/main.go',3,?)`, currentSchemaVersion)
+	require.NoError(t, err)
+
+	require.NoError(t, cache.ReplacePythonFqnIndex([]FqnEntry{
+		pyEntry("app.x.fn", "function", "/proj/x.py", 1),
+	}, nil))
+
+	var goRows int
+	require.NoError(t, cache.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM fqn_index WHERE language='go'`).Scan(&goRows))
+	assert.Equal(t, 1, goRows, "a python replace must not touch go rows")
+}
+
+func TestReplacePythonFqnIndex_NullableColumns(t *testing.T) {
+	cache := openTempCache(t)
+	// An entry with no file and no signature should store NULLs, not empty strings.
+	e := FqnEntry{Fqn: "synthetic.thing", Language: "python", Kind: "function", Source: "project"}
+	require.NoError(t, cache.ReplacePythonFqnIndex([]FqnEntry{e}, nil))
+
+	var file, signature sql.NullString
+	err := cache.db.QueryRowContext(context.Background(),
+		`SELECT file, signature FROM fqn_index WHERE fqn='synthetic.thing'`).Scan(&file, &signature)
+	require.NoError(t, err)
+	assert.False(t, file.Valid, "empty file must be NULL")
+	assert.False(t, signature.Valid, "empty signature must be NULL")
+}
+
+func TestReplacePythonFqnIndex_StampsIndexedFiles(t *testing.T) {
+	cache := openTempCache(t)
+	files := []IndexedFile{{Path: "/proj/app/models.py", ModTimeUnix: 1700000000}}
+	require.NoError(t, cache.ReplacePythonFqnIndex(nil, files))
+
+	mtime, ok, err := cache.GetIndexedFileMtime("/proj/app/models.py")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, int64(1700000000), mtime)
+}
+
+func TestReplacePythonFqnIndex_ClosedDBErrors(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	require.NoError(t, cache.Close())
+
+	err = cache.ReplacePythonFqnIndex([]FqnEntry{pyEntry("a.b", "function", "/a.py", 1)}, nil)
+	assert.Error(t, err)
+}
+
+func TestLookupFqn_ClosedDBErrors(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := OpenAnalysisCache(dir)
+	require.NoError(t, err)
+	require.NoError(t, cache.Close())
+
+	_, _, err = cache.LookupFqn("/a.py", 1, 0)
+	assert.Error(t, err)
+}
+
+func TestReplacePythonFqnIndex_DeleteErrorWhenTableDropped(t *testing.T) {
+	cache := openTempCache(t)
+	_, err := cache.db.ExecContext(context.Background(), `DROP TABLE fqn_index`)
+	require.NoError(t, err)
+
+	err = cache.ReplacePythonFqnIndex([]FqnEntry{pyEntry("a.b", "function", "/a.py", 1)}, nil)
+	assert.Error(t, err, "DELETE on a dropped fqn_index must surface")
+}
+
+func TestReplacePythonFqnIndex_MarkErrorWhenIndexedFilesDropped(t *testing.T) {
+	cache := openTempCache(t)
+	_, err := cache.db.ExecContext(context.Background(), `DROP TABLE indexed_files`)
+	require.NoError(t, err)
+
+	err = cache.ReplacePythonFqnIndex(
+		[]FqnEntry{pyEntry("a.b", "function", "/a.py", 1)},
+		[]IndexedFile{{Path: "/a.py", ModTimeUnix: 1}},
+	)
+	assert.Error(t, err, "stamping indexed_files when the table is gone must surface")
+}
+
+// fqnIndexCols is the column list ReplacePythonFqnIndex inserts into. Tests that
+// recreate the table to inject failures keep it in sync.
+const fqnIndexCols = `fqn, language, kind, source, file, start_line, start_col, end_line, end_col, parent_fqn, signature, schema_version`
+
+func TestReplacePythonFqnIndex_PrepareErrorOnColumnMismatch(t *testing.T) {
+	cache := openTempCache(t)
+	// Replace fqn_index with a table that has the wrong shape so the 12-column
+	// INSERT cannot be prepared (the DELETE still succeeds first).
+	_, err := cache.db.ExecContext(context.Background(), `DROP TABLE fqn_index`)
+	require.NoError(t, err)
+	_, err = cache.db.ExecContext(context.Background(), `CREATE TABLE fqn_index(fqn TEXT)`)
+	require.NoError(t, err)
+
+	err = cache.ReplacePythonFqnIndex([]FqnEntry{pyEntry("a.b", "function", "/a.py", 1)}, nil)
+	assert.Error(t, err, "a shape mismatch must surface as a prepare error")
+}
+
+func TestReplacePythonFqnIndex_InsertErrorRollsBack(t *testing.T) {
+	cache := openTempCache(t)
+	// Seed a good row, then rebuild fqn_index with a CHECK that the next write
+	// violates. The whole call must fail and roll back, leaving the seed intact.
+	require.NoError(t, cache.ReplacePythonFqnIndex([]FqnEntry{pyEntry("keep.me", "function", "/keep.py", 1)}, nil))
+	_, err := cache.db.ExecContext(context.Background(), `DROP TABLE fqn_index`)
+	require.NoError(t, err)
+	_, err = cache.db.ExecContext(context.Background(),
+		`CREATE TABLE fqn_index(`+fqnIndexCols+`, CHECK(kind <> 'class'))`)
+	require.NoError(t, err)
+	require.NoError(t, cache.ReplacePythonFqnIndex([]FqnEntry{pyEntry("keep.me", "function", "/keep.py", 1)}, nil))
+
+	err = cache.ReplacePythonFqnIndex([]FqnEntry{pyEntry("bad.cls", "class", "/bad.py", 1)}, nil)
+	require.Error(t, err, "a CHECK violation mid-insert must surface")
+
+	// Rollback: the prior good row survives, the bad row is absent.
+	_, ok, err := cache.LookupFqn("/keep.py", 1, 0)
+	require.NoError(t, err)
+	assert.True(t, ok, "the transaction must roll back, preserving the previous slice")
+}
+
+func TestReplacePythonFqnIndex_MarkExecErrorRollsBack(t *testing.T) {
+	cache := openTempCache(t)
+	// Rebuild indexed_files with a CHECK the stamp violates, so the insert phase
+	// succeeds but the mark phase fails.
+	_, err := cache.db.ExecContext(context.Background(), `DROP TABLE indexed_files`)
+	require.NoError(t, err)
+	_, err = cache.db.ExecContext(context.Background(),
+		`CREATE TABLE indexed_files(file_path TEXT PRIMARY KEY, indexed_at_mtime INTEGER NOT NULL, indexed_at INTEGER NOT NULL, CHECK(file_path <> '/bad.py'))`)
+	require.NoError(t, err)
+
+	err = cache.ReplacePythonFqnIndex(
+		[]FqnEntry{pyEntry("a.b", "function", "/a.py", 1)},
+		[]IndexedFile{{Path: "/bad.py", ModTimeUnix: 1}},
+	)
+	require.Error(t, err, "a CHECK violation while stamping must surface")
+
+	// Rollback: the entry written before the failing stamp must not persist.
+	_, ok, err := cache.LookupFqn("/a.py", 1, 0)
+	require.NoError(t, err)
+	assert.False(t, ok, "the whole transaction must roll back")
+}

--- a/sast-engine/graph/callgraph/builder/schema.go
+++ b/sast-engine/graph/callgraph/builder/schema.go
@@ -76,6 +76,16 @@ const (
 		diagnostics     TEXT,
 		schema_version  INTEGER NOT NULL
 	)`
+
+	// indexed_files: per-file mtime stamp recorded when a file's definitions were
+	// last written into fqn_index. A later query compares the file's current
+	// mtime against indexed_at_mtime to decide whether the file is stale and its
+	// rows must be refreshed before the query answers.
+	ddlIndexedFiles = `CREATE TABLE IF NOT EXISTS indexed_files (
+		file_path          TEXT    PRIMARY KEY,
+		indexed_at_mtime   INTEGER NOT NULL,
+		indexed_at         INTEGER NOT NULL
+	)`
 )
 
 // schemaStmts is the ordered list of DDL applied at open time. Tables first,
@@ -87,6 +97,7 @@ var schemaStmts = []string{
 	ddlPass4Results,
 	ddlFqnIndex,
 	ddlCallSites,
+	ddlIndexedFiles,
 	`CREATE INDEX IF NOT EXISTS idx_fqn_exact    ON fqn_index(fqn)`,
 	`CREATE INDEX IF NOT EXISTS idx_fqn_prefix   ON fqn_index(fqn COLLATE NOCASE)`,
 	`CREATE INDEX IF NOT EXISTS idx_location     ON fqn_index(file, start_line)`,
@@ -104,6 +115,7 @@ var dataTables = []string{
 	"pass4_results",
 	"fqn_index",
 	"call_sites",
+	"indexed_files",
 }
 
 // applySchema creates every table and index if absent. It is wrapped in a


### PR DESCRIPTION
**Stack**: PR-02 of 14 (Rule Authoring Toolchain, Phase 0). **Stacked on #719 (PR-01)** — review/merge that first; this PR's base is the PR-01 branch so the diff is scoped to PR-02.

## What

Populate the persisted FQN index (added empty in PR-01) with every Python function, method, and class the engine discovers during a scan, plus per-file mtime stamps so a later query can detect stale files. The index is a side effect of the same call-graph build, not a second analysis. The in-memory call graph is identical with or without a cache.

## Changes

- **`BuildCallGraphWithCache`** (builder.go): new entry point taking an `*AnalysisCache`; after the existing passes it writes the Python FQN slice. `BuildCallGraph` stays a nil-cache wrapper so `serve`/integration/tests are untouched (the PR-01 `OpenAnalysisCache` pattern).
- **`fqn_collect.go`**: enumerates functions/methods (from `callGraph.Functions`) and classes (from the code graph) into `fqn_index` rows with kind, parent FQN, signature, start line. Every entry is `source="project"`: these are definitions in the scanned project's own `.py` files.
- **`fqn_writer.go`**: `ReplacePythonFqnIndex` atomically swaps the python slice of `fqn_index` and stamps `indexed_files`, in one transaction; `LookupFqn` reader for PR-04. Go's `function_index`/`pass4` caches are never touched.
- **`file_mtime.go`**: `indexed_files` table + `IsStale`/`GetIndexedFileMtime`, mtime-based per the spec (no checksum).
- **`scan`/`ci`**: the analysis cache is now opened **once before the call-graph build** and shared by the Python and Go builders (was Go-only). `--index-path`/`--rebuild-index` added to `ci` for parity with `scan`.

## Decisions (documented)

- **Module-level variables and import aliases are deferred** to a Phase 0 follow-up. They depend on internal scope/import-map iteration whose stable contract is not established; emitting uncertain rows would be worse than indexing the callable definitions rules actually match. This is an explicit choice, not a silent gap.
- **No global schema bump.** `indexed_files` is additive (`CREATE TABLE IF NOT EXISTS`) and `fqn_index` was empty in PR-01 and is fully repopulated each run, so bumping would only gratuitously cold-start the warm Go cache. Matches the documented per-table policy. A per-table `indexed_files_version` guards that one table.

## Verification

- `go build ./...` clean; `go test ./...` green; `golangci-lint run` -> `0 issues`.
- Unit tests: collection logic and mtime helpers at 100%; writer ~88% incl. SQL-error injection (dropped tables, closed DB).
- In-process integration test: parse a real Python project, `BuildCallGraphWithCache`, assert `models.sanitize` / `models.User` / `models.User.save` / `__init__` land in `fqn_index`, all `source=project`, and the file is stamped (not stale).
- End-to-end binary scan output (real `.py` project):

```
models.User|class|project|8||models
models.User.__init__|method|project|9|(name: str) -> None|models.User
models.User.save|method|project|12|() -> None|models.User
models.helper|function|project|15||models
models.sanitize|function|project|5|(value: str) -> str|models
```

Note: the repo `lintGo` task chains `lintPython`, red on `main` from pre-existing black formatting in three `python-sdk/` files unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)